### PR TITLE
Bugfix: rename IVFLAT to the expected string IVF_FLAT

### DIFF
--- a/sdk/python/feast/expediagroup/vectordb/milvus_online_store.py
+++ b/sdk/python/feast/expediagroup/vectordb/milvus_online_store.py
@@ -411,11 +411,12 @@ class MilvusOnlineStore(OnlineStore):
 
         metric_type = "L2"
         if "metric_type" in tags:
-            metric_type = tags["metric_type"]
+            metric_type = tags["metric_type"].upper()
 
         return {
             "metric_type": metric_type,
-            "index_type": index_type_name,
+            # Note: Milvus aliases variations of IVF_FLAT to the IVFLAT enum, but requires "IVF_FLAT" for index creation
+            "index_type": index_type_name.replace("IVFLAT", "IVF_FLAT"),
             "params": params,
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
MilvusOnlineStore update failed to create IVF_FLAT indexes

**Which issue(s) this PR fixes**:
Renames IVFLAT to the expected string IVF_FLAT for those indexes.
Added test coverage for creating all supported index types.
