### PR TITLE
use the builtin io.ReadAll instead of grabbing arbitrary length bytes.

### DIFF
--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -12,7 +12,6 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/core"
 )
 
-const BUFFER_SIZE = 8192 // Adjust buffer size as needed
 
 type HttpRegistryStore struct {
 	project  string
@@ -93,23 +92,13 @@ func (r *HttpRegistryStore) loadProtobufMessages(url string, messageProcessor fu
 	}
 	defer resp.Body.Close()
 
-	buffer := make([]byte, BUFFER_SIZE)
+	buffer, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
-	for {
-		n, err := resp.Body.Read(buffer)
-		if err != nil && err != io.EOF {
-			return err
-		}
-
-		if n > 0 {
-			if err := messageProcessor(buffer[:n]); err != nil {
+	if err := messageProcessor(buffer); err != nil {
 				return err
-			}
-		}
-
-		if err == io.EOF {
-			break
-		}
 	}
 
 	return nil

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -3,6 +3,7 @@ package transformation
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"unsafe"
 
@@ -127,12 +128,11 @@ func CallTransformations(
 	cdata.ExportArrowRecordBatch(inputRecord, &inputArr, &inputSchema)
 
 	// Recover from a panic from FFI so the server doesn't crash
-	var err error
 	ret := callback(featureView.Base.Name, inputArrPtr, inputSchemaPtr, outArrPtr, outSchemaPtr, fullFeatureNames)
 	defer func() {
 		if e := recover(); e != nil {
 			ret = -1
-			err = e.(error)
+			log.Printf("Execption in python transform callback: %s\n", e.(error).Error())
 		}
 	}()
 

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -132,7 +132,8 @@ func CallTransformations(
 	defer func() {
 		if e := recover(); e != nil {
 			ret = -1
-			log.Printf("Execption in python transform callback: %s\n", e.(error).Error())
+			log.Printf("panic recovered: %v\n", e)
+			fmt.Errorf("python transformation callback error: %v", e)
 		}
 	}()
 

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -133,7 +133,7 @@ func CallTransformations(
 		if e := recover(); e != nil {
 			ret = -1
 			log.Printf("panic recovered: %v\n", e)
-			fmt.Errorf("python transformation callback error: %v", e)
+			err = fmt.Errorf("python transformation callback error: %v", e)
 		}
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We are getting intermittent errors where not all entities get loaded into the cache.

**Which issue(s) this PR fixes**:

- Instead of creating a buffer with an arbitrarily large size to read the registry response, use the builtin `io.ReadAll` function to load the buffer with the entire response to then unmarshal.
- Add a log to error handling in odfv transformations.