### PR TITLE
fix: Refreshes the registry instead of stopping the background refresh

### DIFF
--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -103,7 +103,7 @@ func (r *Registry) getRegistryProto() (*core.Registry, error) {
 	}
 	registryProto, err := r.registryStore.GetRegistryProto()
 	if err != nil {
-		return registryProto, err
+		return nil, err
 	}
 	r.load(registryProto)
 	return registryProto, nil

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -87,7 +87,6 @@ func (r *Registry) RefreshRegistryOnInterval() {
 		err := r.refresh()
 		if err != nil {
 			log.Error().Stack().Err(err).Msg("Registry refresh Failed")
-			return
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
- When error occurs, return statement stop the goroutine. So registry won't refresh. 