### PR TITLE
Revert "Fix semver regex"

### DIFF
--- a/infra/scripts/setup-common-functions.sh
+++ b/infra/scripts/setup-common-functions.sh
@@ -55,7 +55,7 @@ get_tag_release() {
   # Match only Semver tags
   # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
   # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
-  local TAG_REGEX='^eg-v[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+  local TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
   local OPTIND opt
   while getopts "ms" opt; do
     case "${opt}" in


### PR DESCRIPTION
Reverts ExpediaGroup/feast#3

Versioning as `eg-vx.x.x` is not working. The eg-v gets cut off and the versioned docker images/wheels get uploaded as `feastx.x.x`. We need some way of marking which are EG builds and which aren't.