### PR TITLE
fix: Start up issues in Python Feature server with HTTP Registry

### DIFF
--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -8,7 +8,6 @@ from feast.feature_view import FeatureView
 from feast.infra.passthrough_provider import PassthroughProvider
 from feast.repo_config import RepoConfig
 from feast.stream_feature_view import StreamFeatureView
-from feast.usage import set_usage_attribute
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +69,6 @@ class ExpediaProvider(PassthroughProvider):
         entities_to_keep: Sequence[Entity],
         partial: bool,
     ):
-        set_usage_attribute("provider", self.__class__.__name__)
-
         if self.online_store:
             if tables_to_delete:
                 logger.info(

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -607,7 +607,7 @@ class HttpRegistry(BaseRegistry):
         project: str,
         allow_cache: bool = False,
     ) -> List[SavedDataset]:
-        raise NotImplementedError("Method not implemented")
+        return []
 
     def apply_validation_reference(
         self,
@@ -657,7 +657,7 @@ class HttpRegistry(BaseRegistry):
         project: str,
         allow_cache: bool = False,
     ) -> List[ValidationReference]:
-        raise NotImplementedError("Method not implemented")
+        return []
 
     def proto(self) -> RegistryProto:
         r = RegistryProto()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
- Fixes the start up issues with Python Feature Server using HTTP Registry. HTTP Registry is throwing errors for the methods used in application start up. We don't need them in our use cases so it's not implemented. Returning empty response helps to fix the problem as a temporary work around. 

- Usage module is deleted by Feast. As we brought in new merges, we deleted that usage python module specific code from Expedia provider. 