### PR TITLE
fix: CGO Memory leak issue

### DIFF
--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/feast-dev/feast/go/internal/feast"
 	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
 	"github.com/feast-dev/feast/go/internal/feast/server/logging"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	prototypes "github.com/feast-dev/feast/go/protos/feast/types"
@@ -269,6 +270,14 @@ func (s *httpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	go releaseCGOMemory(featureVectors)
+}
+
+func releaseCGOMemory(featureVectors []*onlineserving.FeatureVector) {
+    for _, vector := range featureVectors {
+        vector.Values.Release()
+    }
 }
 
 func (s *httpServer) Serve(host string, port int) error {

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -74,6 +74,11 @@ func AugmentResponseWithOnDemandTransforms(
 			return nil, err
 		}
 		result = append(result, onDemandFeatures...)
+		
+		// Release memory used by requestContextArrow
+		for _, arrowArray := range requestContextArrow {
+			arrowArray.Release()
+		}
 	}
 
 	return result, nil

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -53,7 +53,7 @@ def get_app(
 
     ui_dir = importlib_resources.files(__name__) / "ui/build/"
     # Initialize with the projects-list.json file
-    with open(ui_dir + "projects-list.json", mode="w") as f:
+    with open(str(ui_dir) + "projects-list.json", mode="w") as f:
         projects_dict = {
             "projects": [
                 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: 
Releases the memory used by [CGOArrowAllocator](https://github.com/apache/arrow/blob/go/v8.0.0/go/arrow/memory/cgo_allocator.go). Not releasing the memory causing the memory leaks. Pods restart after all the memory allocated by container is filled up. 

**Which issue(s) this PR fixes**:

- Memory leak in GO code

- Fixes issue observed in building UI module

Fixes #
- Memory leak in GO code

- Fixes issue observed in building UI module
