### PR TITLE
re-enable online_store.update for aws provider

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -821,8 +821,6 @@ class FeatureStore:
             ... )
             >>> fs.apply([driver_hourly_stats_view, driver]) # register entity and feature view
         """
-        # TODO: remove
-        print(f"Apply with: {objects}")
         # TODO: Add locking
         if not isinstance(objects, Iterable):
             objects = [objects]
@@ -993,15 +991,6 @@ class FeatureStore:
         tables_to_delete: List[FeatureView] = views_to_delete + sfvs_to_delete if not partial else []  # type: ignore
         tables_to_keep: List[FeatureView] = views_to_update + sfvs_to_update  # type: ignore
 
-        # TODO: remove
-        print(
-            f"""Update project={self.project},
-            tables_to_delete={tables_to_delete},
-            tables_to_keep={tables_to_keep},
-            entities_to_delete={entities_to_delete if not partial else []},
-            entities_to_keep={entities_to_update},
-            partial={partial},"""
-        )
         self._get_provider().update_infra(
             project=self.project,
             tables_to_delete=tables_to_delete,

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -57,15 +57,15 @@ class AwsProvider(PassthroughProvider):
         # from online stores when a Feature View is deleted.
 
         # Call update only if there is an online store
-        # if self.online_store:
-        #     self.online_store.update(
-        #         config=self.repo_config,
-        #         tables_to_delete=tables_to_delete,
-        #         tables_to_keep=tables_to_keep,
-        #         entities_to_keep=entities_to_keep,
-        #         entities_to_delete=entities_to_delete,
-        #         partial=partial,
-        #     )
+        if self.online_store:
+            self.online_store.update(
+                config=self.repo_config,
+                tables_to_delete=tables_to_delete,
+                tables_to_keep=tables_to_keep,
+                entities_to_keep=entities_to_keep,
+                entities_to_delete=entities_to_delete,
+                partial=partial,
+            )
 
         if self.repo_config.feature_server and self.repo_config.feature_server.enabled:
             warnings.warn(

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -116,8 +116,6 @@ class PassthroughProvider(Provider):
     ):
         set_usage_attribute("provider", self.__class__.__name__)
 
-        # TODO: remove
-        print(f"Is online store={self.online_store}")
         # Call update only if there is an online store
         if self.online_store:
             self.online_store.update(


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
In the AWSProvider the `online_store.update` call was commented out. This breaks any online store that requires setup before insert such as milvus.

Fixes #
