### PR TITLE
Add KafkaSourceModel to Pydantic models

### DIFF
--- a/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
@@ -4,14 +4,26 @@ Pydantic Model for Data Source
 Copyright 2023 Expedia Group
 Author: matcarlin@expediagroup.com
 """
+import sys
+from datetime import timedelta
 from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from typing_extensions import Annotated, Self
 
-from feast.data_source import RequestSource
+from feast.data_source import (
+    KafkaSource,
+    RequestSource,
+)
 from feast.expediagroup.pydantic_models.field_model import FieldModel
+from feast.expediagroup.pydantic_models.stream_format_model import (
+    AnyStreamFormat,
+    AvroFormatModel,
+    JsonFormatModel,
+    ProtoFormatModel,
+
+)
 from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
     SparkSource,
 )
@@ -155,10 +167,110 @@ class SparkSourceModel(DataSourceModel):
             timestamp_field=data_source.timestamp_field,
         )
 
+AnyBatchDataSource = Annotated[
+    Union[RequestSourceModel, SparkSourceModel],
+    PydanticField(discriminator="model_type"),
+]
+
+
+SUPPORTED_MESSAGE_FORMATS = [AvroFormatModel, JsonFormatModel, ProtoFormatModel]
+SUPPORTED_KAFKA_BATCH_SOURCES = [RequestSourceModel, SparkSourceModel]
+
+class KafkaSourceModel(DataSourceModel):
+    """
+    Pydantic Model of a Feast KafkaSource.
+    """
+
+    name: str
+    model_type: Literal["KafkaSourceModel"] = "KafkaSourceModel"
+    timestamp_field: str
+    message_format: AnyStreamFormat
+    kafka_bootstrap_servers: Optional[str] = None
+    topic: Optional[str] = None
+    created_timestamp_column: Optional[str] = ""
+    field_mapping: Optional[Dict[str, str]] = None
+    description: Optional[str] = ""
+    tags: Optional[Dict[str, str]] = None
+    owner: Optional[str] = ""
+    batch_source: Optional[AnyBatchDataSource] = None
+    watermark_delay_threshold: Optional[timedelta] = None
+
+    def to_data_source(self) -> KafkaSource:
+        """
+        Given a Pydantic KafkaSourceModel, create and return a KafkaSource.
+
+        Returns:
+            A KafkaSource.
+        """
+        return KafkaSource(
+            name=self.name,
+            timestamp_field=self.timestamp_field,
+            message_format=self.message_format.to_stream_format(),
+            kafka_bootstrap_servers=self.kafka_bootstrap_servers,
+            topic=self.topic,
+            created_timestamp_column=self.created_timestamp_column,
+            field_mapping=self.field_mapping,
+            description=self.description,
+            tags=self.tags,
+            owner=self.owner,
+            batch_source=self.batch_source.to_data_source(),
+            watermark_delay_threshold=self.watermark_delay_threshold
+        )
+
+    @classmethod
+    def from_data_source(
+        cls,
+        data_source,
+    ) -> Self:  # type: ignore
+        """
+        Converts a KafkaSource object to its pydantic model representation.
+
+        Returns:
+            A KafkaSourceModel.
+        """
+
+        
+        class_ = getattr(
+                sys.modules[__name__],
+                type(data_source.kafka_options.message_format).__name__ + "Model",
+            )
+        if class_ not in SUPPORTED_MESSAGE_FORMATS:
+            raise ValueError(
+                "Data Source message format is not a supported stream format."
+            )
+        message_format = class_.from_stream_format(data_source.kafka_options.message_format)
+
+        batch_source = None
+        if data_source.batch_source:
+            class_ = getattr(
+                    sys.modules[__name__],
+                    type(data_source.batch_source).__name__ + "Model",
+                )
+            if class_ not in SUPPORTED_KAFKA_BATCH_SOURCES:
+                raise ValueError(
+                    "Kafka Source's batch source type is not a supported data source type."
+                )
+            batch_source = class_.from_data_source(data_source.batch_source)
+
+        return cls(
+            name=data_source.name,
+            timestamp_field=data_source.timestamp_field,
+            message_format=message_format,
+            kafka_bootstrap_servers=data_source.kafka_options.kafka_bootstrap_servers if data_source.kafka_options.kafka_bootstrap_servers else "",
+            topic=data_source.kafka_options.topic if data_source.kafka_options.topic else "",
+            created_timestamp_column=data_source.created_timestamp_column,
+            field_mapping=data_source.field_mapping if data_source.field_mapping else None,
+            description=data_source.description,
+            tags=data_source.tags if data_source.tags else None,
+            owner=data_source.owner,
+            batch_source=batch_source,
+            watermark_delay_threshold=data_source.kafka_options.watermark_delay_threshold,
+        )
+
 
 # https://blog.devgenius.io/deserialize-child-classes-with-pydantic-that-gonna-work-784230e1cf83
 # This lets us discriminate child classes of DataSourceModel with type hints.
 AnyDataSource = Annotated[
-    Union[RequestSourceModel, SparkSourceModel],
+    Union[RequestSourceModel, SparkSourceModel, KafkaSourceModel],
     PydanticField(discriminator="model_type"),
 ]

--- a/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
@@ -278,6 +278,6 @@ class KafkaSourceModel(DataSourceModel):
 # https://blog.devgenius.io/deserialize-child-classes-with-pydantic-that-gonna-work-784230e1cf83
 # This lets us discriminate child classes of DataSourceModel with type hints.
 AnyDataSource = Annotated[
-    Union[RequestSourceModel, SparkSourceModel],
+    Union[RequestSourceModel, SparkSourceModel, KafkaSourceModel],
     PydanticField(discriminator="model_type"),
 ]

--- a/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
@@ -12,17 +12,13 @@ from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from typing_extensions import Annotated, Self
 
-from feast.data_source import (
-    KafkaSource,
-    RequestSource,
-)
+from feast.data_source import KafkaSource, RequestSource
 from feast.expediagroup.pydantic_models.field_model import FieldModel
 from feast.expediagroup.pydantic_models.stream_format_model import (
     AnyStreamFormat,
     AvroFormatModel,
     JsonFormatModel,
     ProtoFormatModel,
-
 )
 from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
     SparkSource,
@@ -167,6 +163,7 @@ class SparkSourceModel(DataSourceModel):
             timestamp_field=data_source.timestamp_field,
         )
 
+
 AnyBatchDataSource = Annotated[
     Union[RequestSourceModel, SparkSourceModel],
     PydanticField(discriminator="model_type"),
@@ -175,6 +172,7 @@ AnyBatchDataSource = Annotated[
 
 SUPPORTED_MESSAGE_FORMATS = [AvroFormatModel, JsonFormatModel, ProtoFormatModel]
 SUPPORTED_KAFKA_BATCH_SOURCES = [RequestSourceModel, SparkSourceModel]
+
 
 class KafkaSourceModel(DataSourceModel):
     """
