### PR TITLE
chore: Added logging to understand the time to refresh registry cache

### DIFF
--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -13,8 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const BUFFER_SIZE = 8192 // Adjust buffer size as needed
-
 type HttpRegistryStore struct {
 	project  string
 	endpoint string

--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/rs/zerolog/log"
 )
 
 const BUFFER_SIZE = 8192 // Adjust buffer size as needed
@@ -112,6 +113,9 @@ func (r *HttpRegistryStore) loadEntities(registry *core.Registry) error {
 		if err := proto.Unmarshal(data, entity_list); err != nil {
 			return err
 		}
+		if len(entity_list.GetEntities()) == 0 {
+			log.Warn().Msg(fmt.Sprintf("Feature Registry has no associated Entities for project %s.", r.project))
+		}
 		registry.Entities = append(registry.Entities, entity_list.GetEntities()...)
 		return nil
 	})
@@ -123,6 +127,9 @@ func (r *HttpRegistryStore) loadDatasources(registry *core.Registry) error {
 		data_source_list := &core.DataSourceList{}
 		if err := proto.Unmarshal(data, data_source_list); err != nil {
 			return err
+		}
+		if len(data_source_list.GetDatasources()) == 0 {
+			log.Warn().Msg(fmt.Sprintf("Feature Registry has no associated Datasources for project %s.", r.project))
 		}
 		registry.DataSources = append(registry.DataSources, data_source_list.GetDatasources()...)
 		return nil
@@ -136,6 +143,9 @@ func (r *HttpRegistryStore) loadFeatureViews(registry *core.Registry) error {
 		if err := proto.Unmarshal(data, feature_view_list); err != nil {
 			return err
 		}
+		if len(feature_view_list.GetFeatureviews()) == 0 {
+			log.Warn().Msg(fmt.Sprintf("Feature Registry has no associated FeatureViews for project %s.", r.project))
+		}
 		registry.FeatureViews = append(registry.FeatureViews, feature_view_list.GetFeatureviews()...)
 		return nil
 	})
@@ -148,6 +158,9 @@ func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry) er
 		if err := proto.Unmarshal(data, od_feature_view_list); err != nil {
 			return err
 		}
+		if len(od_feature_view_list.GetOndemandfeatureviews()) == 0 {
+			log.Warn().Msg(fmt.Sprintf("Feature Registry has no associated Ondemandfeatureviews for project %s.", r.project))
+		}
 		registry.OnDemandFeatureViews = append(registry.OnDemandFeatureViews, od_feature_view_list.GetOndemandfeatureviews()...)
 		return nil
 	})
@@ -159,6 +172,9 @@ func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry) error {
 		feature_service_list := &core.FeatureServiceList{}
 		if err := proto.Unmarshal(data, feature_service_list); err != nil {
 			return err
+		}
+		if len(feature_service_list.GetFeatureservices()) == 0 {
+			log.Warn().Msg(fmt.Sprintf("Feature Registry has no associated FeatureServices for project %s.", r.project))
 		}
 		registry.FeatureServices = append(registry.FeatureServices, feature_service_list.GetFeatureservices()...)
 		return nil

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -221,9 +221,11 @@ class SqlRegistry(BaseRegistry):
         self.cached_registry_proto_created = datetime.utcnow()
         self._refresh_lock = Lock()
         self.cached_registry_proto_ttl = timedelta(
-            seconds=registry_config.cache_ttl_seconds
-            if registry_config.cache_ttl_seconds is not None
-            else 0
+            seconds=(
+                registry_config.cache_ttl_seconds
+                if registry_config.cache_ttl_seconds is not None
+                else 0
+            )
         )
         self.stop_thread = False
         self.refresh_cache_thread = threading.Thread(target=self._refresh_cache)
@@ -233,7 +235,10 @@ class SqlRegistry(BaseRegistry):
     def _refresh_cache(self):
         while not self.stop_thread:
             try:
+                start_time = time.time()
                 self.refresh()
+                end_time = time.time()
+                logger.info("Registry refresh took %.2f seconds", end_time - start_time)
             except Exception as e:
                 logger.error(f"Registry refresh failed with exception: {e}")
             # Sleep for cached_registry_proto_ttl - 10 seconds


### PR DESCRIPTION
**What this PR does / why we need it**:

Added logging to understand the time to refresh registry cache

**Which issue(s) this PR fixes**:
chore: Added logging to understand the time to refresh registry cache

Fixes #
chore: Added logging to understand the time to refresh registry cache