### PR TITLE
feat: Add Iceberg support to SparkSource

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -28,6 +28,7 @@ class SparkSourceFormat(Enum):
     parquet = "parquet"
     delta = "delta"
     avro = "avro"
+    iceberg = "iceberg"
 
 
 class SparkSource(DataSource):


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds support for the file format, Apache Iceberg, to SparkSource.
**Which issue(s) this PR fixes**:
Fixes #

1. Apache Iceberg format is supported when using Spark Offline Store. Materialization test using Iceberg format has been conducted. 
