### PR TITLE
fix: Support for feature view deletes using Expedia provider

### DIFF
--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -1,12 +1,14 @@
 import logging
-from typing import List, Set
+from typing import List, Sequence, Set
 
 import pandas as pd
 
+from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.infra.passthrough_provider import PassthroughProvider
 from feast.repo_config import RepoConfig
 from feast.stream_feature_view import StreamFeatureView
+from feast.usage import set_usage_attribute
 
 logger = logging.getLogger(__name__)
 
@@ -58,3 +60,29 @@ class ExpediaProvider(PassthroughProvider):
             )
 
         super().ingest_df(feature_view, df.drop(drop_list, axis=1))
+
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[FeatureView],
+        tables_to_keep: Sequence[FeatureView],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        set_usage_attribute("provider", self.__class__.__name__)
+
+        if self.online_store:
+            if tables_to_delete:
+                logger.info(
+                    f"Data associated to {list(tables_to_delete)} feature views will be deleted from the online store based on ttl defined if the entities are not shared with other feature views"
+                )
+
+        if self.batch_engine:
+            self.batch_engine.update(
+                project,
+                tables_to_delete,
+                tables_to_keep,
+                entities_to_delete,
+                entities_to_keep,
+            )

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -75,7 +75,7 @@ class ExpediaProvider(PassthroughProvider):
         if self.online_store:
             if tables_to_delete:
                 logger.info(
-                    f"Data associated to {list(tables_to_delete)} feature views will be deleted from the online store based on ttl defined if the entities are not shared with other feature views"
+                    f"Data associated to {[feature_view.name for feature_view in tables_to_delete]} feature views will be deleted from the online store based on ttl defined if the entities are not shared with other feature views"
                 )
 
         if self.batch_engine:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
fix: Support for feature view deletes using Expedia provider - Default behavior is to delete data from Redis online store when the feature view is deleted. We are not supporting this behavior because GH runner doesn't have access to Redis and it's not performant way to delete data. 