@@ -213,8 +211,10 @@ class KafkaSourceModel(DataSourceModel):
             description=self.description,
             tags=self.tags,
             owner=self.owner,
-            batch_source=self.batch_source.to_data_source(),
-            watermark_delay_threshold=self.watermark_delay_threshold
+            batch_source=self.batch_source.to_data_source()
+            if self.batch_source
+            else None,
+            watermark_delay_threshold=self.watermark_delay_threshold,
         )
 
     @classmethod
@@ -229,23 +229,24 @@ class KafkaSourceModel(DataSourceModel):
             A KafkaSourceModel.
         """
 
-        
         class_ = getattr(
-                sys.modules[__name__],
-                type(data_source.kafka_options.message_format).__name__ + "Model",
-            )
+            sys.modules[__name__],
+            type(data_source.kafka_options.message_format).__name__ + "Model",
+        )
         if class_ not in SUPPORTED_MESSAGE_FORMATS:
             raise ValueError(
                 "Data Source message format is not a supported stream format."
             )
-        message_format = class_.from_stream_format(data_source.kafka_options.message_format)
+        message_format = class_.from_stream_format(
+            data_source.kafka_options.message_format
+        )
 
         batch_source = None
         if data_source.batch_source:
             class_ = getattr(
-                    sys.modules[__name__],
-                    type(data_source.batch_source).__name__ + "Model",
-                )
+                sys.modules[__name__],
+                type(data_source.batch_source).__name__ + "Model",
+            )
             if class_ not in SUPPORTED_KAFKA_BATCH_SOURCES:
                 raise ValueError(
                     "Kafka Source's batch source type is not a supported data source type."
@@ -256,10 +257,16 @@ class KafkaSourceModel(DataSourceModel):
             name=data_source.name,
             timestamp_field=data_source.timestamp_field,
             message_format=message_format,
-            kafka_bootstrap_servers=data_source.kafka_options.kafka_bootstrap_servers if data_source.kafka_options.kafka_bootstrap_servers else "",
-            topic=data_source.kafka_options.topic if data_source.kafka_options.topic else "",
+            kafka_bootstrap_servers=data_source.kafka_options.kafka_bootstrap_servers
+            if data_source.kafka_options.kafka_bootstrap_servers
+            else "",
+            topic=data_source.kafka_options.topic
+            if data_source.kafka_options.topic
+            else "",
             created_timestamp_column=data_source.created_timestamp_column,
-            field_mapping=data_source.field_mapping if data_source.field_mapping else None,
+            field_mapping=data_source.field_mapping
+            if data_source.field_mapping
+            else None,
             description=data_source.description,
             tags=data_source.tags if data_source.tags else None,
             owner=data_source.owner,
@@ -271,6 +278,6 @@ class KafkaSourceModel(DataSourceModel):
 # https://blog.devgenius.io/deserialize-child-classes-with-pydantic-that-gonna-work-784230e1cf83
 # This lets us discriminate child classes of DataSourceModel with type hints.
 AnyDataSource = Annotated[
-    Union[RequestSourceModel, SparkSourceModel, KafkaSourceModel],
+    Union[RequestSourceModel, SparkSourceModel],
     PydanticField(discriminator="model_type"),
 ]

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_service.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_service.py
@@ -53,7 +53,6 @@ class FeatureServiceModel(BaseModel):
         cls,
         feature_service: FeatureService,
     ) -> Self:  # type: ignore
-
         features = []
         for feature in feature_service._features:
             class_ = getattr(

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
@@ -14,9 +14,9 @@ from typing_extensions import Self
 
 from feast.expediagroup.pydantic_models.data_source_model import (
     AnyBatchDataSource,
+    KafkaSourceModel,
     RequestSourceModel,
     SparkSourceModel,
-    KafkaSourceModel,
 )
 from feast.expediagroup.pydantic_models.entity_model import EntityModel
 from feast.expediagroup.pydantic_models.field_model import FieldModel
@@ -137,7 +137,9 @@ class FeatureViewModel(BaseFeatureViewModel):
         # on a parameter.
         stream_source = None
         if feature_view.stream_source:
-            stream_source = KafkaSourceModel.from_data_source(feature_view.stream_source)
+            stream_source = KafkaSourceModel.from_data_source(
+                feature_view.stream_source
+            )
         return cls(
             name=feature_view.name,
             original_entities=[

--- a/sdk/python/feast/expediagroup/pydantic_models/stream_format_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/stream_format_model.py
@@ -1,0 +1,150 @@
+from typing import Dict, Literal, Optional, Union
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+from typing_extensions import Annotated, Self
+
+from feast.data_format import (
+    StreamFormat,
+    AvroFormat,
+    JsonFormat,
+    ProtoFormat
+)
+
+
+class StreamFormatModel(BaseModel):
+    """
+    Pydantic Model of a Feast StreamFormat.
+    """
+
+    def to_stream_format(self):
+        """
+        Given a Pydantic StreamFormatModel, create and return a StreamFormat.
+
+        Returns:
+            A StreamFormat.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def from_stream_format(cls, stream_format):
+        """
+        Converts a StreamFormat object to its pydantic model representation.
+
+        Returns:
+            A StreamFormatModel.
+        """
+        raise NotImplementedError
+
+
+class AvroFormatModel(StreamFormatModel):
+    """
+    Pydantic Model of a Feast AvroFormat.
+    """
+
+    format: Literal["AvroFormatModel"] = "AvroFormatModel"
+    schoma: str
+
+    def to_stream_format(self) -> AvroFormat:
+        """
+        Given a Pydantic AvroFormatModel, create and return an AvroFormat.
+
+        Returns:
+            An AvroFormat.
+        """
+        return AvroFormat(
+            schema_json=self.schoma
+        )
+
+    @classmethod
+    def from_stream_format(
+        cls,
+        avro_format,
+    ) -> Self:  # type: ignore
+        """
+        Converts an AvroFormat object to its pydantic model representation.
+
+        Returns:
+            An AvroFormatModel.
+        """
+        return cls(
+            schoma=avro_format.schema_json
+        )
+
+
+class JsonFormatModel(StreamFormatModel):
+    """
+    Pydantic Model of a Feast JsonFormat.
+    """
+
+    format: Literal["JsonFormatModel"] = "JsonFormatModel"
+    schoma: str
+
+    def to_stream_format(self) -> JsonFormat:
+        """
+        Given a Pydantic JsonFormatModel, create and return a JsonFormat.
+
+        Returns:
+            A JsonFormat.
+        """
+        return JsonFormat(
+            schema_json=self.schoma
+        )
+
+    @classmethod
+    def from_stream_format(
+        cls,
+        json_format,
+    ) -> Self:  # type: ignore
+        """
+        Converts a JsonFormat object to its pydantic model representation.
+
+        Returns:
+            A JsonFormatModel.
+        """
+        return cls(
+            schoma=json_format.schema_json
+        )
+
+
+class ProtoFormatModel(StreamFormatModel):
+    """
+    Pydantic Model of a Feast ProtoFormat.
+    """
+
+    format: Literal["ProtoFormatModel"] = "ProtoFormatModel"
+    class_path: str
+
+    def to_stream_format(self) -> ProtoFormat:
+        """
+        Given a Pydantic ProtoFormatModel, create and return a ProtoFormat.
+
+        Returns:
+            A ProtoFormat.
+        """
+        return ProtoFormat(
+            class_path=self.class_path
+        )
+
+    @classmethod
+    def from_stream_format(
+        cls,
+        proto_format,
+    ) -> Self:  # type: ignore
+        """
+        Converts a ProtoFormat object to its pydantic model representation.
+
+        Returns:
+            A ProtoFormatModel.
+        """
+        return cls(
+            class_path=proto_format.class_path
+        )
+
+
+# https://blog.devgenius.io/deserialize-child-classes-with-pydantic-that-gonna-work-784230e1cf83
+# This lets us discriminate child classes of DataSourceModel with type hints.
+AnyStreamFormat = Annotated[
+    Union[AvroFormatModel, JsonFormatModel, ProtoFormatModel],
+    PydanticField(discriminator="format"),
+]

