### PR TITLE
(feat): Sql registry search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gonuts/commander v0.1.0 // indirect
+	github.com/gonuts/flag v0.1.0 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,10 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gonuts/commander v0.1.0 h1:EcDTiVw9oAVORFjQOEOuHQqcl6OXMyTgELocTq6zJ0I=
+github.com/gonuts/commander v0.1.0/go.mod h1:qkb5mSlcWodYgo7vs8ulLnXhfinhZsZcm6+H/z1JjgY=
+github.com/gonuts/flag v0.1.0 h1:fqMv/MZ+oNGu0i9gp0/IQ/ZaPIDoAZBOBaJoV7viCWM=
+github.com/gonuts/flag v0.1.0/go.mod h1:ZTmTGtrSPejTo/SRNhCqwLTmiAgyBdCkLYhHrAoBdz4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.5+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1072,7 +1072,7 @@ class SqlRegistry(BaseRegistry):
         owning_team="",
         created_at=datetime(1, 1, 1),
         updated_at=datetime(1, 1, 1),
-    ) -> List[Union[FeatureView, ProjectMetadata]]:
+    ) -> List[Union[FeatureView, ProjectMetadataModel]]:
         """
         Search for feature views or projects based on the provided search
         parameters. Since the SQL database stores only metadata and protos, we

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1070,8 +1070,8 @@ class SqlRegistry(BaseRegistry):
         name="",
         application="",
         owning_team="",
-        created_at=datetime(1, 1, 1),
-        updated_at=datetime(1, 1, 1),
+        created_at=datetime.min,
+        updated_at=datetime.min,
     ) -> List[Union[FeatureView, ProjectMetadataModel]]:
         """
         Search for feature views or projects based on the provided search
@@ -1095,13 +1095,14 @@ class SqlRegistry(BaseRegistry):
                 fv_list = [
                     view
                     for view in fv_list
-                    if getattr(view, "created_timestamp", datetime.max) >= created_at
+                    if view.created_timestamp is not None
+                    and view.created_timestamp >= created_at
                 ]
                 fv_list = [
                     view
                     for view in fv_list
-                    if getattr(view, "last_updated_timestamp", datetime.max)
-                    >= updated_at
+                    if view.last_updated_timestamp is not None
+                    and view.last_updated_timestamp >= updated_at
                 ]
 
                 if owning_team:
@@ -1125,7 +1126,8 @@ class SqlRegistry(BaseRegistry):
         project_list = [
             project
             for project in project_list
-            if getattr(project, "last_updated_timestamp", datetime.max) >= updated_at
+            if project.last_updated_timestamp is not None
+            and project.last_updated_timestamp >= updated_at
         ]
 
         final_list: List[FeatureView | ProjectMetadataModel] = []

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1080,9 +1080,13 @@ class SqlRegistry(BaseRegistry):
         """
         fv_list = []
         with self.engine.connect() as conn:
-            stmt = select(feature_views).where(
-                name in feature_views.c.feature_view_name
-            )
+            if name:
+                stmt = select(feature_views).where(
+                    feature_views.c.feature_view_name == name
+                )
+            else:
+                stmt = select(feature_views)
+
             rows = conn.execute(stmt).all()
             print('Before if rows')
             print(rows)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -200,20 +200,12 @@ class SqlRegistryConfig(RegistryConfig):
     If registry_type is 'sql', then this is a database URL as expected by SQLAlchemy """
 
 
