### PR TITLE
fix: support INT32 type for entity keys

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -2,6 +2,7 @@ package feast
 
 import (
 	"context"
+	"github.com/feast-dev/feast/go/protos/feast/core"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -10,7 +11,7 @@ import (
 
 	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
 	"github.com/feast-dev/feast/go/internal/feast/registry"
-	"github.com/feast-dev/feast/go/protos/feast/types"
+	types "github.com/feast-dev/feast/go/protos/feast/types"
 )
 
 // Return absolute path to the test_repo registry regardless of the working directory
@@ -69,4 +70,166 @@ func TestGetOnlineFeaturesRedis(t *testing.T) {
 		ctx, featureNames, nil, entities, map[string]*types.RepeatedValue{}, true)
 	assert.Nil(t, err)
 	assert.Len(t, response, 4) // 3 Features + 1 entity = 4 columns (feature vectors) in response
+}
+
+func getRepoConfig() (config registry.RepoConfig) {
+	return registry.RepoConfig{
+		Project:  "feature_repo",
+		Registry: getRegistryPath(),
+		Provider: "local",
+		OnlineStore: map[string]interface{}{
+			"type":              "redis",
+			"connection_string": "localhost:6379",
+		},
+	}
+}
+func TestGetEntityKeyTypeMapsReturnsExpectedResult(t *testing.T) {
+
+	config := getRepoConfig()
+	fs, _ := NewFeatureStore(&config, nil)
+	entity1 := &core.Entity{
+		Spec: &core.EntitySpecV2{
+			Name:      "entity1",
+			JoinKey:   "joinKey1",
+			ValueType: types.ValueType_INT64,
+		},
+	}
+	entity2 := &core.Entity{
+		Spec: &core.EntitySpecV2{
+			Name:      "entity2",
+			JoinKey:   "joinKey2",
+			ValueType: types.ValueType_INT32,
+		},
+	}
+	cachedEntities := make(map[string]map[string]*core.Entity)
+	cachedEntities["feature_repo"] = make(map[string]*core.Entity)
+	cachedEntities["feature_repo"]["entity1"] = entity1
+	cachedEntities["feature_repo"]["entity2"] = entity2
+
+	fs.registry.CachedEntities = cachedEntities
+
+	entityKeyTypeMap, err := fs.GetEntityKeyTypeMaps()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(entityKeyTypeMap))
+	assert.Equal(t, types.ValueType_INT64, entityKeyTypeMap["joinKey1"])
+	assert.Equal(t, types.ValueType_INT32, entityKeyTypeMap["joinKey2"])
+}
+
+func TestGetEntityKeyTypeMapsReturnsErrorWhenNoEntities(t *testing.T) {
+
+	config := getRepoConfig()
+	fs, _ := NewFeatureStore(&config, nil)
+
+	cachedEntities := make(map[string]map[string]*core.Entity)
+	fs.registry.CachedEntities = cachedEntities
+
+	entityKeyTypeMap, err := fs.GetEntityKeyTypeMaps()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(entityKeyTypeMap))
+}
+func TestGetRequestSourcesWithValidFeatures(t *testing.T) {
+	config := getRepoConfig()
+	fs, _ := NewFeatureStore(&config, nil)
+	fVList := []string{"odfv1", "fv1"}
+
+	odfv := &core.OnDemandFeatureView{
+		Spec: &core.OnDemandFeatureViewSpec{
+			Name:    "odfv1",
+			Project: "feature_repo",
+			Sources: map[string]*core.OnDemandSource{
+				"odfv1": {
+					Source: &core.OnDemandSource_RequestDataSource{
+						RequestDataSource: &core.DataSource{
+							Name: "request_source_1",
+							Type: core.DataSource_REQUEST_SOURCE,
+							Options: &core.DataSource_RequestDataOptions_{
+								RequestDataOptions: &core.DataSource_RequestDataOptions{
+									DeprecatedSchema: map[string]types.ValueType_Enum{
+										"feature1": types.ValueType_INT64,
+									},
+									Schema: []*core.FeatureSpecV2{
+										{
+											Name:      "feat1",
+											ValueType: types.ValueType_INT64,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cachedOnDemandFVs := make(map[string]map[string]*core.OnDemandFeatureView)
+	cachedOnDemandFVs["feature_repo"] = make(map[string]*core.OnDemandFeatureView)
+	cachedOnDemandFVs["feature_repo"]["odfv1"] = odfv
+	fs.registry.CachedOnDemandFeatureViews = cachedOnDemandFVs
+	requestSources, err := fs.GetRequestSources(fVList)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(requestSources))
+	assert.Equal(t, types.ValueType_INT64.Enum(), requestSources["feat1"].Enum())
+}
+
+func TestGetRequestSourcesWithInvalidFeatures(t *testing.T) {
+
+	config := getRepoConfig()
+	fs, _ := NewFeatureStore(&config, nil)
+	fVList := []string{"invalidFV", "fv1"}
+
+	odfv := &core.OnDemandFeatureView{
+		Spec: &core.OnDemandFeatureViewSpec{
+			Name:    "odfv1",
+			Project: "feature_repo",
+			Sources: map[string]*core.OnDemandSource{
+				"odfv1": {
+					Source: &core.OnDemandSource_RequestDataSource{
+						RequestDataSource: &core.DataSource{
+							Name: "request_source_1",
+							Type: core.DataSource_REQUEST_SOURCE,
+							Options: &core.DataSource_RequestDataOptions_{
+								RequestDataOptions: &core.DataSource_RequestDataOptions{
+									DeprecatedSchema: map[string]types.ValueType_Enum{
+										"feature1": types.ValueType_INT64,
+									},
+									Schema: []*core.FeatureSpecV2{
+										{
+											Name:      "feature1",
+											ValueType: types.ValueType_INT64,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cachedOnDemandFVs := make(map[string]map[string]*core.OnDemandFeatureView)
+	cachedOnDemandFVs["feature_repo"] = make(map[string]*core.OnDemandFeatureView)
+	cachedOnDemandFVs["feature_repo"]["odfv1"] = odfv
+	fs.registry.CachedOnDemandFeatureViews = cachedOnDemandFVs
+
+	requestSources, err := fs.GetRequestSources(fVList)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(requestSources))
+}
+
+func TestGetRequestSourcesWithNoFeatures(t *testing.T) {
+
+	config := getRepoConfig()
+	fs, _ := NewFeatureStore(&config, nil)
+	var fvList []string
+
+	requestSources, err := fs.GetRequestSources(fvList)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(requestSources))
 }

--- a/go/internal/feast/model/entity.go
+++ b/go/internal/feast/model/entity.go
@@ -2,16 +2,19 @@ package model
 
 import (
 	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/feast-dev/feast/go/protos/feast/types"
 )
 
 type Entity struct {
-	Name    string
-	JoinKey string
+	Name      string
+	JoinKey   string
+	ValueType types.ValueType_Enum
 }
 
 func NewEntityFromProto(proto *core.Entity) *Entity {
 	return &Entity{
-		Name:    proto.Spec.Name,
-		JoinKey: proto.Spec.JoinKey,
+		Name:      proto.Spec.Name,
+		JoinKey:   proto.Spec.JoinKey,
+		ValueType: proto.Spec.ValueType,
 	}
 }

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -32,10 +32,10 @@ type Registry struct {
 	project                        string
 	registryStore                  RegistryStore
 	cachedFeatureServices          map[string]map[string]*core.FeatureService
-	cachedEntities                 map[string]map[string]*core.Entity
+	CachedEntities                 map[string]map[string]*core.Entity
 	cachedFeatureViews             map[string]map[string]*core.FeatureView
 	cachedStreamFeatureViews       map[string]map[string]*core.StreamFeatureView
-	cachedOnDemandFeatureViews     map[string]map[string]*core.OnDemandFeatureView
+	CachedOnDemandFeatureViews     map[string]map[string]*core.OnDemandFeatureView
 	cachedRegistry                 *core.Registry
 	cachedRegistryProtoLastUpdated time.Time
 	cachedRegistryProtoTtl         time.Duration
@@ -114,10 +114,10 @@ func (r *Registry) load(registry *core.Registry) {
 	defer r.mu.Unlock()
 	r.cachedRegistry = registry
 	r.cachedFeatureServices = make(map[string]map[string]*core.FeatureService)
-	r.cachedEntities = make(map[string]map[string]*core.Entity)
+	r.CachedEntities = make(map[string]map[string]*core.Entity)
 	r.cachedFeatureViews = make(map[string]map[string]*core.FeatureView)
 	r.cachedStreamFeatureViews = make(map[string]map[string]*core.StreamFeatureView)
-	r.cachedOnDemandFeatureViews = make(map[string]map[string]*core.OnDemandFeatureView)
+	r.CachedOnDemandFeatureViews = make(map[string]map[string]*core.OnDemandFeatureView)
 	r.loadEntities(registry)
 	r.loadFeatureServices(registry)
 	r.loadFeatureViews(registry)
@@ -130,10 +130,10 @@ func (r *Registry) loadEntities(registry *core.Registry) {
 	entities := registry.Entities
 	for _, entity := range entities {
 		// fmt.Println("Entity load: ", entity.Spec.Name)
-		if _, ok := r.cachedEntities[r.project]; !ok {
-			r.cachedEntities[r.project] = make(map[string]*core.Entity)
+		if _, ok := r.CachedEntities[r.project]; !ok {
+			r.CachedEntities[r.project] = make(map[string]*core.Entity)
 		}
-		r.cachedEntities[r.project][entity.Spec.Name] = entity
+		r.CachedEntities[r.project][entity.Spec.Name] = entity
 	}
 }
 
@@ -174,10 +174,10 @@ func (r *Registry) loadOnDemandFeatureViews(registry *core.Registry) {
 	onDemandFeatureViews := registry.OnDemandFeatureViews
 	for _, onDemandFeatureView := range onDemandFeatureViews {
 		// fmt.Println("onDemandFeatureView load: ", onDemandFeatureView.Spec.Name)
-		if _, ok := r.cachedOnDemandFeatureViews[r.project]; !ok {
-			r.cachedOnDemandFeatureViews[r.project] = make(map[string]*core.OnDemandFeatureView)
+		if _, ok := r.CachedOnDemandFeatureViews[r.project]; !ok {
+			r.CachedOnDemandFeatureViews[r.project] = make(map[string]*core.OnDemandFeatureView)
 		}
-		r.cachedOnDemandFeatureViews[r.project][onDemandFeatureView.Spec.Name] = onDemandFeatureView
+		r.CachedOnDemandFeatureViews[r.project][onDemandFeatureView.Spec.Name] = onDemandFeatureView
 	}
 }
 
@@ -189,7 +189,7 @@ func (r *Registry) loadOnDemandFeatureViews(registry *core.Registry) {
 func (r *Registry) ListEntities(project string) ([]*model.Entity, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if cachedEntities, ok := r.cachedEntities[project]; !ok {
+	if cachedEntities, ok := r.CachedEntities[project]; !ok {
 		return []*model.Entity{}, nil
 	} else {
 		entities := make([]*model.Entity, len(cachedEntities))
@@ -273,7 +273,7 @@ func (r *Registry) ListFeatureServices(project string) ([]*model.FeatureService,
 func (r *Registry) ListOnDemandFeatureViews(project string) ([]*model.OnDemandFeatureView, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if cachedOnDemandFeatureViews, ok := r.cachedOnDemandFeatureViews[project]; !ok {
+	if cachedOnDemandFeatureViews, ok := r.CachedOnDemandFeatureViews[project]; !ok {
 		return []*model.OnDemandFeatureView{}, nil
 	} else {
 		onDemandFeatureViews := make([]*model.OnDemandFeatureView, len(cachedOnDemandFeatureViews))
@@ -289,7 +289,7 @@ func (r *Registry) ListOnDemandFeatureViews(project string) ([]*model.OnDemandFe
 func (r *Registry) GetEntity(project, entityName string) (*model.Entity, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if cachedEntities, ok := r.cachedEntities[project]; !ok {
+	if cachedEntities, ok := r.CachedEntities[project]; !ok {
 		return nil, fmt.Errorf("no cached entities found for project %s", project)
 	} else {
 		if entity, ok := cachedEntities[entityName]; !ok {
@@ -345,7 +345,7 @@ func (r *Registry) GetFeatureService(project, featureServiceName string) (*model
 func (r *Registry) GetOnDemandFeatureView(project, onDemandFeatureViewName string) (*model.OnDemandFeatureView, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if cachedOnDemandFeatureViews, ok := r.cachedOnDemandFeatureViews[project]; !ok {
+	if cachedOnDemandFeatureViews, ok := r.CachedOnDemandFeatureViews[project]; !ok {
 		return nil, fmt.Errorf("no cached on demand feature views found for project %s", project)
 	} else {
 		if onDemandFeatureViewProto, ok := cachedOnDemandFeatureViews[onDemandFeatureViewName]; !ok {

--- a/go/internal/feast/server/http_server_test.go
+++ b/go/internal/feast/server/http_server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	prototypes "github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -37,4 +38,12 @@ func TestUnmarshalJSON(t *testing.T) {
 	u = repeatedValue{}
 	assert.Nil(t, u.UnmarshalJSON([]byte("[[true, false, true], [false, true, false]]")))
 	assert.Equal(t, [][]bool{{true, false, true}, {false, true, false}}, u.boolListVal)
+}
+
+func testTypecastToCorrectTypeWithInt32Val(t *testing.T) {
+	val := repeatedValue{}
+	val.int64Val = append(val.int64Val, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+	typecastToEntitySchemaType(&val, prototypes.ValueType_INT32)
+	assert.Equal(t, nil, val.int64Val)
+	assert.NotEqual(t, nil, val.int32Val)
 }

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -236,20 +236,17 @@ func CallTransformations(
 func EnsureRequestedDataExist(requestedOnDemandFeatureViews []*model.OnDemandFeatureView,
 	requestDataFeatures map[string]*prototypes.RepeatedValue) error {
 
-	log.Info().Msgf("requestedOnDemandFeatureViews %v", requestedOnDemandFeatureViews)
 	neededRequestData, err := getNeededRequestData(requestedOnDemandFeatureViews)
 	if err != nil {
 		return err
 	}
-	log.Info().Msgf("neededRequestData %v", neededRequestData)
 	missingFeatures := make([]string, 0)
 	for feature := range neededRequestData {
 		if _, ok := requestDataFeatures[feature]; !ok {
 			missingFeatures = append(missingFeatures, feature)
 		}
-		log.Info().Msgf("feature %s", feature)
-		log.Info().Msgf("requestDataFeature values %v", requestDataFeatures[feature])
 	}
+
 	if len(missingFeatures) > 0 {
 		return fmt.Errorf("requestDataNotFoundInEntityRowsException: %s", strings.Join(missingFeatures, ", "))
 	}

--- a/go/internal/feast/transformation/transformation.go
+++ b/go/internal/feast/transformation/transformation.go
@@ -236,17 +236,20 @@ func CallTransformations(
 func EnsureRequestedDataExist(requestedOnDemandFeatureViews []*model.OnDemandFeatureView,
 	requestDataFeatures map[string]*prototypes.RepeatedValue) error {
 
+	log.Info().Msgf("requestedOnDemandFeatureViews %v", requestedOnDemandFeatureViews)
 	neededRequestData, err := getNeededRequestData(requestedOnDemandFeatureViews)
 	if err != nil {
 		return err
 	}
+	log.Info().Msgf("neededRequestData %v", neededRequestData)
 	missingFeatures := make([]string, 0)
 	for feature := range neededRequestData {
 		if _, ok := requestDataFeatures[feature]; !ok {
 			missingFeatures = append(missingFeatures, feature)
 		}
+		log.Info().Msgf("feature %s", feature)
+		log.Info().Msgf("requestDataFeature values %v", requestDataFeatures[feature])
 	}
-
 	if len(missingFeatures) > 0 {
 		return fmt.Errorf("requestDataNotFoundInEntityRowsException: %s", strings.Join(missingFeatures, ", "))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Add support for INT32 type for entity keys. This is because there's a bug when using INT32 for entity values, where the feature server would return those values as null. This is because the JSON marshaling for these values are only supported for INT64.

Also add support for request sources to be specified in the `request_context` as well

Edit: We will need to update the Feature Definitions related documentation to be clear on the fact that we should pass entity join keys when retrieving features, not entities themselves and also use the request Context to pass their request sources.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://jira.expedia.biz/browse/EAPC-11996
