### PR TITLE
Milvus version update to 2.3.0

### DIFF
--- a/sdk/python/tests/expediagroup/milvus_online_store_creator.py
+++ b/sdk/python/tests/expediagroup/milvus_online_store_creator.py
@@ -12,7 +12,7 @@ class MilvusOnlineStoreCreator(OnlineStoreCreator):
     def __init__(self, project_name: str, **kwargs):
         super().__init__(project_name)
         self.container = DockerContainer(
-            "mbackes/milvus-lite:2.2.12"
+            "mbackes/milvus-lite:2.3.0"
         ).with_exposed_ports("19530")
 
     def create_online_store(self) -> Dict[str, str]:

--- a/sdk/python/tests/expediagroup/test_milvus_online_store.py
+++ b/sdk/python/tests/expediagroup/test_milvus_online_store.py
@@ -191,7 +191,7 @@ class TestMilvusOnlineStore:
             "params": {"nlist": 64},
         },
         {
-            "metric_type": "L2",
+            "metric_type": "COSINE",
             "index_type": "IVF_SQ8",
             "params": {"nlist": 64},
         },

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,10 @@ HAZELCAST_REQUIRED = [
 ]
 
 
-MILVUS_REQUIRED = ["pymilvus==2.2.14", "bidict==0.22.1"]
+MILVUS_REQUIRED = [
+    "pymilvus==2.3.0",
+    "bidict==0.22.1"
+]
 
 CI_REQUIRED = (
     [


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to utilize the latest features of Milvus v2.3.0

**Which issue(s) this PR fixes**:
- Updates the milvus version
- Replace IndexType map with strings since the enum is out of date
- Use tagging on String fields to define max_length of the VARCHAR
- Use query iterator on large queries
- Check load state on read