--- a/sdk/python/feast/expediagroup/pydantic_models/stream_format_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/stream_format_model.py
@@ -1,15 +1,10 @@
-from typing import Dict, Literal, Optional, Union
+from typing import Literal, Union
 
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from typing_extensions import Annotated, Self
 
-from feast.data_format import (
-    StreamFormat,
-    AvroFormat,
-    JsonFormat,
-    ProtoFormat
-)
+from feast.data_format import AvroFormat, JsonFormat, ProtoFormat
 
 
 class StreamFormatModel(BaseModel):
@@ -52,9 +47,7 @@ class AvroFormatModel(StreamFormatModel):
         Returns:
             An AvroFormat.
         """
-        return AvroFormat(
-            schema_json=self.schoma
-        )
+        return AvroFormat(schema_json=self.schoma)
 
     @classmethod
     def from_stream_format(
@@ -67,9 +60,7 @@ class AvroFormatModel(StreamFormatModel):
         Returns:
             An AvroFormatModel.
         """
-        return cls(
-            schoma=avro_format.schema_json
-        )
+        return cls(schoma=avro_format.schema_json)
 
 
 class JsonFormatModel(StreamFormatModel):
@@ -87,9 +78,7 @@ class JsonFormatModel(StreamFormatModel):
         Returns:
             A JsonFormat.
         """
-        return JsonFormat(
-            schema_json=self.schoma
-        )
+        return JsonFormat(schema_json=self.schoma)
 
     @classmethod
     def from_stream_format(
@@ -102,9 +91,7 @@ class JsonFormatModel(StreamFormatModel):
         Returns:
             A JsonFormatModel.
         """
