### PR TITLE
release arrow context before any return

### DIFF
--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -56,6 +56,7 @@ func AugmentResponseWithOnDemandTransforms(
 		for name, values := range requestData {
 			requestContextArrow[name], err = types.ProtoValuesToArrowArray(values.Val, arrowMemory, numRows)
 			if err != nil {
+				ReleaseArrowContext(requestContextArrow)
 				return nil, err
 			}
 		}
@@ -63,6 +64,7 @@ func AugmentResponseWithOnDemandTransforms(
 		for name, values := range entityRows {
 			requestContextArrow[name], err = types.ProtoValuesToArrowArray(values.Val, arrowMemory, numRows)
 			if err != nil {
+				ReleaseArrowContext(requestContextArrow)
 				return nil, err
 			}
 		}
@@ -80,17 +82,22 @@ func AugmentResponseWithOnDemandTransforms(
 			fullFeatureNames,
 		)
 		if err != nil {
+			ReleaseArrowContext(requestContextArrow)
 			return nil, err
 		}
 		result = append(result, onDemandFeatures...)
 
-		// Release memory used by requestContextArrow
-		for _, arrowArray := range requestContextArrow {
-			arrowArray.Release()
-		}
+		ReleaseArrowContext(requestContextArrow)
 	}
 
 	return result, nil
+}
+
+func ReleaseArrowContext(requestContextArrow map[string]arrow.Array) {
+	// Release memory used by requestContextArrow
+	for _, arrowArray := range requestContextArrow {
+		arrowArray.Release()
+	}
 }
 
 func CallTransformations(

--- a/sdk/python/feast/embedded_go/online_features_service.py
+++ b/sdk/python/feast/embedded_go/online_features_service.py
@@ -247,7 +247,9 @@ def transformation_callback(
     full_feature_names: bool,
 ) -> int:
     try:
-        odfv = fs.get_on_demand_feature_view(on_demand_feature_view_name, allow_cache=True)
+        odfv = fs.get_on_demand_feature_view(
+            on_demand_feature_view_name, allow_cache=True
+        )
 
         input_record = pa.RecordBatch._import_from_c(input_arr_ptr, input_schema_ptr)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't release the arrow memory if there are any errors which can cause a buildup of allocated memory. This ensures we always release the memory before returning out of the function.