### PR TITLE
accepting client_id header

### DIFF
--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -125,13 +125,9 @@ class HttpRegistry(BaseRegistry):
         logger.exception("Request failed with exception: %s", str(exception))
         raise httpx.HTTPError("Request failed with exception: " + str(exception))
 
-    def _send_request(
-        self, method: str, url: str, params=None, data=None
-    ):
+    def _send_request(self, method: str, url: str, params=None, data=None):
         try:
-            request = httpx.Request(
-                method=method, url=url, params=params, data=data
-            )
+            request = httpx.Request(method=method, url=url, params=params, data=data)
             response = self.http_client.send(request)
             response.raise_for_status()
             return response.json()

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -551,9 +551,9 @@ class HttpRegistry(BaseRegistry):
         raise NotImplementedError("Method not implemented")
 
     def list_request_feature_views(
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[RequestFeatureView]:
         # TODO: Implement listing Request Feature Views
         return []

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -718,15 +718,19 @@ class HttpRegistry(BaseRegistry):
     def _refresh_cached_registry_if_necessary(self):
         with self._refresh_lock:
             expired = (
-                              self.cached_registry_proto is None
-                              or self.cached_registry_proto_created is None
-                      ) or (
-                              self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
-                              and (
-                                      datetime.utcnow()
-                                      > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
-                              )
-                      )
+                self.cached_registry_proto is None
+                or self.cached_registry_proto_created is None
+            ) or (
+                self.cached_registry_proto_ttl.total_seconds()
+                > 0  # 0 ttl means infinity
+                and (
+                    datetime.utcnow()
+                    > (
+                        self.cached_registry_proto_created
+                        + self.cached_registry_proto_ttl
+                    )
+                )
+            )
 
             if expired:
                 logger.info("Registry cache expired, so refreshing")
@@ -734,17 +738,17 @@ class HttpRegistry(BaseRegistry):
 
     def _check_if_registry_refreshed(self):
         if (
-                self.cached_registry_proto is None
-                or self.cached_registry_proto_created is None
+            self.cached_registry_proto is None
+            or self.cached_registry_proto_created is None
         ) or (
-                self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
-                and (
-                        datetime.utcnow()
-                        > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
-                )
+            self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
+            and (
+                datetime.utcnow()
+                > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
+            )
         ):
             seconds_since_last_refresh = (
-                    datetime.utcnow() - self.cached_registry_proto_created
+                datetime.utcnow() - self.cached_registry_proto_created
             ).total_seconds()
             if seconds_since_last_refresh > CACHE_REFRESH_THRESHOLD_SECONDS:
                 logger.warning(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -123,7 +123,7 @@ class HttpRegistry(BaseRegistry):
         logger.exception("Request failed with exception: %s", str(exception))
         raise httpx.HTTPError("Request failed with exception: " + str(exception))
 
-    def _send_request(self, method: str, url: str, params=None, data=None, headers= None):
+    def _send_request(self, method: str, url: str, params=None, data=None, headers=None):
         try:
             request = httpx.Request(method=method, url=url, params=params, data=data, headers=headers)
             response = self.http_client.send(request)
@@ -139,7 +139,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects"
             params = {"project": project, "commit": commit}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("PUT", url, params=params, headers = headers)
+            response_data = self._send_request("PUT", url, params=params, headers=headers)
             return ProjectMetadataModel.parse_obj(response_data)
         except Exception as exception:
             self._handle_exception(exception)
@@ -160,7 +160,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"commit": commit}
             headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers= headers)
+            self._send_request("DELETE", url, params=params, headers=headers)
             logger.info(f"Deleted Entity {name} from project {project}")
         except EntityNotFoundException as exception:
             logger.error(
@@ -248,7 +248,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"commit": commit}
             headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers = headers)
