### PR TITLE
fix: Added caching to get project calls

### DIFF
--- a/go/embedded/online_features.go
+++ b/go/embedded/online_features.go
@@ -27,6 +27,7 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	prototypes "github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/feast-dev/feast/go/types"
+	jsonlog "github.com/rs/zerolog/log"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -65,6 +66,7 @@ type LoggingOptions struct {
 func NewOnlineFeatureService(conf *OnlineFeatureServiceConfig, transformationCallback transformation.TransformationCallback) *OnlineFeatureService {
 	repoConfig, err := registry.NewRepoConfigFromJSON(conf.RepoPath, conf.RepoConfig)
 	if err != nil {
+		jsonlog.Error().Stack().Err(err).Msg("Failed to convert to RepoConfig")
 		return &OnlineFeatureService{
 			err: err,
 		}
@@ -72,6 +74,7 @@ func NewOnlineFeatureService(conf *OnlineFeatureServiceConfig, transformationCal
 
 	fs, err := feast.NewFeatureStore(repoConfig, transformationCallback)
 	if err != nil {
+		jsonlog.Error().Stack().Err(err).Msg("Failed to create NewFeatureStore")
 		return &OnlineFeatureService{
 			err: err,
 		}

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -3,7 +3,6 @@ package feast
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/apache/arrow/go/v8/arrow/memory"
 
@@ -53,7 +52,6 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 	}
 	err = registry.InitializeRegistry()
 	if err != nil {
-		fmt.Println("ERROR: Unable to Initialize Registry: ", err)
 		return nil, err
 	}
 

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/rs/zerolog/log"
 
 	"github.com/feast-dev/feast/go/protos/feast/core"
 )
@@ -70,7 +71,7 @@ func (r *Registry) InitializeRegistry() error {
 	_, err := r.getRegistryProto()
 	if err != nil {
 		if _, ok := r.registryStore.(*HttpRegistryStore); ok {
-			fmt.Printf("[%s] %s %s\n", time.UTC.String(), "ERROR: Registry Initialization Failed: ", err)
+			log.Error().Err(err).Msg("Registry Initialization Failed")
 			return err
 		}
 		registryProto := &core.Registry{RegistrySchemaVersion: REGISTRY_SCHEMA_VERSION}
@@ -85,7 +86,7 @@ func (r *Registry) RefreshRegistryOnInterval() {
 	for ; true; <-ticker.C {
 		err := r.refresh()
 		if err != nil {
-			fmt.Printf("[%s] %s %s\n", time.UTC.String(), "ERROR: Failed to refresh Registry: ", err)
+			log.Error().Stack().Err(err).Msg("Registry refresh Failed")
 			return
 		}
 	}

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -322,6 +322,7 @@ func (s *httpServer) Serve(host string, port int) error {
 	if err == http.ErrServerClosed {
 		return nil
 	}
+	log.Error().Stack().Err(err).Msg("Startup failed")
 	return err
 }
 

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -58,4 +58,6 @@ message Registry {
 message ProjectMetadata {
     string project = 1;
     string project_uuid = 2;
+    google.protobuf.Timestamp last_updated_timestamp = 3;
+
 }

--- a/sdk/python/feast/expediagroup/pydantic_models/project_metadata_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/project_metadata_model.py
@@ -25,6 +25,7 @@ class ProjectMetadataModel(BaseModel):
         return ProjectMetadata(
             project_name=self.project_name,
             project_uuid=self.project_uuid,
+            last_updated_timestamp=self.last_updated_timestamp,
         )
 
     @classmethod
@@ -41,4 +42,5 @@ class ProjectMetadataModel(BaseModel):
         return cls(
             project_name=project_metadata.project_name,
             project_uuid=project_metadata.project_uuid,
+            last_updated_timestamp=project_metadata.last_updated_timestamp,
         )

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -90,7 +90,7 @@ class HttpRegistry(BaseRegistry):
             if registry_config.cache_ttl_seconds is not None
             else 0
         )
-        self.cached_registry_proto = self.proto(allow_cache=False)
+        self.cached_registry_proto = self.proto()
         self.stop_thread = False
         self.refresh_cache_thread = threading.Thread(target=self._refresh_cache)
         self.refresh_cache_thread.daemon = True
@@ -171,12 +171,10 @@ class HttpRegistry(BaseRegistry):
     ) -> Entity:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_entity(
-                self.cached_registry_proto, name, project
-            )
+            return proto_registry_utils.get_entity(self.cached_registry_proto, name, project)
         try:
             url = f"{self.base_url}/projects/{project}/entities/{name}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return EntityModel.parse_obj(response_data).to_entity()
         except EntityNotFoundException as exception:
@@ -194,23 +192,17 @@ class HttpRegistry(BaseRegistry):
     ) -> List[Entity]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_entities(
-                self.cached_registry_proto, project
-            )
+            return proto_registry_utils.list_entities(self.cached_registry_proto, project)
         try:
             url = f"{self.base_url}/projects/{project}/entities"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
-            return [
-                EntityModel.parse_obj(entity).to_entity() for entity in response_list
-            ]
+            return [EntityModel.parse_obj(entity).to_entity() for entity in response_list]
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_data_source(
-        self, data_source: DataSource, project: str, commit: bool = True
-    ):
+    def apply_data_source(self, data_source: DataSource, project: str, commit: bool = True):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"commit": commit}
@@ -251,12 +243,10 @@ class HttpRegistry(BaseRegistry):
     ) -> DataSource:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_data_source(
-                self.cached_registry_proto, name, project
-            )
+            return proto_registry_utils.get_data_source(self.cached_registry_proto, name, project)
         try:
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             if "model_type" in response_data:
                 if response_data["model_type"] == "RequestSourceModel":
@@ -281,12 +271,10 @@ class HttpRegistry(BaseRegistry):
     ) -> List[DataSource]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_data_sources(
-                self.cached_registry_proto, project
-            )
+            return proto_registry_utils.list_data_sources(self.cached_registry_proto, project)
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             data_source_list = []
@@ -345,13 +333,11 @@ class HttpRegistry(BaseRegistry):
             )
         try:
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
-            logger.error(
-                f"FeatureService {name} requested does not exist: %s", str(exception)
-            )
+            logger.error(f"FeatureService {name} requested does not exist: %s", str(exception))
             raise httpx.HTTPError(message=f"FeatureService: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -361,12 +347,10 @@ class HttpRegistry(BaseRegistry):
     ) -> List[FeatureService]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_feature_services(
-                self.cached_registry_proto, project
-            )
+            return proto_registry_utils.list_feature_services(self.cached_registry_proto, project)
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -376,9 +360,7 @@ class HttpRegistry(BaseRegistry):
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_feature_view(
-        self, feature_view: BaseFeatureView, project: str, commit: bool = True
-    ):
+    def apply_feature_view(self, feature_view: BaseFeatureView, project: str, commit: bool = True):
         try:
             params = {"commit": commit}
             if isinstance(feature_view, FeatureView):