-        return cls(
-            schoma=json_format.schema_json
-        )
+        return cls(schoma=json_format.schema_json)
 
 
 class ProtoFormatModel(StreamFormatModel):
@@ -122,9 +109,7 @@ class ProtoFormatModel(StreamFormatModel):
         Returns:
             A ProtoFormat.
         """
-        return ProtoFormat(
-            class_path=self.class_path
-        )
+        return ProtoFormat(class_path=self.class_path)
 
     @classmethod
     def from_stream_format(
@@ -137,9 +122,7 @@ class ProtoFormatModel(StreamFormatModel):
         Returns:
             A ProtoFormatModel.
         """
-        return cls(
-            class_path=proto_format.class_path
-        )
+        return cls(class_path=proto_format.class_path)
 
 
 # https://blog.devgenius.io/deserialize-child-classes-with-pydantic-that-gonna-work-784230e1cf83

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -18,12 +18,21 @@ from typing import List
 import pandas as pd
 from pydantic import BaseModel
 
-from feast.data_source import RequestSource
+from feast.data_source import (
+    KafkaSource,
+    RequestSource,
+)
+from feast.data_format import (
+    AvroFormat,
+    JsonFormat,
+    ProtoFormat
+)
 from feast.entity import Entity
 from feast.expediagroup.pydantic_models.data_source_model import (
     AnyDataSource,
     RequestSourceModel,
     SparkSourceModel,
+    KafkaSourceModel,
 )
 from feast.expediagroup.pydantic_models.entity_model import EntityModel
 from feast.expediagroup.pydantic_models.feature_service import FeatureServiceModel
