### PR TITLE
feat: Add transformations server endpoint to feature_store.yaml

### DIFF
--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -3,9 +3,6 @@ package feast
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
-	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow/memory"
 

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -56,10 +56,14 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 		return nil, err
 	}
 
-  var transformationService *transformation.GrpcTransformationService = nil
-  if config.GoTransformationsEndpoint != "" && config.GoTransformationsEndpoint != "null" {
-    transformationService, _ = transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
-  }
+	if config.GoTransformationsEndpoint == "" && config.GoTransformationsServer {
+		return nil, errors.New("transformations server endpoint is missing")
+	}
+
+	var transformationService *transformation.GrpcTransformationService = nil
+	if config.GoTransformationsEndpoint != "" {
+		transformationService, _ = transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
+	}
 
 	return &FeatureStore{
 		config:                 config,

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -57,7 +57,7 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 	}
 
   var transformationService *transformation.GrpcTransformationService = nil
-  if config.GoTransformationsEndpoint != "" {
+  if config.GoTransformationsEndpoint != "" && config.GoTransformationsEndpoint != "null" {
     transformationService, _ = transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
   }
 

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -58,10 +58,7 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 	if err != nil {
 		return nil, err
 	}
-  sanitizedProjectName := strings.Replace(config.Project, "_", "-", -1)
-  productName := os.Getenv("PRODUCT")
-  endpoint := fmt.Sprintf("%s-transformations.%s.svc.cluster.local:80", sanitizedProjectName, productName)
-  transformationService, _ := transformation.NewGrpcTransformationService(config, endpoint)
+  transformationService, _ := transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
 
 	return &FeatureStore{
 		config:                 config,

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -56,12 +56,11 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 		return nil, err
 	}
 
-	if config.GoTransformationsEndpoint == "" && config.GoTransformationsServer {
-		return nil, errors.New("transformations server endpoint is missing")
-	}
-
 	var transformationService *transformation.GrpcTransformationService = nil
-	if config.GoTransformationsEndpoint != "" {
+	if config.GoTransformationsServer {
+		if config.GoTransformationsEndpoint == "" {
+			return nil, errors.New("Transformations server endpoint is missing. Update featue_store.yaml with go_transformations_endpint configuration")
+		}
 		transformationService, _ = transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
 	}
 

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -55,7 +55,11 @@ func NewFeatureStore(config *registry.RepoConfig, callback transformation.Transf
 	if err != nil {
 		return nil, err
 	}
-  transformationService, _ := transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
+
+  var transformationService *transformation.GrpcTransformationService = nil
+  if config.GoTransformationsEndpoint != "" {
+    transformationService, _ = transformation.NewGrpcTransformationService(config, config.GoTransformationsEndpoint)
+  }
 
 	return &FeatureStore{
 		config:                 config,

--- a/go/internal/feast/registry/repoconfig.go
+++ b/go/internal/feast/registry/repoconfig.go
@@ -32,6 +32,8 @@ type RepoConfig struct {
 	RepoPath string `json:"repo_path"`
 	// EntityKeySerializationVersion
 	EntityKeySerializationVersion int64 `json:"entity_key_serialization_version"`
+  // If false, use gopy bindings to calculate ODFV transformations
+  GoTransformationsServer bool `json:"go_transformations_server"`
   // Transformation server base endpoint
   GoTransformationsEndpoint string `json:"go_transformations_endpoint"`
 }

--- a/go/internal/feast/registry/repoconfig.go
+++ b/go/internal/feast/registry/repoconfig.go
@@ -32,9 +32,10 @@ type RepoConfig struct {
 	RepoPath string `json:"repo_path"`
 	// EntityKeySerializationVersion
 	EntityKeySerializationVersion int64 `json:"entity_key_serialization_version"`
-	// If false, use gopy bindings to calculate ODFV transformations
+	// If false, use gopy bindings to calculate ODFV transformations.
+	// "True" value required for Go feature server to serve ODFVs with stability and at scale.
 	GoTransformationsServer bool `json:"go_transformations_server"`
-	// Transformation server base endpoint
+	// Transformation server base endpoint.
 	GoTransformationsEndpoint string `json:"go_transformations_endpoint"`
 }
 

--- a/go/internal/feast/registry/repoconfig.go
+++ b/go/internal/feast/registry/repoconfig.go
@@ -32,6 +32,8 @@ type RepoConfig struct {
 	RepoPath string `json:"repo_path"`
 	// EntityKeySerializationVersion
 	EntityKeySerializationVersion int64 `json:"entity_key_serialization_version"`
+  // Transformation server base endpoint
+  GoTransformationsEndpoint string `json:"go_transformations_endpoint"`
 }
 
 type RegistryConfig struct {

--- a/go/internal/feast/registry/repoconfig.go
+++ b/go/internal/feast/registry/repoconfig.go
@@ -32,10 +32,10 @@ type RepoConfig struct {
 	RepoPath string `json:"repo_path"`
 	// EntityKeySerializationVersion
 	EntityKeySerializationVersion int64 `json:"entity_key_serialization_version"`
-  // If false, use gopy bindings to calculate ODFV transformations
-  GoTransformationsServer bool `json:"go_transformations_server"`
-  // Transformation server base endpoint
-  GoTransformationsEndpoint string `json:"go_transformations_endpoint"`
+	// If false, use gopy bindings to calculate ODFV transformations
+	GoTransformationsServer bool `json:"go_transformations_server"`
+	// Transformation server base endpoint
+	GoTransformationsEndpoint string `json:"go_transformations_endpoint"`
 }
 
 type RegistryConfig struct {

--- a/go/internal/feast/registry/repoconfig_test.go
+++ b/go/internal/feast/registry/repoconfig_test.go
@@ -96,3 +96,28 @@ online_store:
 	assert.Equal(t, dir, config.RepoPath)
 	assert.Equal(t, "data/registry.db", config.GetRegistryConfig().Path)
 }
+
+func TestGoTransformationsEndpoint(t *testing.T) {
+	dir, err := os.MkdirTemp("", "feature_repo_*")
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.RemoveAll(dir))
+	}()
+	filePath := filepath.Join(dir, "feature_store.yaml")
+	data := []byte(`
+registry:
+ path: data/registry.db
+project: feature_repo
+provider: local
+online_store:
+ type: redis
+ connection_string: "localhost:6379"
+go_transformations_endpoint: https://go.dev:9999
+`)
+	err = os.WriteFile(filePath, data, 0666)
+	assert.Nil(t, err)
+	config, err := NewRepoConfigFromFile(dir)
+	assert.Nil(t, err)
+	assert.Equal(t, dir, config.RepoPath)
+  assert.Equal(t, "https://go.dev:9999", config.GoTransformationsEndpoint)
+}

--- a/go/internal/feast/registry/repoconfig_test.go
+++ b/go/internal/feast/registry/repoconfig_test.go
@@ -120,6 +120,6 @@ go_transformations_server: True
 	config, err := NewRepoConfigFromFile(dir)
 	assert.Nil(t, err)
 	assert.Equal(t, dir, config.RepoPath)
-  assert.Equal(t, "https://go.dev:9999", config.GoTransformationsEndpoint)
-  assert.Equal(t, true, config.GoTransformationsServer)
+	assert.Equal(t, "https://go.dev:9999", config.GoTransformationsEndpoint)
+	assert.Equal(t, true, config.GoTransformationsServer)
 }

--- a/go/internal/feast/registry/repoconfig_test.go
+++ b/go/internal/feast/registry/repoconfig_test.go
@@ -113,6 +113,7 @@ online_store:
  type: redis
  connection_string: "localhost:6379"
 go_transformations_endpoint: https://go.dev:9999
+go_transformations_server: True
 `)
 	err = os.WriteFile(filePath, data, 0666)
 	assert.Nil(t, err)
@@ -120,4 +121,5 @@ go_transformations_endpoint: https://go.dev:9999
 	assert.Nil(t, err)
 	assert.Equal(t, dir, config.RepoPath)
   assert.Equal(t, "https://go.dev:9999", config.GoTransformationsEndpoint)
+  assert.Equal(t, true, config.GoTransformationsServer)
 }

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -174,9 +174,6 @@ class RepoConfig(FeastBaseModel):
     go_feature_serving: Optional[bool] = False
     """ If True, use the Go feature server instead of the Python feature server. """
 
-    go_transformations_endpoint: Optional[StrictStr]
-    """ Specify the URL for the Go feature server to hit the transformations server. """
-
     go_feature_retrieval: Optional[bool] = False
     """ If True, use the embedded Go code to retrieve features instead of the Python SDK. """
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -180,7 +180,7 @@ class RepoConfig(FeastBaseModel):
     go_transformations_server: Optional[bool] = True
     """ If True, use the transformations server to perform ODVF transformations in Go feature server. """
 
-    go_transformations_endpoint: Optional[StrictStr] = ''
+    go_transformations_endpoint: Optional[StrictStr] = ""
     """ Specify the endpoint for Go feature server to find the transformations server.
     NOTE: Unless go_transformations_server is False, the Go feature server will throw errors if this is
     blank or null. """

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -174,6 +174,9 @@ class RepoConfig(FeastBaseModel):
     go_feature_serving: Optional[bool] = False
     """ If True, use the Go feature server instead of the Python feature server. """
 
+    go_transformations_endpoint: Optional[StrictStr]
+    """ Specify the URL for the Go feature server to hit the transformations server. """
+
     go_feature_retrieval: Optional[bool] = False
     """ If True, use the embedded Go code to retrieve features instead of the Python SDK. """
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -177,6 +177,14 @@ class RepoConfig(FeastBaseModel):
     go_feature_retrieval: Optional[bool] = False
     """ If True, use the embedded Go code to retrieve features instead of the Python SDK. """
 
+    go_transformations_server: Optional[bool] = True
+    """ If True, use the transformations server to perform ODVF transformations in Go feature server. """
+
+    go_transformations_endpoint: Optional[StrictStr] = ''
+    """ Specify the endpoint for Go feature server to find the transformations server.
+    NOTE: Unless go_transformations_server is False, the Go feature server will throw errors if this is
+    blank or null. """
+
     entity_key_serialization_version: StrictInt = 1
     """ Entity key serialization version: This version is used to control what serialization scheme is
     used when writing data to the online store.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the transformations server endpoint is only configurable through environment variables. This will allow users to fully specify the endpoint to be used.

*Why put this in feature_store.yaml?*
I studied the Java feature server, which includes its own transformations server. The Java feature server is a Springboot application, and therefore uses its Helm charts to specify the endpoint and port for the transformations server.
However, there is no Springboot equivalent in Go. Go developers tend to prefer a more spartan style of development and ingesting variables from the Helm charts would have to be done manually, and may not be portable depending on use cases.
However, the Go process already ingests the feature_store.yaml file, and we can easily set the value there. This requires no extra code and should be more portable for open source users.