@@ -390,9 +372,7 @@ class HttpRegistry(BaseRegistry):
                 url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
                 data = OnDemandFeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request("PUT", url, params=params, data=data)
-                return OnDemandFeatureViewModel.parse_obj(
-                    response_data
-                ).to_feature_view()
+                return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
             else:
                 raise TypeError(
                     "Unsupported FeatureView type. Please use either FeatureView or OnDemandFeatureView only"
@@ -423,18 +403,14 @@ class HttpRegistry(BaseRegistry):
     ) -> FeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_feature_view(
-                self.cached_registry_proto, name, project
-            )
+            return proto_registry_utils.get_feature_view(self.cached_registry_proto, name, project)
         try:
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return FeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
-            logger.error(
-                f"FeatureView {name} requested does not exist: %s", str(exception)
-            )
+            logger.error(f"FeatureView {name} requested does not exist: %s", str(exception))
             raise httpx.HTTPError(message=f"FeatureView: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -444,12 +420,10 @@ class HttpRegistry(BaseRegistry):
     ) -> List[FeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_feature_views(
-                self.cached_registry_proto, project
-            )
+            return proto_registry_utils.list_feature_views(self.cached_registry_proto, project)
         try:
             url = f"{self.base_url}/projects/{project}/feature_views"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -469,13 +443,11 @@ class HttpRegistry(BaseRegistry):
             )
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views/{name}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
-            logger.error(
-                f"FeatureView {name} requested does not exist: %s", str(exception)
-            )
+            logger.error(f"FeatureView {name} requested does not exist: %s", str(exception))
             raise httpx.HTTPError(message=f"FeatureView: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -490,7 +462,7 @@ class HttpRegistry(BaseRegistry):
             )
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -554,9 +526,7 @@ class HttpRegistry(BaseRegistry):
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_saved_dataset(
-        self, saved_dataset: SavedDataset, project: str, commit: bool = True
-    ):
+    def apply_saved_dataset(self, saved_dataset: SavedDataset, project: str, commit: bool = True):
         raise NotImplementedError("Method not implemented")
 
     def get_saved_dataset(
@@ -612,9 +582,7 @@ class HttpRegistry(BaseRegistry):
     ):
         raise NotImplementedError("Method not implemented")
 