@@ -207,6 +216,51 @@ def test_idempotent_sparksource_conversion():
     assert pydantic_obj == SparkSourceModel.parse_obj(pydantic_json)
 
 
+def test_idempotent_kafkasource_conversion():
+
+    schema = [
+        Field(name="f1", dtype=Float32),
+        Field(name="f2", dtype=Bool),
+    ]
+    batch_source = RequestSource(
+        name="source",
+        schema=schema,
+        description="desc",
+        tags={"tag1": "val1"},,
+        owner="feast",
+    )
+
+    python_obj = KafkaSource(
+        name="kafka_source",
+        timestamp_field="whatevs, just a string",
+        message_format=AvroFormat(schema_json="whatevs, also just a string"),
+        batch_source=batch_source,
+        description="Bob's used message formats emporium is open 24/7",
+        tags={"source_thing": "thing_val"},
+        kafka_bootstrap_servers="http://stuff.vals.place.go:3543/duck/duck/goose",
+        topic="ad_spam",
+        created_timestamp_column="created",
+        field_mapping={"source_thing": "thing_val"},
+        owner="bdodla@expediagroup.com",
+        watermark_delay_threshold=timedelta(days=1),
+
+    )
+
+    pydantic_obj = KafkaSourceModel.from_data_source(python_obj)
+    converted_python_obj = pydantic_obj.to_data_source()
+    assert python_obj == converted_python_obj
+
+    feast_proto = converted_python_obj.to_proto()
+    python_obj_from_proto = KafkaSource.from_proto(feast_proto)
+    assert python_obj == python_obj_from_proto
+
+    pydantic_json = pydantic_obj.json()
+    assert pydantic_obj == KafkaSourceModel.parse_raw(pydantic_json)
+
+    pydantic_json = pydantic_obj.dict()
+    assert pydantic_obj == KafkaSourceModel.parse_obj(pydantic_json)
+
+
 def test_idempotent_featureview_conversion():
     schema = [
         Field(name="f1", dtype=Float32),
@@ -231,6 +285,78 @@ def test_idempotent_featureview_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=request_source,
+        ttl=timedelta(days=0),
+    )
+    feature_view_model = FeatureViewModel.from_feature_view(feature_view)
+    feature_view_b = feature_view_model.to_feature_view()
+    assert feature_view == feature_view_b
+
+    spark_source = SparkSource(
+        name="sparky_sparky_boom_man",
+        path="/data/driver_hourly_stats",
+        file_format="parquet",
+        timestamp_field="event_timestamp",
+        created_timestamp_column="created",
+    )
+    python_obj = FeatureView(
+        name="my-feature-view",
+        entities=[user_entity],
+        schema=[
+            Field(name="feature1", dtype=Float32),
+            Field(name="feature2", dtype=Float32),
+        ],
+        source=spark_source,
+    )
+    python_obj.materialization_intervals = [
+        (datetime.now() - timedelta(days=10), datetime.now() - timedelta(days=9)),
+        (datetime.now(), datetime.now()),
+    ]
+    pydantic_obj = FeatureViewModel.from_feature_view(python_obj)
+    converted_python_obj = pydantic_obj.to_feature_view()
+    assert python_obj == converted_python_obj
+
+    feast_proto = converted_python_obj.to_proto()
+    python_obj_from_proto = FeatureView.from_proto(feast_proto)
+    assert python_obj == python_obj_from_proto
+
+    pydantic_json = pydantic_obj.json()
+    assert pydantic_obj == FeatureViewModel.parse_raw(pydantic_json)
+
+    pydantic_json = pydantic_obj.dict()
+    assert pydantic_obj == FeatureViewModel.parse_obj(pydantic_json)
+
+
+def test_idempotent_featureview_with_streaming_source_conversion():
+    schema = [
+        Field(name="f1", dtype=Float32),
+        Field(name="f2", dtype=Bool),
+    ]
+    user_entity = Entity(
+        name="user1", join_keys=["user_id"], value_type=ValueType.INT64
+    )
+    request_source = RequestSource(
+        name="source",
+        schema=schema,
+        description="desc",
+        tags={},
+        owner="feast",
+    )
+    kafka_source = KafkaSource(
+        name="kafka_source",
+        timestamp_field="whatevs, just a string",
+        message_format=AvroFormat(schema_json="whatevs, also just a string"),
+        batch_source=request_source,
+        description="Bob's used message formats emporium is open 24/7"
+    )
+    feature_view = FeatureView(
+        name="my-feature-view",
+        entities=[user_entity],
+        schema=[
+            Field(name="user1", dtype=Int64),
+            Field(name="feature1", dtype=Float32),
+            Field(name="feature2", dtype=Float32),
+        ],
+        source=kafka_source,
         ttl=timedelta(days=0),
     )
     feature_view_model = FeatureViewModel.from_feature_view(feature_view)

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -18,21 +18,14 @@ from typing import List
 import pandas as pd
 from pydantic import BaseModel
 