+            self._send_request("DELETE", url, params=params, headers=headers)
             logger.info(f"Deleted Datasource {name} from project {project}")
         except DataSourceObjectNotFoundException as exception:
             logger.error(
@@ -273,7 +273,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers =headers)
+            response_data = self._send_request("GET", url, params=params, headers=headers)
             if "model_type" in response_data:
                 if response_data["model_type"] == "RequestSourceModel":
                     return RequestSourceModel.parse_obj(response_data).to_data_source()
@@ -340,7 +340,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"commit": commit}
             headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers = headers)
+            self._send_request("DELETE", url, params=params, headers=headers)
             logger.info(f"Deleted FeatureService {name} from project {project}")
         except FeatureServiceNotFoundException as exception:
             logger.error(
@@ -366,7 +366,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers= headers)
+            response_data = self._send_request("GET", url, params=params, headers=headers)
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
             logger.error(
@@ -721,14 +721,10 @@ class HttpRegistry(BaseRegistry):
                               self.cached_registry_proto is None
                               or self.cached_registry_proto_created is None
                       ) or (
-                              self.cached_registry_proto_ttl.total_seconds()
-                              > 0  # 0 ttl means infinity
+                              self.cached_registry_proto_ttl.total_seconds() > 0  # 0 ttl means infinity
                               and (
                                       datetime.utcnow()
-                                      > (
-                                              self.cached_registry_proto_created
-                                              + self.cached_registry_proto_ttl
-                                      )
+                                      > (self.cached_registry_proto_created + self.cached_registry_proto_ttl)
                               )
                       )
 

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -123,9 +123,13 @@ class HttpRegistry(BaseRegistry):
         logger.exception("Request failed with exception: %s", str(exception))
         raise httpx.HTTPError("Request failed with exception: " + str(exception))
 
-    def _send_request(self, method: str, url: str, params=None, data=None, headers=None):
+    def _send_request(
+        self, method: str, url: str, params=None, data=None, headers=None
+    ):
         try:
-            request = httpx.Request(method=method, url=url, params=params, data=data, headers=headers)
+            request = httpx.Request(
+                method=method, url=url, params=params, data=data, headers=headers
+            )
             response = self.http_client.send(request)
             response.raise_for_status()
             return response.json()
@@ -139,7 +143,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects"
             params = {"project": project, "commit": commit}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("PUT", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "PUT", url, params=params, headers=headers
+            )
             return ProjectMetadataModel.parse_obj(response_data)
         except Exception as exception:
             self._handle_exception(exception)
@@ -150,7 +156,9 @@ class HttpRegistry(BaseRegistry):
             data = EntityModel.from_entity(entity).json()
             params = {"commit": commit}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+            response_data = self._send_request(
+                "PUT", url, params=params, data=data, headers=headers
+            )
             return EntityModel.parse_obj(response_data).to_entity()
         except Exception as exception:
             self._handle_exception(exception)
