### PR TITLE
Add deadline to Java gRPC client

### DIFF
--- a/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
+++ b/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Rule;
@@ -86,7 +87,7 @@ public class FeastClientTest {
     ManagedChannel channel =
         this.grpcRule.register(
             InProcessChannelBuilder.forName(serverName).directExecutor().build());
-    this.client = new FeastClient(channel, Optional.empty());
+    this.client = new FeastClient(channel, Optional.empty(), Deadline.after(200, TimeUnit.MILLISECONDS));
   }
 
   @Test


### PR DESCRIPTION
# What this PR does / why we need it:
Added configurable deadlines for the Feast Java gRPC client. We need it because clients could otherwise [get stuck forever](https://grpc.io/docs/guides/deadlines/) waiting for the server to respond, and we should make it simpler for users of this library to implement retries and timeouts; especially when it's already supported by gRPC by default.