-    def get_user_metadata(
-        self, project: str, feature_view: BaseFeatureView
-    ) -> Optional[bytes]:
+    def get_user_metadata(self, project: str, feature_view: BaseFeatureView) -> Optional[bytes]:
         raise NotImplementedError("Method not implemented")
 
     def list_validation_references(
@@ -645,7 +613,7 @@ class HttpRegistry(BaseRegistry):
                 (self.list_validation_references, r.validation_references),
                 (self.list_project_metadata, r.project_metadata),
             ]:
-                objs: List[Any] = lister(project, allow_cache)  # type: ignore
+                objs: List[Any] = lister(project)  # type: ignore
                 if objs:
                     obj_protos = [obj.to_proto() for obj in objs]
                     for obj_proto in obj_protos:
@@ -678,11 +646,9 @@ class HttpRegistry(BaseRegistry):
             if project_metadata:
                 usage.set_current_project_uuid(project_metadata.project_uuid)
             else:
-                proto_registry_utils.init_project_metadata(
-                    self.cached_registry_proto, project
-                )
+                proto_registry_utils.init_project_metadata(self.cached_registry_proto, project)
 
-        refreshed_cache_registry_proto = self.proto(True)
+        refreshed_cache_registry_proto = self.proto()
         with self._refresh_lock:
             self.cached_registry_proto = refreshed_cache_registry_proto
         self.cached_registry_proto_created = datetime.utcnow()
@@ -690,17 +656,12 @@ class HttpRegistry(BaseRegistry):
     def _refresh_cached_registry_if_necessary(self):
         with self._refresh_lock:
             expired = (
-                self.cached_registry_proto is None
-                or self.cached_registry_proto_created is None
+                self.cached_registry_proto is None or self.cached_registry_proto_created is None
             ) or (
-                self.cached_registry_proto_ttl.total_seconds()
-                > 0  # 0 ttl means infinity
+                self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
                 and (
                     datetime.utcnow()
-                    > (
-                        self.cached_registry_proto_created
-                        + self.cached_registry_proto_ttl
-                    )
+                    > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
                 )
             )
 
@@ -709,10 +670,7 @@ class HttpRegistry(BaseRegistry):
                 self.refresh()
 
     def _check_if_registry_refreshed(self):
-        if (
-            self.cached_registry_proto is None
-            or self.cached_registry_proto_created is None
-        ) or (
+        if (self.cached_registry_proto is None or self.cached_registry_proto_created is None) or (
             self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
             and (
                 datetime.utcnow()
@@ -739,9 +697,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}"
             response_data = self._send_request("GET", url)
-            return datetime.strptime(
-                response_data["last_updated_timestamp"], "%Y-%m-%dT%H:%M:%S"
-            )
+            return datetime.strptime(response_data["last_updated_timestamp"], "%Y-%m-%dT%H:%M:%S")
         except Exception as exception:
             self._handle_exception(exception)
 
@@ -750,18 +706,14 @@ class HttpRegistry(BaseRegistry):
     ) -> List[ProjectMetadata]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_project_metadata(
-                self.cached_registry_proto, project
-            )
+            return proto_registry_utils.list_project_metadata(self.cached_registry_proto, project)
         try:
             url = f"{self.base_url}/projects/{project}"
-            params = {"allow_cache": False}
+            params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:
-            logger.error(
-                f"Project {project} requested does not exist: {str(exception)}"
-            )
+            logger.error(f"Project {project} requested does not exist: {str(exception)}")
             raise httpx.HTTPError(message=f"ProjectMetadata: {project} not found")
         except Exception as exception:
             self._handle_exception(exception)

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -626,7 +626,7 @@ class HttpRegistry(BaseRegistry):
 
     def proto(self, allow_cache: bool = True) -> RegistryProto:
         r = RegistryProto()
-        last_updated_timestamps = []
+        # last_updated_timestamps = []
         if self.project is None:
             projects = self._get_all_projects()
         else:
@@ -658,10 +658,11 @@ class HttpRegistry(BaseRegistry):
             # This is suuuper jank. Because of https://github.com/feast-dev/feast/issues/2783,
             # the registry proto only has a single infra field, which we're currently setting as the "last" project.
             r.infra.CopyFrom(self.get_infra(project).to_proto())
-            last_updated_timestamps.append(self._get_last_updated_metadata(project))
+            # last_updated_timestamps.append(self._get_last_updated_metadata(project))
 
-        if last_updated_timestamps:
-            r.last_updated.FromDatetime(max(last_updated_timestamps))
+        # if last_updated_timestamps:
+        #     r.last_updated.FromDatetime(max(last_updated_timestamps))
+        r.last_updated.FromDatetime(datetime.utcnow())
 
         return r
 
@@ -754,7 +755,8 @@ class HttpRegistry(BaseRegistry):
             )
         try:
             url = f"{self.base_url}/projects/{project}"