@@ -185,7 +193,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             return EntityModel.parse_obj(response_data).to_entity()
         except EntityNotFoundException as exception:
             logger.error(
@@ -209,7 +219,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/entities"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 EntityModel.parse_obj(entity).to_entity() for entity in response_list
@@ -226,7 +238,9 @@ class HttpRegistry(BaseRegistry):
             headers = {"client_id": self.client_id}
             if isinstance(data_source, SparkSource):
                 data = SparkSourceModel.from_data_source(data_source).json()
-                response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+                response_data = self._send_request(
+                    "PUT", url, params=params, data=data, headers=headers
+                )
                 return SparkSourceModel.parse_obj(response_data).to_data_source()
             elif isinstance(data_source, RequestSource):
                 data = RequestSourceModel.from_data_source(data_source).json()
@@ -273,7 +287,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             if "model_type" in response_data:
                 if response_data["model_type"] == "RequestSourceModel":
                     return RequestSourceModel.parse_obj(response_data).to_data_source()
@@ -304,7 +320,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             response_list = response_data if isinstance(response_data, list) else []
             data_source_list = []
             for data_source in response_list:
@@ -330,7 +348,9 @@ class HttpRegistry(BaseRegistry):
             data = FeatureServiceModel.from_feature_service(feature_service).json()
             params = {"commit": commit}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+            response_data = self._send_request(
+                "PUT", url, params=params, data=data, headers=headers
+            )
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except Exception as exception:
             self._handle_exception(exception)
@@ -366,7 +386,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
             logger.error(
@@ -388,7 +410,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 FeatureServiceModel.parse_obj(feature_service).to_feature_service()
@@ -406,12 +430,16 @@ class HttpRegistry(BaseRegistry):
             if isinstance(feature_view, FeatureView):
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+                response_data = self._send_request(
+                    "PUT", url, params=params, data=data, headers=headers
+                )
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             elif isinstance(feature_view, OnDemandFeatureView):
                 url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
                 data = OnDemandFeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+                response_data = self._send_request(
+                    "PUT", url, params=params, data=data, headers=headers
+                )
                 return OnDemandFeatureViewModel.parse_obj(
                     response_data
                 ).to_feature_view()
@@ -453,7 +481,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             return FeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
             logger.error(
@@ -475,7 +505,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_views"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 FeatureViewModel.parse_obj(feature_view).to_feature_view()
@@ -496,7 +528,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views/{name}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
             logger.error(
@@ -518,7 +552,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 OnDemandFeatureViewModel.parse_obj(feature_view).to_feature_view()
@@ -573,7 +609,9 @@ class HttpRegistry(BaseRegistry):
                 headers = {"client_id": self.client_id}
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)
+                response_data = self._send_request(
+                    "PUT", url, params=params, data=data, headers=headers
+                )
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             else:
                 raise TypeError(
@@ -787,7 +825,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}"
             params = {"allow_cache": True}
             headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, params=params, headers=headers)
+            response_data = self._send_request(
+                "GET", url, params=params, headers=headers
+            )
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:
             logger.error(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -79,10 +79,12 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
-        headers = {
-            "Content-Type": "application/json",
-            "Client-Id": registry_config.client_id,
-        }
+        headers = httpx.Headers(
+            {
+                "Content-Type": "application/json",
+                "Client-Id": registry_config.client_id,
+            }
+        )
         self.http_client = httpx.Client(
             timeout=timeout, transport=transport, headers=headers
         )

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -79,13 +79,13 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
+        headers = [
+            ("Content-Type", "application/json"),
+            ("client_id", registry_config.client_id),
+        ]
+
         self.http_client = httpx.Client(
-            timeout=timeout,
-            transport=transport,
-            headers={
-                "Content-Type": "application/json",
-                "client_id": registry_config.clint_id,
-            },
+            timeout=timeout, transport=transport, headers=headers
         )
         self.project = project
         self.apply_project(self.project)

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -69,10 +69,10 @@ CACHE_REFRESH_THRESHOLD_SECONDS = 300
 
 class HttpRegistry(BaseRegistry):
     def __init__(
-            self,
-            registry_config: Optional[Union[RegistryConfig, HttpRegistryConfig]],
-            project: str,
-            repo_path: Optional[Path],
+        self,
+        registry_config: Optional[Union[RegistryConfig, HttpRegistryConfig]],
+        project: str,
+        repo_path: Optional[Path],
     ):
         assert registry_config is not None, "HTTPRegistry needs a valid registry_config"
         # Timeouts in seconds
@@ -171,10 +171,10 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_entity(  # type: ignore[return]
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> Entity:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -196,9 +196,9 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_entities(  # type: ignore[return]
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[Entity]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -218,7 +218,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def apply_data_source(
-            self, data_source: DataSource, project: str, commit: bool = True
+        self, data_source: DataSource, project: str, commit: bool = True
     ):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
@@ -259,10 +259,10 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_data_source(  # type: ignore[return]
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> DataSource:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -291,9 +291,9 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_data_sources(  # type: ignore[return]
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[DataSource]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -323,7 +323,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def apply_feature_service(
-            self, feature_service: FeatureService, project: str, commit: bool = True
+        self, feature_service: FeatureService, project: str, commit: bool = True
     ):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
@@ -352,10 +352,10 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_feature_service(  # type: ignore[return]
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> FeatureService:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -377,7 +377,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_feature_services(  # type: ignore[return]
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[FeatureService]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -398,7 +398,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def apply_feature_view(
-            self, feature_view: BaseFeatureView, project: str, commit: bool = True
+        self, feature_view: BaseFeatureView, project: str, commit: bool = True
     ):
         try:
             params = {"commit": commit}
@@ -439,10 +439,10 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_feature_view(  # type: ignore[return]
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> FeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -464,7 +464,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_feature_views(  # type: ignore[return]
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[FeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -485,7 +485,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_on_demand_feature_view(  # type: ignore[return]
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> OnDemandFeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -507,7 +507,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_on_demand_feature_views(  # type: ignore[return]
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[OnDemandFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -528,25 +528,25 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def get_stream_feature_view(
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ):
         raise NotImplementedError("Method not implemented")
 
     def list_stream_feature_views(
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[StreamFeatureView]:
         # TODO: Implement listing Stream Feature Views
         return []
 
     def get_request_feature_view(
-            self,
-            name: str,
-            project: str,
+        self,
+        name: str,
+        project: str,
     ) -> RequestFeatureView:
         raise NotImplementedError("Method not implemented")
 
@@ -559,12 +559,12 @@ class HttpRegistry(BaseRegistry):
         return []
 
     def apply_materialization(
-            self,
-            feature_view: FeatureView,
-            project: str,
-            start_date: datetime,
-            end_date: datetime,
-            commit: bool = True,
+        self,
+        feature_view: FeatureView,
+        project: str,
+        start_date: datetime,
+        end_date: datetime,
+        commit: bool = True,
     ):
         try:
             if isinstance(feature_view, FeatureView):
@@ -583,30 +583,30 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def apply_saved_dataset(
-            self, saved_dataset: SavedDataset, project: str, commit: bool = True
+        self, saved_dataset: SavedDataset, project: str, commit: bool = True
     ):
         raise NotImplementedError("Method not implemented")
 
     def get_saved_dataset(
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> SavedDataset:
         raise NotImplementedError("Method not implemented")
 
     def list_saved_datasets(
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[SavedDataset]:
         pass
 
     def apply_validation_reference(
-            self,
-            validation_reference: ValidationReference,
-            project: str,
-            commit: bool = True,
+        self,
+        validation_reference: ValidationReference,
+        project: str,
+        commit: bool = True,
     ):
         raise NotImplementedError("Method not implemented")
 
@@ -614,10 +614,10 @@ class HttpRegistry(BaseRegistry):
         raise NotImplementedError("Method not implemented")
 
     def get_validation_reference(
-            self,
-            name: str,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        name: str,
+        project: str,
+        allow_cache: bool = False,
     ) -> ValidationReference:
         raise NotImplementedError("Method not implemented")
 
@@ -625,30 +625,30 @@ class HttpRegistry(BaseRegistry):
         raise NotImplementedError("Method not implemented")
 
     def get_infra(
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> Infra:
         # TODO: Need to implement this when necessary
         return Infra()
 
     def apply_user_metadata(
-            self,
-            project: str,
-            feature_view: BaseFeatureView,
-            metadata_bytes: Optional[bytes],
+        self,
+        project: str,
+        feature_view: BaseFeatureView,
+        metadata_bytes: Optional[bytes],
     ):
         raise NotImplementedError("Method not implemented")
 
     def get_user_metadata(
-            self, project: str, feature_view: BaseFeatureView
+        self, project: str, feature_view: BaseFeatureView
     ) -> Optional[bytes]:
         raise NotImplementedError("Method not implemented")
 
     def list_validation_references(
-            self,
-            project: str,
-            allow_cache: bool = False,
+        self,
+        project: str,
+        allow_cache: bool = False,
     ) -> List[ValidationReference]:
         pass
 
@@ -776,7 +776,7 @@ class HttpRegistry(BaseRegistry):
             self._handle_exception(exception)
 
     def list_project_metadata(  # type: ignore[return]
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[ProjectMetadata]:
         if allow_cache:
             self._check_if_registry_refreshed()

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -79,11 +79,12 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
-        headers = httpx.Headers([
-            ("Content-Type", "application/json"),
-            ("Client-Id", registry_config.client_id),
-        ])
-
+        headers = {
+            "Content-Type",
+            "application/json",
+            "Client-Id",
+            registry_config.client_id,
+        }
         self.http_client = httpx.Client(
             timeout=timeout, transport=transport, headers=headers
         )

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -61,7 +61,7 @@ class HttpRegistryConfig(RegistryConfig):
     """ str: Endpoint of Feature registry.
     If registry_type is 'http', then this is a endpoint of Feature Registry """
 
-    clint_id: StrictStr = "Unknown"
+    clint_id: Optional[StrictStr] = "Unknown"
 
 
 CACHE_REFRESH_THRESHOLD_SECONDS = 300

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -80,10 +80,8 @@ class HttpRegistry(BaseRegistry):
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
         headers = {
-            "Content-Type",
-            "application/json",
-            "Client-Id",
-            registry_config.client_id,
+            "Content-Type": "application/json",
+            "Client-Id": registry_config.client_id,
         }
         self.http_client = httpx.Client(
             timeout=timeout, transport=transport, headers=headers

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -61,7 +61,7 @@ class HttpRegistryConfig(RegistryConfig):
     """ str: Endpoint of Feature registry.
     If registry_type is 'http', then this is a endpoint of Feature Registry """
 
-    clint_id: Optional[StrictStr] = "Unknown"
+    client_id: Optional[StrictStr] = "Unknown"
 
 
 CACHE_REFRESH_THRESHOLD_SECONDS = 300
@@ -79,11 +79,10 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
-        self.client_id = registry_config.clint_id
         self.http_client = httpx.Client(
             timeout=timeout,
             transport=transport,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "client_id": registry_config.clint_id},
         )
         self.project = project
         self.apply_project(self.project)
@@ -142,9 +141,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects"
             params = {"project": project, "commit": commit}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "PUT", url, params=params, headers=headers
+                "PUT", url, params=params
             )
             return ProjectMetadataModel.parse_obj(response_data)
         except Exception as exception:
@@ -155,9 +153,9 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/entities"
             data = EntityModel.from_entity(entity).json()
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
+
             response_data = self._send_request(
-                "PUT", url, params=params, data=data, headers=headers
+                "PUT", url, params=params, data=data
             )
             return EntityModel.parse_obj(response_data).to_entity()
         except Exception as exception:
@@ -167,8 +165,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers=headers)
+            self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted Entity {name} from project {project}")
         except EntityNotFoundException as exception:
             logger.error(
@@ -192,9 +189,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             return EntityModel.parse_obj(response_data).to_entity()
         except EntityNotFoundException as exception:
@@ -218,9 +214,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/entities"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -235,11 +230,10 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
             if isinstance(data_source, SparkSource):
                 data = SparkSourceModel.from_data_source(data_source).json()
                 response_data = self._send_request(
-                    "PUT", url, params=params, data=data, headers=headers
+                    "PUT", url, params=params, data=data
                 )
                 return SparkSourceModel.parse_obj(response_data).to_data_source()
             elif isinstance(data_source, RequestSource):
@@ -261,8 +255,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers=headers)
+            self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted Datasource {name} from project {project}")
         except DataSourceObjectNotFoundException as exception:
             logger.error(
@@ -286,9 +279,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             if "model_type" in response_data:
                 if response_data["model_type"] == "RequestSourceModel":
@@ -319,9 +311,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             response_list = response_data if isinstance(response_data, list) else []
             data_source_list = []
@@ -347,9 +338,8 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services"
             data = FeatureServiceModel.from_feature_service(feature_service).json()
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "PUT", url, params=params, data=data, headers=headers
+                "PUT", url, params=params, data=data
             )
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except Exception as exception:
@@ -359,8 +349,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers=headers)
+            self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted FeatureService {name} from project {project}")
         except FeatureServiceNotFoundException as exception:
             logger.error(
@@ -385,9 +374,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
@@ -409,9 +397,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -426,19 +413,18 @@ class HttpRegistry(BaseRegistry):
     ):
         try:
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
             if isinstance(feature_view, FeatureView):
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request(
-                    "PUT", url, params=params, data=data, headers=headers
+                    "PUT", url, params=params, data=data
                 )
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             elif isinstance(feature_view, OnDemandFeatureView):
                 url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
                 data = OnDemandFeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request(
-                    "PUT", url, params=params, data=data, headers=headers
+                    "PUT", url, params=params, data=data
                 )
                 return OnDemandFeatureViewModel.parse_obj(
                     response_data
@@ -454,8 +440,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
             params = {"commit": commit}
-            headers = {"client_id": self.client_id}
-            self._send_request("DELETE", url, params=params, headers=headers)
+            self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted FeatureView {name} from project {project}")
         except FeatureViewNotFoundException as exception:
             logger.error(
@@ -480,9 +465,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             return FeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
@@ -504,9 +488,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_views"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -527,9 +510,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views/{name}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
@@ -551,9 +533,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             response_list = response_data if isinstance(response_data, list) else []
             return [
@@ -606,11 +587,10 @@ class HttpRegistry(BaseRegistry):
             if isinstance(feature_view, FeatureView):
                 feature_view.materialization_intervals.append((start_date, end_date))
                 params = {"commit": commit}
-                headers = {"client_id": self.client_id}
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request(
-                    "PUT", url, params=params, data=data, headers=headers
+                    "PUT", url, params=params, data=data
                 )
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             else:
@@ -796,8 +776,7 @@ class HttpRegistry(BaseRegistry):
     def _get_all_projects(self) -> Set[str]:  # type: ignore[return]
         try:
             url = f"{self.base_url}/projects"
-            headers = {"client_id": self.client_id}
-            projects = self._send_request("GET", url, headers=headers)
+            projects = self._send_request("GET", url)
             return {project["project_name"] for project in projects}
         except Exception as exception:
             self._handle_exception(exception)
@@ -805,8 +784,7 @@ class HttpRegistry(BaseRegistry):
     def _get_last_updated_metadata(self, project: str):
         try:
             url = f"{self.base_url}/projects/{project}"
-            headers = {"client_id": self.client_id}
-            response_data = self._send_request("GET", url, headers=headers)
+            response_data = self._send_request("GET", url)
             return datetime.strptime(
                 response_data["last_updated_timestamp"], "%Y-%m-%dT%H:%M:%S"
             )
@@ -824,9 +802,8 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}"
             params = {"allow_cache": True}
-            headers = {"client_id": self.client_id}
             response_data = self._send_request(
-                "GET", url, params=params, headers=headers
+                "GET", url, params=params
             )
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -82,7 +82,10 @@ class HttpRegistry(BaseRegistry):
         self.http_client = httpx.Client(
             timeout=timeout,
             transport=transport,
-            headers={"Content-Type": "application/json", "client_id": registry_config.clint_id},
+            headers={
+                "Content-Type": "application/json",
+                "client_id": registry_config.clint_id,
+            },
         )
         self.project = project
         self.apply_project(self.project)
@@ -141,9 +144,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects"
             params = {"project": project, "commit": commit}
-            response_data = self._send_request(
-                "PUT", url, params=params
-            )
+            response_data = self._send_request("PUT", url, params=params)
             return ProjectMetadataModel.parse_obj(response_data)
         except Exception as exception:
             self._handle_exception(exception)
@@ -154,9 +155,7 @@ class HttpRegistry(BaseRegistry):
             data = EntityModel.from_entity(entity).json()
             params = {"commit": commit}
 
-            response_data = self._send_request(
-                "PUT", url, params=params, data=data
-            )
+            response_data = self._send_request("PUT", url, params=params, data=data)
             return EntityModel.parse_obj(response_data).to_entity()
         except Exception as exception:
             self._handle_exception(exception)
@@ -189,9 +188,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/entities/{name}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             return EntityModel.parse_obj(response_data).to_entity()
         except EntityNotFoundException as exception:
             logger.error(
@@ -214,9 +211,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/entities"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 EntityModel.parse_obj(entity).to_entity() for entity in response_list
@@ -232,9 +227,7 @@ class HttpRegistry(BaseRegistry):
             params = {"commit": commit}
             if isinstance(data_source, SparkSource):
                 data = SparkSourceModel.from_data_source(data_source).json()
-                response_data = self._send_request(
-                    "PUT", url, params=params, data=data
-                )
+                response_data = self._send_request("PUT", url, params=params, data=data)
                 return SparkSourceModel.parse_obj(response_data).to_data_source()
             elif isinstance(data_source, RequestSource):
                 data = RequestSourceModel.from_data_source(data_source).json()
@@ -279,9 +272,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources/{name}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             if "model_type" in response_data:
                 if response_data["model_type"] == "RequestSourceModel":
                     return RequestSourceModel.parse_obj(response_data).to_data_source()
@@ -311,9 +302,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             data_source_list = []
             for data_source in response_list:
@@ -338,9 +327,7 @@ class HttpRegistry(BaseRegistry):
             url = f"{self.base_url}/projects/{project}/feature_services"
             data = FeatureServiceModel.from_feature_service(feature_service).json()
             params = {"commit": commit}
-            response_data = self._send_request(
-                "PUT", url, params=params, data=data
-            )
+            response_data = self._send_request("PUT", url, params=params, data=data)
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except Exception as exception:
             self._handle_exception(exception)
@@ -374,9 +361,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services/{name}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             return FeatureServiceModel.parse_obj(response_data).to_feature_service()
         except FeatureServiceNotFoundException as exception:
             logger.error(
@@ -397,9 +382,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 FeatureServiceModel.parse_obj(feature_service).to_feature_service()
@@ -416,16 +399,12 @@ class HttpRegistry(BaseRegistry):
             if isinstance(feature_view, FeatureView):
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request(
-                    "PUT", url, params=params, data=data
-                )
+                response_data = self._send_request("PUT", url, params=params, data=data)
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             elif isinstance(feature_view, OnDemandFeatureView):
                 url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
                 data = OnDemandFeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request(
-                    "PUT", url, params=params, data=data
-                )
+                response_data = self._send_request("PUT", url, params=params, data=data)
                 return OnDemandFeatureViewModel.parse_obj(
                     response_data
                 ).to_feature_view()
@@ -465,9 +444,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_views/{name}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             return FeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
             logger.error(
@@ -488,9 +465,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/feature_views"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 FeatureViewModel.parse_obj(feature_view).to_feature_view()
@@ -510,9 +485,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views/{name}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             return OnDemandFeatureViewModel.parse_obj(response_data).to_feature_view()
         except FeatureViewNotFoundException as exception:
             logger.error(
@@ -533,9 +506,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             response_list = response_data if isinstance(response_data, list) else []
             return [
                 OnDemandFeatureViewModel.parse_obj(feature_view).to_feature_view()
@@ -589,9 +560,7 @@ class HttpRegistry(BaseRegistry):
                 params = {"commit": commit}
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
-                response_data = self._send_request(
-                    "PUT", url, params=params, data=data
-                )
+                response_data = self._send_request("PUT", url, params=params, data=data)
                 return FeatureViewModel.parse_obj(response_data).to_feature_view()
             else:
                 raise TypeError(
@@ -802,9 +771,7 @@ class HttpRegistry(BaseRegistry):
         try:
             url = f"{self.base_url}/projects/{project}"
             params = {"allow_cache": True}
-            response_data = self._send_request(
-                "GET", url, params=params
-            )
+            response_data = self._send_request("GET", url, params=params)
             return [ProjectMetadataModel.parse_obj(response_data).to_project_metadata()]
         except ProjectMetadataNotFoundException as exception:
             logger.error(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -79,12 +79,14 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
+        headers_dict = {
+            "Content-Type": "application/json",
+            "Client-Id": registry_config.client_id,
+        }
         headers = httpx.Headers(
-            {
-                "Content-Type": "application/json",
-                "Client-Id": registry_config.client_id,
-            }
+            {k: str(v) for k, v in headers_dict.items() if v is not None}
         )
+
         self.http_client = httpx.Client(
             timeout=timeout, transport=transport, headers=headers
         )

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -126,11 +126,11 @@ class HttpRegistry(BaseRegistry):
         raise httpx.HTTPError("Request failed with exception: " + str(exception))
 
     def _send_request(
-        self, method: str, url: str, params=None, data=None, headers=None
+        self, method: str, url: str, params=None, data=None
     ):
         try:
             request = httpx.Request(
-                method=method, url=url, params=params, data=data, headers=headers
+                method=method, url=url, params=params, data=data
             )
             response = self.http_client.send(request)
             response.raise_for_status()

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -570,7 +570,7 @@ class HttpRegistry(BaseRegistry):
             if isinstance(feature_view, FeatureView):
                 feature_view.materialization_intervals.append((start_date, end_date))
                 params = {"commit": commit}
-                headers = {client_id: self.client_id}
+                headers = {"client_id": self.client_id}
                 url = f"{self.base_url}/projects/{project}/feature_views"
                 data = FeatureViewModel.from_feature_view(feature_view).json()
                 response_data = self._send_request("PUT", url, params=params, data=data, headers=headers)

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -81,7 +81,7 @@ class HttpRegistry(BaseRegistry):
         self.base_url = registry_config.path
         headers = [
             ("Content-Type", "application/json"),
-            ("client_id", registry_config.client_id),
+            ("Client-Id", registry_config.client_id),
         ]
 
         self.http_client = httpx.Client(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -79,10 +79,10 @@ class HttpRegistry(BaseRegistry):
         timeout = httpx.Timeout(5.0, connect=60.0)
         transport = httpx.HTTPTransport(retries=3, verify=False)
         self.base_url = registry_config.path
-        headers = [
+        headers = httpx.Headers([
             ("Content-Type", "application/json"),
             ("Client-Id", registry_config.client_id),
-        ]
+        ])
 
         self.http_client = httpx.Client(
             timeout=timeout, transport=transport, headers=headers

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -131,6 +131,7 @@ class RegistryConfig(FeastBaseModel):
 
     s3_additional_kwargs: Optional[Dict[str, str]]
     """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
+    clint_id: Optional[StrictStr] = "Unknown"
 
 
 class RepoConfig(FeastBaseModel):

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -131,7 +131,7 @@ class RegistryConfig(FeastBaseModel):
 
     s3_additional_kwargs: Optional[Dict[str, str]]
     """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
-    clint_id: Optional[StrictStr] = "Unknown"
+    client_id: Optional[StrictStr] = "Unknown"
 
 
 class RepoConfig(FeastBaseModel):


### PR DESCRIPTION
What this PR does / why we need it:
This PR is adding client_id to http registry request headers and accepting the client_id in config.
It helps tracking the requests to registry.