-def _sanitize_search_params(**kwargs):
-    search_params = {}
-    for key, value in kwargs.items():
-        if value is not None:
-            search_params[key] = value
-    return search_params
-
-
 class SqlRegistry(BaseRegistry):
     def __init__(
-            self,
-            registry_config: Optional[Union[RegistryConfig, SqlRegistryConfig]],
-            project: str = None,
-            repo_path: Optional[Path] = None,
+        self,
+        registry_config: Optional[Union[RegistryConfig, SqlRegistryConfig]],
+        project: str = None,
+        repo_path: Optional[Path] = None,
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
         # pool_recycle will recycle connections after the given number of seconds has passed
@@ -369,7 +361,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_stream_feature_views(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[StreamFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -415,7 +407,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_feature_view(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -434,7 +426,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_on_demand_feature_view(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> OnDemandFeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -453,7 +445,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_request_feature_view(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ):
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -472,7 +464,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_feature_service(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureService:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -491,7 +483,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_saved_dataset(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> SavedDataset:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -510,7 +502,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_validation_reference(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> ValidationReference:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -529,7 +521,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_validation_references(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[ValidationReference]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -583,7 +575,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_data_source(
-            self, name: str, project: str, allow_cache: bool = False
+        self, name: str, project: str, allow_cache: bool = False
     ) -> DataSource:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -602,7 +594,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_data_sources(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[DataSource]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -614,14 +606,14 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_data_source(
-            self, data_source: DataSource, project: str, commit: bool = True
+        self, data_source: DataSource, project: str, commit: bool = True
     ):
         return self._apply_object(
             data_sources, project, "data_source_name", data_source, "data_source_proto"
         )
 
     def apply_feature_view(
-            self, feature_view: BaseFeatureView, project: str, commit: bool = True
+        self, feature_view: BaseFeatureView, project: str, commit: bool = True
     ):
         fv_table = self._infer_fv_table(feature_view)
 
@@ -630,7 +622,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_feature_service(
-            self, feature_service: FeatureService, project: str, commit: bool = True
+        self, feature_service: FeatureService, project: str, commit: bool = True
     ):
         return self._apply_object(
             feature_services,
@@ -651,7 +643,7 @@ class SqlRegistry(BaseRegistry):
                 raise DataSourceObjectNotFoundException(name, project)
 
     def list_feature_services(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[FeatureService]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -667,7 +659,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_feature_views(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[FeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -679,7 +671,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_saved_datasets(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[SavedDataset]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -695,7 +687,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_request_feature_views(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[RequestFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -711,7 +703,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_on_demand_feature_views(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[OnDemandFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -727,7 +719,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_project_metadata(
-            self, project: str, allow_cache: bool = False
+        self, project: str, allow_cache: bool = False
     ) -> List[ProjectMetadata]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -746,8 +738,8 @@ class SqlRegistry(BaseRegistry):
                         project_metadata.project_uuid = row["metadata_value"]
 
                     if (
-                            row["metadata_key"]
-                            == FeastMetadataKeys.LAST_UPDATED_TIMESTAMP.value
+                        row["metadata_key"]
+                        == FeastMetadataKeys.LAST_UPDATED_TIMESTAMP.value
                     ):
                         project_metadata.last_updated_timestamp = (
                             datetime.utcfromtimestamp(int(row["metadata_value"]))
@@ -758,10 +750,10 @@ class SqlRegistry(BaseRegistry):
         return []
 
     def apply_saved_dataset(
-            self,
-            saved_dataset: SavedDataset,
-            project: str,
-            commit: bool = True,
+        self,
+        saved_dataset: SavedDataset,
+        project: str,
+        commit: bool = True,
     ):
         return self._apply_object(
             saved_datasets,
@@ -772,10 +764,10 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_validation_reference(
-            self,
-            validation_reference: ValidationReference,
-            project: str,
-            commit: bool = True,
+        self,
+        validation_reference: ValidationReference,
+        project: str,
+        commit: bool = True,
     ):
         return self._apply_object(
             validation_references,
@@ -786,12 +778,12 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_materialization(
-            self,
-            feature_view: FeatureView,
-            project: str,
-            start_date: datetime,
-            end_date: datetime,
-            commit: bool = True,
+        self,
+        feature_view: FeatureView,
+        project: str,
+        start_date: datetime,
+        end_date: datetime,
+        commit: bool = True,
     ):
         table = self._infer_fv_table(feature_view)
         python_class, proto_class = self._infer_fv_classes(feature_view)
@@ -850,10 +842,10 @@ class SqlRegistry(BaseRegistry):
         return Infra()
 
     def apply_user_metadata(
-            self,
-            project: str,
-            feature_view: BaseFeatureView,
-            metadata_bytes: Optional[bytes],
+        self,
+        project: str,
+        feature_view: BaseFeatureView,
+        metadata_bytes: Optional[bytes],
     ):
         table = self._infer_fv_table(feature_view)
 
@@ -912,7 +904,7 @@ class SqlRegistry(BaseRegistry):
         return python_class, proto_class
 
     def get_user_metadata(
-            self, project: str, feature_view: BaseFeatureView
+        self, project: str, feature_view: BaseFeatureView
     ) -> Optional[bytes]:
         table = self._infer_fv_table(feature_view)
 
@@ -968,7 +960,7 @@ class SqlRegistry(BaseRegistry):
 
         # Use a ThreadPoolExecutor to process projects concurrently
         with concurrent.futures.ThreadPoolExecutor(
-                max_workers=MAX_WORKERS
+            max_workers=MAX_WORKERS
         ) as executor:  # Adjust max_workers as needed
             executor.map(process_project, projects)
 
@@ -985,13 +977,13 @@ class SqlRegistry(BaseRegistry):
         pass
 
     def _apply_object(
-            self,
-            table: Table,
-            project: str,
-            id_field_name: str,
-            obj: Any,
-            proto_field_name: str,
-            name: Optional[str] = None,
+        self,
+        table: Table,
+        project: str,
+        id_field_name: str,
+        obj: Any,
+        proto_field_name: str,
+        name: Optional[str] = None,
     ):
         name = name or (obj.name if hasattr(obj, "name") else None)
         assert name, f"name needs to be provided for {obj}"
@@ -1026,7 +1018,7 @@ class SqlRegistry(BaseRegistry):
                 obj_proto = obj.to_proto()
 
                 if hasattr(obj_proto, "meta") and hasattr(
-                        obj_proto.meta, "created_timestamp"
+                    obj_proto.meta, "created_timestamp"
                 ):
                     obj_proto.meta.created_timestamp.FromDatetime(update_datetime)
 
@@ -1072,48 +1064,70 @@ class SqlRegistry(BaseRegistry):
         if new_project:
             self._set_last_updated_metadata(update_datetime, project)
 
-    def search(self, **kwargs) -> List[Union[FeatureView, ProjectMetadata]]:
+    def search(
+        self,
+        name="",
+        application="",
+        owning_team="",
+        created_at=datetime(1, 1, 1),
+        updated_at=datetime(1, 1, 1),
+        online=True,
+    ) -> List[Union[FeatureView, ProjectMetadata]]:
         """
-        Search for feature views or projects based on the provided search parameters.
-        Since the SQL database stores only metadata and protos, we have to pull all potentially matching objects
-        and filter in memory.
+        Search for feature views or projects based on the provided search
+        parameters. Since the SQL database stores only metadata and protos, we
+        have to pull all potentially matching objects and filter in memory.
         """
-
-        search_params = _sanitize_search_params(**kwargs)
-
-        # Set default values for created_at and updated_at
-        created_at_obj = datetime.strptime(search_params.get('created_at', '0001-01-01T00:00:00'), '%Y-%m-%dT%H:%M:%S')
-        updated_at_obj = datetime.strptime(search_params.get('updated_at', '0001-01-01T00:00:00'), '%Y-%m-%dT%H:%M:%S')
 
         with self.engine.connect() as conn:
-            stmt = select(feature_views).where(feature_views.c.feature_view_name == search_params.get('name', '*'))
+            stmt = select(feature_views).where(
+                feature_views.c.feature_view_name == name
+            )
             rows = conn.execute(stmt).all()
             if rows:
-                fv_list = [
+                fv_list: List[FeatureView] = [
                     FeatureView.from_proto(
                         FeatureViewProto.FromString(row["feature_view_proto"])
                     )
                     for row in rows
                 ]
 
-                fv_list = [view for view in fv_list if view.created_timestamp >= created_at_obj]
-                fv_list = [view for view in fv_list if view.last_updated_timestamp >= updated_at_obj]
+                fv_list = [
+                    view
+                    for view in fv_list
+                    if getattr(view, "created_timestamp", datetime(1, 1, 1))
+                    >= created_at
+                ]
+                fv_list = [
+                    view
+                    for view in fv_list
+                    if getattr(view, "last_updated_timestamp", datetime(1, 1, 1))
+                    >= updated_at
+                ]
 
-                if 'application' in search_params:
-                    fv_list = [view for view in fv_list if view.tags.get('application') == search_params.get('application')]
-                if 'owning_team' in search_params:
-                    fv_list = [view for view in fv_list if view.tags.get('team') == search_params.get('owning_team')]
-                if 'online' in search_params:
-                    fv_list = [view for view in fv_list if view.online == search_params.get('online')]
+                fv_list = [
+                    view for view in fv_list if view.tags.get("team") == owning_team
+                ]
+                fv_list = [
+                    view
+                    for view in fv_list
+                    if view.tags.get("application") == application
+                ]
+                fv_list = [view for view in fv_list if view.online == online]
 
             else:
                 fv_list = []
 
-        project_list = self.get_all_project_metadata(self)
+        project_list: List[ProjectMetadataModel] = self.get_all_project_metadata()
 
-        if 'name' in search_params:
-            project_list = [project for project in project_list if project.project_name == search_params.get('name')]
-        project_list = [project for project in project_list if project.last_updated_timestamp >= updated_at_obj]
+        project_list = [
+            project for project in project_list if project.project_name == name
+        ]
+        project_list = [
+            project
+            for project in project_list
+            if project.last_updated_timestamp >= updated_at
+        ]
 
         return project_list.extend(fv_list)
 

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1081,9 +1081,11 @@ class SqlRegistry(BaseRegistry):
         fv_list = []
         with self.engine.connect() as conn:
             stmt = select(feature_views).where(
-                feature_views.c.feature_view_name == name if name else "*"
+                name in feature_views.c.feature_view_name
             )
             rows = conn.execute(stmt).all()
+            print('Before if rows')
+            print(rows)
             if rows:
                 fv_list = [
                     FeatureView.from_proto(
@@ -1091,6 +1093,8 @@ class SqlRegistry(BaseRegistry):
                     )
                     for row in rows
                 ]
+                print('after converting from proto')
+                print(fv_list)
 
                 fv_list = [
                     view
@@ -1098,25 +1102,35 @@ class SqlRegistry(BaseRegistry):
                     if view.created_timestamp is not None
                     and view.created_timestamp >= created_at
                 ]
+                print('1')
+                print(fv_list)
                 fv_list = [
                     view
                     for view in fv_list
                     if view.last_updated_timestamp is not None
                     and view.last_updated_timestamp >= updated_at
                 ]
+                print('2')
+                print(fv_list)
 
                 if owning_team:
                     fv_list = [
                         view for view in fv_list if view.tags.get("team") == owning_team
                     ]
+                print('3')
+                print(fv_list)
                 if application:
                     fv_list = [
                         view
                         for view in fv_list
                         if view.tags.get("application") == application
                     ]
+                print('4')
+                print(fv_list)
                 if online:
                     fv_list = [view for view in fv_list if view.online == online]
+                print('5')
+                print(fv_list)
 
         project_list = self.get_all_project_metadata()
 

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -200,12 +200,20 @@ class SqlRegistryConfig(RegistryConfig):
     If registry_type is 'sql', then this is a database URL as expected by SQLAlchemy """
 
 
+def _sanitize_search_params(**kwargs):
+    search_params = {}
+    for key, value in kwargs.items():
+        if value is not None:
+            search_params[key] = value
+    return search_params
+
+
 class SqlRegistry(BaseRegistry):
     def __init__(
-        self,
-        registry_config: Optional[Union[RegistryConfig, SqlRegistryConfig]],
-        project: str = None,
-        repo_path: Optional[Path] = None,
+            self,
+            registry_config: Optional[Union[RegistryConfig, SqlRegistryConfig]],
+            project: str = None,
+            repo_path: Optional[Path] = None,
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
         # pool_recycle will recycle connections after the given number of seconds has passed
@@ -361,7 +369,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_stream_feature_views(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[StreamFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -407,7 +415,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -426,7 +434,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_on_demand_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> OnDemandFeatureView:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -445,7 +453,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_request_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ):
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -464,7 +472,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_feature_service(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureService:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -483,7 +491,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_saved_dataset(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> SavedDataset:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -502,7 +510,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_validation_reference(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> ValidationReference:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -521,7 +529,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_validation_references(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[ValidationReference]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -575,7 +583,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def get_data_source(
-        self, name: str, project: str, allow_cache: bool = False
+            self, name: str, project: str, allow_cache: bool = False
     ) -> DataSource:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -594,7 +602,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_data_sources(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[DataSource]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -606,14 +614,14 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_data_source(
-        self, data_source: DataSource, project: str, commit: bool = True
+            self, data_source: DataSource, project: str, commit: bool = True
     ):
         return self._apply_object(
             data_sources, project, "data_source_name", data_source, "data_source_proto"
         )
 
     def apply_feature_view(
-        self, feature_view: BaseFeatureView, project: str, commit: bool = True
+            self, feature_view: BaseFeatureView, project: str, commit: bool = True
     ):
         fv_table = self._infer_fv_table(feature_view)
 
@@ -622,7 +630,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_feature_service(
-        self, feature_service: FeatureService, project: str, commit: bool = True
+            self, feature_service: FeatureService, project: str, commit: bool = True
     ):
         return self._apply_object(
             feature_services,
@@ -643,7 +651,7 @@ class SqlRegistry(BaseRegistry):
                 raise DataSourceObjectNotFoundException(name, project)
 
     def list_feature_services(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[FeatureService]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -659,7 +667,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_feature_views(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[FeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -671,7 +679,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_saved_datasets(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[SavedDataset]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -687,7 +695,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_request_feature_views(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[RequestFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -703,7 +711,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_on_demand_feature_views(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[OnDemandFeatureView]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -719,7 +727,7 @@ class SqlRegistry(BaseRegistry):
         )
 
     def list_project_metadata(
-        self, project: str, allow_cache: bool = False
+            self, project: str, allow_cache: bool = False
     ) -> List[ProjectMetadata]:
         if allow_cache:
             self._check_if_registry_refreshed()
@@ -738,8 +746,8 @@ class SqlRegistry(BaseRegistry):
                         project_metadata.project_uuid = row["metadata_value"]
 
                     if (
-                        row["metadata_key"]
-                        == FeastMetadataKeys.LAST_UPDATED_TIMESTAMP.value
+                            row["metadata_key"]
+                            == FeastMetadataKeys.LAST_UPDATED_TIMESTAMP.value
                     ):
                         project_metadata.last_updated_timestamp = (
                             datetime.utcfromtimestamp(int(row["metadata_value"]))
@@ -750,10 +758,10 @@ class SqlRegistry(BaseRegistry):
         return []
 
     def apply_saved_dataset(
-        self,
-        saved_dataset: SavedDataset,
-        project: str,
-        commit: bool = True,
+            self,
+            saved_dataset: SavedDataset,
+            project: str,
+            commit: bool = True,
     ):
         return self._apply_object(
             saved_datasets,
@@ -764,10 +772,10 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_validation_reference(
-        self,
-        validation_reference: ValidationReference,
-        project: str,
-        commit: bool = True,
+            self,
+            validation_reference: ValidationReference,
+            project: str,
+            commit: bool = True,
     ):
         return self._apply_object(
             validation_references,
@@ -778,12 +786,12 @@ class SqlRegistry(BaseRegistry):
         )
 
     def apply_materialization(
-        self,
-        feature_view: FeatureView,
-        project: str,
-        start_date: datetime,
-        end_date: datetime,
-        commit: bool = True,
+            self,
+            feature_view: FeatureView,
+            project: str,
+            start_date: datetime,
+            end_date: datetime,
+            commit: bool = True,
     ):
         table = self._infer_fv_table(feature_view)
         python_class, proto_class = self._infer_fv_classes(feature_view)
@@ -842,10 +850,10 @@ class SqlRegistry(BaseRegistry):
         return Infra()
 
     def apply_user_metadata(
-        self,
-        project: str,
-        feature_view: BaseFeatureView,
-        metadata_bytes: Optional[bytes],
+            self,
+            project: str,
+            feature_view: BaseFeatureView,
+            metadata_bytes: Optional[bytes],
     ):
         table = self._infer_fv_table(feature_view)
 
@@ -904,7 +912,7 @@ class SqlRegistry(BaseRegistry):
         return python_class, proto_class
 
     def get_user_metadata(
-        self, project: str, feature_view: BaseFeatureView
+            self, project: str, feature_view: BaseFeatureView
     ) -> Optional[bytes]:
         table = self._infer_fv_table(feature_view)
 
@@ -919,6 +927,7 @@ class SqlRegistry(BaseRegistry):
 
     def proto(self) -> RegistryProto:
         r = RegistryProto()
+
         # last_updated_timestamps = []
 
         def process_project(project):
@@ -959,7 +968,7 @@ class SqlRegistry(BaseRegistry):
 
         # Use a ThreadPoolExecutor to process projects concurrently
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=MAX_WORKERS
+                max_workers=MAX_WORKERS
         ) as executor:  # Adjust max_workers as needed
             executor.map(process_project, projects)
 
@@ -976,13 +985,13 @@ class SqlRegistry(BaseRegistry):
         pass
 
     def _apply_object(
-        self,
-        table: Table,
-        project: str,
-        id_field_name: str,
-        obj: Any,
-        proto_field_name: str,
-        name: Optional[str] = None,
+            self,
+            table: Table,
+            project: str,
+            id_field_name: str,
+            obj: Any,
+            proto_field_name: str,
+            name: Optional[str] = None,
     ):
         name = name or (obj.name if hasattr(obj, "name") else None)
         assert name, f"name needs to be provided for {obj}"
@@ -1017,7 +1026,7 @@ class SqlRegistry(BaseRegistry):
                 obj_proto = obj.to_proto()
 
                 if hasattr(obj_proto, "meta") and hasattr(
-                    obj_proto.meta, "created_timestamp"
+                        obj_proto.meta, "created_timestamp"
                 ):
                     obj_proto.meta.created_timestamp.FromDatetime(update_datetime)
 
@@ -1062,6 +1071,51 @@ class SqlRegistry(BaseRegistry):
 
         if new_project:
             self._set_last_updated_metadata(update_datetime, project)
+
+    def search(self, **kwargs) -> List[Union[FeatureView, ProjectMetadata]]:
+        """
+        Search for feature views or projects based on the provided search parameters.
+        Since the SQL database stores only metadata and protos, we have to pull all potentially matching objects
+        and filter in memory.
+        """
+
+        search_params = _sanitize_search_params(**kwargs)
+
+        # Set default values for created_at and updated_at
+        created_at_obj = datetime.strptime(search_params.get('created_at', '0001-01-01T00:00:00'), '%Y-%m-%dT%H:%M:%S')
+        updated_at_obj = datetime.strptime(search_params.get('updated_at', '0001-01-01T00:00:00'), '%Y-%m-%dT%H:%M:%S')
+
+        with self.engine.connect() as conn:
+            stmt = select(feature_views).where(feature_views.c.feature_view_name == search_params.get('name', '*'))
+            rows = conn.execute(stmt).all()
+            if rows:
+                fv_list = [
+                    FeatureView.from_proto(
+                        FeatureViewProto.FromString(row["feature_view_proto"])
+                    )
+                    for row in rows
+                ]
+
+                fv_list = [view for view in fv_list if view.created_timestamp >= created_at_obj]
+                fv_list = [view for view in fv_list if view.last_updated_timestamp >= updated_at_obj]
+
+                if 'application' in search_params:
+                    fv_list = [view for view in fv_list if view.tags.get('application') == search_params.get('application')]
+                if 'owning_team' in search_params:
+                    fv_list = [view for view in fv_list if view.tags.get('team') == search_params.get('owning_team')]
+                if 'online' in search_params:
+                    fv_list = [view for view in fv_list if view.online == search_params.get('online')]
+
+            else:
+                fv_list = []
+
+        project_list = self.get_all_project_metadata(self)
+
+        if 'name' in search_params:
+            project_list = [project for project in project_list if project.project_name == search_params.get('name')]
+        project_list = [project for project in project_list if project.last_updated_timestamp >= updated_at_obj]
+
+        return project_list.extend(fv_list)
 
     def _delete_object(
         self,

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1103,16 +1103,16 @@ class SqlRegistry(BaseRegistry):
                 fv_list = [
                     view
                     for view in fv_list
-                    if view.created_timestamp is not None
-                    and view.created_timestamp >= created_at
+                    if view.created_timestamp is None
+                    or view.created_timestamp >= created_at
                 ]
                 print('1')
                 print(fv_list)
                 fv_list = [
                     view
                     for view in fv_list
-                    if view.last_updated_timestamp is not None
-                    and view.last_updated_timestamp >= updated_at
+                    if view.last_updated_timestamp is None
+                    or view.last_updated_timestamp >= updated_at
                 ]
                 print('2')
                 print(fv_list)
@@ -1144,8 +1144,8 @@ class SqlRegistry(BaseRegistry):
         project_list = [
             project
             for project in project_list
-            if project.last_updated_timestamp is not None
-            and project.last_updated_timestamp >= updated_at
+            if project.last_updated_timestamp is None
+            or project.last_updated_timestamp >= updated_at
         ]
 
         final_list: List[FeatureView | ProjectMetadataModel] = []

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -534,7 +534,7 @@ mypy-extensions==1.0.0
     #   mypy
 mypy-protobuf==3.1.0
     # via eg-feast (setup.py)
-mysqlclient==2.2.0
+mysqlclient==2.2.4
     # via eg-feast (setup.py)
 nbclient==0.8.0
     # via nbconvert

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -216,7 +216,7 @@ executing==1.2.0
     # via stack-data
 fastapi==0.95.2
     # via feast (setup.py)
-fastavro==1.7.4
+fastavro==1.8.2
     # via
     #   feast (setup.py)
     #   pandavro
@@ -529,7 +529,7 @@ mypy-extensions==1.0.0
     #   mypy
 mypy-protobuf==3.1
     # via feast (setup.py)
-mysqlclient==2.1.1
+mysqlclient==2.2.4
     # via feast (setup.py)
 nbclassic==1.0.0
     # via notebook
@@ -732,7 +732,7 @@ pyjwt[crypto]==2.7.0
     #   snowflake-connector-python
 pymilvus==2.2.14
     # via eg-feast (setup.py)
-pymssql==2.2.7
+pymssql==2.2.8
     # via feast (setup.py)
 pymysql==1.0.3
     # via feast (setup.py)
@@ -798,7 +798,7 @@ pytz==2023.3
     #   pandas
     #   snowflake-connector-python
     #   trino
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   dask
     #   feast (setup.py)


### PR DESCRIPTION
# What this PR does / why we need it:
This adds a function to the SQL registry to allow searching in accordance with the parameters set by the AI workbench team.

You will notice that we're not doing this search in a SQL query. That is because the database schemas are a proto stored as a `VARCHAR` and a little bit of metadata. As such, we have to pull all potentially relevant objects from the DB and then filter in memory. This is not ideal, but it's the only approach that will work.

