### PR TITLE
fix: enabled cache background refresh for http registry

### DIFF
--- a/sdk/python/feast/embedded_go/online_features_service.py
+++ b/sdk/python/feast/embedded_go/online_features_service.py
@@ -65,7 +65,6 @@ class EmbeddedOnlineFeatureServer:
         request_data: Dict[str, Union[List[Any], Value_pb2.RepeatedValue]],
         full_feature_names: bool = False,
     ):
-
         if feature_service:
             join_keys_types = self._service.GetEntityTypesMapByFeatureService(
                 feature_service.name
@@ -244,7 +243,7 @@ def transformation_callback(
     output_schema_ptr: int,
     full_feature_names: bool,
 ) -> int:
-    odfv = fs.get_on_demand_feature_view(on_demand_feature_view_name)
+    odfv = fs.get_on_demand_feature_view(on_demand_feature_view_name, allow_cache=True)
 
     input_record = pa.RecordBatch._import_from_c(input_arr_ptr, input_schema_ptr)
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -466,12 +466,15 @@ class FeatureStore:
         return stream_feature_view
 
     @log_exceptions_and_usage
-    def get_on_demand_feature_view(self, name: str) -> OnDemandFeatureView:
+    def get_on_demand_feature_view(
+        self, name: str, allow_cache: bool = False
+    ) -> OnDemandFeatureView:
         """
         Retrieves a feature view.
 
         Args:
             name: Name of feature view.
+            allow_cache: Whether to allow returning this on demand feature view from a cached registry
 
         Returns:
             The specified feature view.
@@ -479,15 +482,18 @@ class FeatureStore:
         Raises:
             FeatureViewNotFoundException: The feature view could not be found.
         """
-        return self._registry.get_on_demand_feature_view(name, self.project)
+        return self._registry.get_on_demand_feature_view(
+            name, self.project, allow_cache
+        )
 
     @log_exceptions_and_usage
-    def get_data_source(self, name: str) -> DataSource:
+    def get_data_source(self, name: str, allow_cache: bool = False) -> DataSource:
         """
         Retrieves the list of data sources from the registry.
 
         Args:
             name: Name of the data source.
+            allow_cache: Whether to allow returning this data source from a cached registry
 
         Returns:
             The specified data source.
@@ -495,7 +501,7 @@ class FeatureStore:
         Raises:
             DataSourceObjectNotFoundException: The data source could not be found.
         """
-        return self._registry.get_data_source(name, self.project)
+        return self._registry.get_data_source(name, self.project, allow_cache)
 
     @log_exceptions_and_usage
     def delete_feature_view(self, name: str):

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -70,6 +70,7 @@ def pg_registry():
     registry_config = RegistryConfig(
         registry_type="sql",
         path=f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
+        cache_ttl_seconds=60,
     )
 
     yield SqlRegistry(registry_config, "project", None)
@@ -104,6 +105,7 @@ def mysql_registry():
     registry_config = RegistryConfig(
         registry_type="sql",
         path=f"mysql+mysqldb://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
+        cache_ttl_seconds=60,
     )
 
     yield SqlRegistry(registry_config, "project", None)
@@ -116,6 +118,7 @@ def sqlite_registry():
     registry_config = RegistryConfig(
         registry_type="sql",
         path="sqlite://",
+        cache_ttl_seconds=60,
     )
     print("Initializing SQL Registry for SQlite..")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1. HTTP Registry initialization failing with error "_refresh_lock" doesn't exist. When initializing registry in __init__ method, allow_cache to False for proto() function to avoid the error
2. Enabled background registry refresh. This process needs tuning. 
3. Updated get odfv and datasource functions to allow allow_cache functionality 
4. ODFV execution from Go Feature server uses cached odfv
5. Added support for delete_project in SQL Registry
6. cache_ttl_seconds is added to tests to the thread wait will not wait for default 600 seconds. This caused the increase in unit tests execution time. As mentioned in #2, this process needs tuning so we can send signal to stop thread when the execution is completed. 