-            response_data = self._send_request("GET", url)
+            params = {"allow_cache": False}
+            response_data = self._send_request("GET", url, params=params)
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:
             logger.error(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -171,7 +171,9 @@ class HttpRegistry(BaseRegistry):
     ) -> Entity:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_entity(self.cached_registry_proto, name, project)
+            return proto_registry_utils.get_entity(
+                self.cached_registry_proto, name, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"allow_cache": True}
@@ -192,17 +194,23 @@ class HttpRegistry(BaseRegistry):
     ) -> List[Entity]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_entities(self.cached_registry_proto, project)
+            return proto_registry_utils.list_entities(
+                self.cached_registry_proto, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/entities"
             params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
-            return [EntityModel.parse_obj(entity).to_entity() for entity in response_list]
+            return [
+                EntityModel.parse_obj(entity).to_entity() for entity in response_list
+            ]
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_data_source(self, data_source: DataSource, project: str, commit: bool = True):
+    def apply_data_source(
+        self, data_source: DataSource, project: str, commit: bool = True
+    ):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"commit": commit}
@@ -243,7 +251,9 @@ class HttpRegistry(BaseRegistry):
     ) -> DataSource:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_data_source(self.cached_registry_proto, name, project)
+            return proto_registry_utils.get_data_source(
+                self.cached_registry_proto, name, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"allow_cache": True}
@@ -271,7 +281,9 @@ class HttpRegistry(BaseRegistry):
     ) -> List[DataSource]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_data_sources(self.cached_registry_proto, project)
+            return proto_registry_utils.list_data_sources(
+                self.cached_registry_proto, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"allow_cache": True}
@@ -337,7 +349,9 @@ class HttpRegistry(BaseRegistry):
             response_data = self._send_request("GET", url, params=params)
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
-            logger.error(f"FeatureService {name} requested does not exist: %s", str(exception))
+            logger.error(
+                f"FeatureService {name} requested does not exist: %s", str(exception)
+            )
             raise httpx.HTTPError(message=f"FeatureService: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -347,7 +361,9 @@ class HttpRegistry(BaseRegistry):
     ) -> List[FeatureService]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_feature_services(self.cached_registry_proto, project)