-from feast.data_source import (
-    KafkaSource,
-    RequestSource,
-)
-from feast.data_format import (
-    AvroFormat,
-    JsonFormat,
-    ProtoFormat
-)
+from feast.data_format import AvroFormat
+from feast.data_source import KafkaSource, RequestSource
 from feast.entity import Entity
 from feast.expediagroup.pydantic_models.data_source_model import (
     AnyDataSource,
+    KafkaSourceModel,
     RequestSourceModel,
     SparkSourceModel,
-    KafkaSourceModel,
 )
 from feast.expediagroup.pydantic_models.entity_model import EntityModel
 from feast.expediagroup.pydantic_models.feature_service import FeatureServiceModel
@@ -217,7 +210,6 @@ def test_idempotent_sparksource_conversion():
 
 
 def test_idempotent_kafkasource_conversion():
-
     schema = [
         Field(name="f1", dtype=Float32),
         Field(name="f2", dtype=Bool),
@@ -226,7 +218,7 @@ def test_idempotent_kafkasource_conversion():
         name="source",
         schema=schema,
         description="desc",
-        tags={"tag1": "val1"},,
+        tags={"tag1": "val1"},
         owner="feast",
     )
 
@@ -243,7 +235,6 @@ def test_idempotent_kafkasource_conversion():
         field_mapping={"source_thing": "thing_val"},
         owner="bdodla@expediagroup.com",
         watermark_delay_threshold=timedelta(days=1),
-
     )
 
     pydantic_obj = KafkaSourceModel.from_data_source(python_obj)
@@ -346,7 +337,7 @@ def test_idempotent_featureview_with_streaming_source_conversion():
         timestamp_field="whatevs, just a string",
         message_format=AvroFormat(schema_json="whatevs, also just a string"),
         batch_source=request_source,
-        description="Bob's used message formats emporium is open 24/7"
+        description="Bob's used message formats emporium is open 24/7",
     )
     feature_view = FeatureView(
         name="my-feature-view",


### PR DESCRIPTION
This PR adds KafkaSourceModel to Pydantic models, making KafkaSources viable data sources for transmission in service calls such as the ones in Registry Service.

https://jira.expedia.biz/browse/EAPC-9689