+            return proto_registry_utils.list_feature_services(
+                self.cached_registry_proto, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
             params = {"allow_cache": True}
@@ -360,7 +376,9 @@ class HttpRegistry(BaseRegistry):
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_feature_view(self, feature_view: BaseFeatureView, project: str, commit: bool = True):
+    def apply_feature_view(
+        self, feature_view: BaseFeatureView, project: str, commit: bool = True
+    ):
         try:
             params = {"commit": commit}
             if isinstance(feature_view, FeatureView):
@@ -372,7 +390,9 @@ class HttpRegistry(BaseRegistry):
                 url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
                 data = OnDemandFeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request("PUT", url, params=params, data=data)
-                return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
+                return OnDemandFeatureViewModel.parse_obj(
+                    response_data
+                ).to_feature_view()
             else:
                 raise TypeError(
                     "Unsupported FeatureView type. Please use either FeatureView or OnDemandFeatureView only"
@@ -403,14 +423,18 @@ class HttpRegistry(BaseRegistry):
     ) -> FeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.get_feature_view(self.cached_registry_proto, name, project)
+            return proto_registry_utils.get_feature_view(
+                self.cached_registry_proto, name, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
             params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return FeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
-            logger.error(f"FeatureView {name} requested does not exist: %s", str(exception))
+            logger.error(
+                f"FeatureView {name} requested does not exist: %s", str(exception)
+            )
             raise httpx.HTTPError(message=f"FeatureView: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -420,7 +444,9 @@ class HttpRegistry(BaseRegistry):
     ) -> List[FeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_feature_views(self.cached_registry_proto, project)
+            return proto_registry_utils.list_feature_views(
+                self.cached_registry_proto, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}/feature_views"
             params = {"allow_cache": True}
@@ -447,7 +473,9 @@ class HttpRegistry(BaseRegistry):
             response_data = self._send_request("GET", url, params=params)
             return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
-            logger.error(f"FeatureView {name} requested does not exist: %s", str(exception))
+            logger.error(
+                f"FeatureView {name} requested does not exist: %s", str(exception)
+            )
             raise httpx.HTTPError(message=f"FeatureView: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
@@ -526,7 +554,9 @@ class HttpRegistry(BaseRegistry):
         except Exception as exception:
             self._handle_exception(exception)
 
-    def apply_saved_dataset(self, saved_dataset: SavedDataset, project: str, commit: bool = True):
+    def apply_saved_dataset(
+        self, saved_dataset: SavedDataset, project: str, commit: bool = True
+    ):
         raise NotImplementedError("Method not implemented")
 
     def get_saved_dataset(
@@ -582,7 +612,9 @@ class HttpRegistry(BaseRegistry):
     ):
         raise NotImplementedError("Method not implemented")
 
-    def get_user_metadata(self, project: str, feature_view: BaseFeatureView) -> Optional[bytes]:
+    def get_user_metadata(
+        self, project: str, feature_view: BaseFeatureView
+    ) -> Optional[bytes]:
         raise NotImplementedError("Method not implemented")
 
     def list_validation_references(
@@ -646,7 +678,9 @@ class HttpRegistry(BaseRegistry):
             if project_metadata:
                 usage.set_current_project_uuid(project_metadata.project_uuid)
             else:
-                proto_registry_utils.init_project_metadata(self.cached_registry_proto, project)
+                proto_registry_utils.init_project_metadata(
+                    self.cached_registry_proto, project
+                )
 
         refreshed_cache_registry_proto = self.proto()
         with self._refresh_lock:
@@ -656,12 +690,17 @@ class HttpRegistry(BaseRegistry):
     def _refresh_cached_registry_if_necessary(self):
         with self._refresh_lock:
             expired = (
-                self.cached_registry_proto is None or self.cached_registry_proto_created is None
+                self.cached_registry_proto is None
+                or self.cached_registry_proto_created is None
             ) or (
-                self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
+                self.cached_registry_proto_ttl.total_seconds()
+                > 0  # 0 ttl means infinity
                 and (
                     datetime.utcnow()
-                    > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
+                    > (
+                        self.cached_registry_proto_created
+                        + self.cached_registry_proto_ttl
+                    )
                 )
             )
 
@@ -670,7 +709,10 @@ class HttpRegistry(BaseRegistry):
                 self.refresh()
 
     def _check_if_registry_refreshed(self):
-        if (self.cached_registry_proto is None or self.cached_registry_proto_created is None) or (
+        if (
+            self.cached_registry_proto is None
+            or self.cached_registry_proto_created is None
+        ) or (
             self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
             and (
                 datetime.utcnow()
@@ -697,7 +739,9 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}"
             response_data = self._send_request("GET", url)
-            return datetime.strptime(response_data["last_updated_timestamp"], "%Y-%m-%dT%H:%M:%S")
+            return datetime.strptime(
+                response_data["last_updated_timestamp"], "%Y-%m-%dT%H:%M:%S"
+            )
         except Exception as exception:
             self._handle_exception(exception)
 
@@ -706,14 +750,18 @@ class HttpRegistry(BaseRegistry):
     ) -> List[ProjectMetadata]:
         if allow_cache:
             self._check_if_registry_refreshed()
-            return proto_registry_utils.list_project_metadata(self.cached_registry_proto, project)
+            return proto_registry_utils.list_project_metadata(
+                self.cached_registry_proto, project
+            )
         try:
             url = f"{self.base_url}/projects/{project}"
             params = {"allow_cache": True}
             response_data = self._send_request("GET", url, params=params)
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:
-            logger.error(f"Project {project} requested does not exist: {str(exception)}")
+            logger.error(
+                f"Project {project} requested does not exist: {str(exception)}"
+            )
             raise httpx.HTTPError(message=f"ProjectMetadata: {project} not found")
         except Exception as exception:
             self._handle_exception(exception)

--- a/sdk/python/feast/project_metadata.py
+++ b/sdk/python/feast/project_metadata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import uuid
+from datetime import datetime
 from typing import Optional
 
 from google.protobuf.json_format import MessageToJson
@@ -33,6 +34,7 @@ class ProjectMetadata:
 
     project_name: str
     project_uuid: str
+    last_updated_timestamp: datetime
 
     @log_exceptions
     def __init__(
@@ -40,6 +42,7 @@ class ProjectMetadata:
         *args,
         project_name: Optional[str] = None,
         project_uuid: Optional[str] = None,
+        last_updated_timestamp: datetime = datetime.utcfromtimestamp(1),
     ):
         """
         Creates an Project metadata object.
@@ -56,6 +59,7 @@ class ProjectMetadata:
 
         self.project_name = project_name
         self.project_uuid = project_uuid or f"{uuid.uuid4()}"
+        self.last_updated_timestamp = last_updated_timestamp
 
     def __hash__(self) -> int:
         return hash((self.project_name, self.project_uuid))
@@ -69,6 +73,7 @@ class ProjectMetadata:
         if (
             self.project_name != other.project_name
             or self.project_uuid != other.project_uuid
+            or self.last_updated_timestamp != other.last_updated_timestamp
         ):
             return False
 
@@ -94,6 +99,7 @@ class ProjectMetadata:
         entity = cls(
             project_name=project_metadata_proto.project,
             project_uuid=project_metadata_proto.project_uuid,
+            last_updated_timestamp=project_metadata_proto.last_updated_timestamp.ToDatetime(),
         )
 
         return entity
@@ -106,6 +112,11 @@ class ProjectMetadata:
             An ProjectMetadataProto protobuf.
         """
 
-        return ProjectMetadataProto(
-            project=self.project_name, project_uuid=self.project_uuid
+        project_metadata_proto = ProjectMetadataProto(
+            project=self.project_name,
+            project_uuid=self.project_uuid,
         )
+        project_metadata_proto.last_updated_timestamp.FromDatetime(
+            self.last_updated_timestamp
+        )
+        return project_metadata_proto

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -542,7 +542,9 @@ def test_idempotent_feature_service_conversion():
 
 def test_idempotent_project_metadata_conversion():
     python_obj = ProjectMetadata(
-        project_name="test_project", project_uuid=f"{uuid.uuid4()}"
+        project_name="test_project",
+        project_uuid=f"{uuid.uuid4()}",
+        last_updated_timestamp=datetime.utcnow(),
     )
     pydantic_obj = ProjectMetadataModel.from_project_metadata(python_obj)
     converted_python_obj = pydantic_obj.to_project_metadata()
@@ -552,8 +554,8 @@ def test_idempotent_project_metadata_conversion():
     python_obj_from_proto = ProjectMetadata.from_proto(feast_proto)
     assert python_obj == python_obj_from_proto
 
-    pydantic_json = pydantic_obj.json(exclude={"last_updated_timestamp"})
+    pydantic_json = pydantic_obj.json()
     assert pydantic_obj == ProjectMetadataModel.parse_raw(pydantic_json)
 
-    pydantic_json = pydantic_obj.dict(exclude={"last_updated_timestamp"})
+    pydantic_json = pydantic_obj.dict()
     assert pydantic_obj == ProjectMetadataModel.parse_obj(pydantic_json)


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Allows cached calls to get_project_metadata
2. Added last_time_stamp to ProjectMetadata object. This avoids separate calls to get last_updated_timestamp 
3. Added some error logging to Go feature server
4. Leverage http registry cache for refresh in Http.py