### PR TITLE
fix: Fix compatibility issues between Pydantic V1 and V2 with timedelta

### DIFF
--- a/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
@@ -9,7 +9,7 @@ import sys
 from datetime import timedelta
 from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 from pydantic import Field as PydanticField
 from typing_extensions import Annotated, Self
 
@@ -267,6 +267,27 @@ class KafkaSourceModel(DataSourceModel):
     owner: Optional[str] = ""
     batch_source: Optional[AnyBatchDataSource] = None
     watermark_delay_threshold: Optional[timedelta] = None
+
+    # To make it compatible with Pydantic V1, we need this field_serializer
+    @field_serializer("watermark_delay_threshold")
+    def serialize_ttl(self, ttl: timedelta):
+        return timedelta.total_seconds(ttl) if ttl else None
+
+    # To make it compatible with Pydantic V1, we need this field_validator
+    @field_validator("watermark_delay_threshold", mode="before")
+    @classmethod
+    def validate_ttl(cls, v: Union[int, float, str, timedelta]):
+        try:
+            if isinstance(v, timedelta):
+                return v
+            elif isinstance(v, float):
+                return timedelta(seconds=v)
+            elif isinstance(v, str):
+                return timedelta(seconds=float(v))
+            elif isinstance(v, int):
+                return timedelta(seconds=v)
+        except ValueError:
+            raise ValueError("ttl must be one of the int, float, str, timedelta types")
 
     def to_data_source(self) -> KafkaSource:
         """

--- a/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/data_source_model.py
@@ -276,7 +276,7 @@ class KafkaSourceModel(DataSourceModel):
     # To make it compatible with Pydantic V1, we need this field_validator
     @field_validator("watermark_delay_threshold", mode="before")
     @classmethod
-    def validate_ttl(cls, v: Union[int, float, str, timedelta]):
+    def validate_ttl(cls, v: Optional[Union[int, float, str, timedelta]]):
         try:
             if isinstance(v, timedelta):
                 return v
@@ -286,6 +286,8 @@ class KafkaSourceModel(DataSourceModel):
                 return timedelta(seconds=float(v))
             elif isinstance(v, int):
                 return timedelta(seconds=v)
+            else:
+                return timedelta(seconds=0)
         except ValueError:
             raise ValueError("ttl must be one of the int, float, str, timedelta types")
 

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
 import dill
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer, field_validator
 from typing_extensions import Self
 
 from feast.expediagroup.pydantic_models.data_source_model import (
@@ -77,6 +77,27 @@ class FeatureViewModel(BaseFeatureViewModel):
     created_timestamp: Optional[datetime]
     last_updated_timestamp: Optional[datetime]
 
+    # To make it compatible with Pydantic V1, we need this field_serializer
+    @field_serializer("ttl")
+    def serialize_ttl(self, ttl: timedelta):
+        return timedelta.total_seconds(ttl) if ttl else None
+
+    # To make it compatible with Pydantic V1, we need this field_validator
+    @field_validator("ttl", mode="before")
+    @classmethod
+    def validate_ttl(cls, v: Union[int, float, str, timedelta]):
+        try:
+            if isinstance(v, timedelta):
+                return v
+            elif isinstance(v, float):
+                return timedelta(seconds=v)
+            elif isinstance(v, str):
+                return timedelta(seconds=float(v))
+            elif isinstance(v, int):
+                return timedelta(seconds=v)
+        except ValueError:
+            raise ValueError("ttl must be one of the int, float, str, timedelta types")
+
     def to_feature_view(self) -> FeatureView:
         """
         Given a Pydantic FeatureViewModel, create and return a FeatureView.
@@ -109,6 +130,7 @@ class FeatureViewModel(BaseFeatureViewModel):
             ),
             entities=[entity.to_entity() for entity in self.original_entities],
             ttl=self.ttl,
+            # ttl=Duration().FromTimedelta(self.ttl),
             online=self.online,
             description=self.description,
             tags=self.tags if self.tags else None,
@@ -300,11 +322,13 @@ class OnDemandFeatureViewModel(BaseFeatureViewModel):
     source_request_sources: Dict[str, RequestSourceModel]
     udf: str = ""
     udf_string: str = ""
-    feature_transformation: Union[
-        PandasTransformationModel,
-        PythonTransformationModel,
-        SubstraitTransformationModel,
-    ]
+    feature_transformation: Optional[
+        Union[
+            PandasTransformationModel,
+            PythonTransformationModel,
+            SubstraitTransformationModel,
+        ]
+    ] = None
     mode: str = "pandas"
     description: str = ""
     tags: Optional[dict[str, str]] = None
@@ -328,17 +352,22 @@ class OnDemandFeatureViewModel(BaseFeatureViewModel):
                     feature_view_projection.to_feature_view_projection()  # type: ignore
                 )
 
-        if self.mode == "pandas":
-            feature_transformation = (
-                self.feature_transformation.to_pandas_transformation()  # type: ignore
-            )
-        elif self.mode == "python":
-            feature_transformation = (
-                self.feature_transformation.to_python_transformation()  # type: ignore
-            )
-        elif self.mode == "substrait":
-            feature_transformation = (
-                self.feature_transformation.to_substrait_transformation()  # type: ignore
+        if self.feature_transformation is not None:
+            if self.mode == "pandas":
+                feature_transformation = (
+                    self.feature_transformation.to_pandas_transformation()  # type: ignore
+                )
+            elif self.mode == "python":
+                feature_transformation = (
+                    self.feature_transformation.to_python_transformation()  # type: ignore
+                )
+            elif self.mode == "substrait":
+                feature_transformation = (
+                    self.feature_transformation.to_substrait_transformation()  # type: ignore
+                )
+        else:
+            feature_transformation = PandasTransformation(
+                udf=dill.loads(bytes.fromhex(self.udf)), udf_string=self.udf_string
             )
 
         odfv = OnDemandFeatureView(

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
@@ -85,7 +85,7 @@ class FeatureViewModel(BaseFeatureViewModel):
     # To make it compatible with Pydantic V1, we need this field_validator
     @field_validator("ttl", mode="before")
     @classmethod
-    def validate_ttl(cls, v: Union[int, float, str, timedelta]):
+    def validate_ttl(cls, v: Optional[Union[int, float, str, timedelta]]):
         try:
             if isinstance(v, timedelta):
                 return v
@@ -95,6 +95,8 @@ class FeatureViewModel(BaseFeatureViewModel):
                 return timedelta(seconds=float(v))
             elif isinstance(v, int):
                 return timedelta(seconds=v)
+            else:
+                return timedelta(seconds=0)  # Default value
         except ValueError:
             raise ValueError("ttl must be one of the int, float, str, timedelta types")
 

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
@@ -130,7 +130,6 @@ class FeatureViewModel(BaseFeatureViewModel):
             ),
             entities=[entity.to_entity() for entity in self.original_entities],
             ttl=self.ttl,
-            # ttl=Duration().FromTimedelta(self.ttl),
             online=self.online,
             description=self.description,
             tags=self.tags if self.tags else None,

--- a/sdk/python/feast/infra/registry/caching_registry.py
+++ b/sdk/python/feast/infra/registry/caching_registry.py
@@ -351,7 +351,7 @@ class CachingRegistry(BaseRegistry):
         self.registry_refresh_thread = threading.Timer(
             cache_ttl_seconds, self._start_thread_async_refresh, [cache_ttl_seconds]
         )
-        self.registry_refresh_thread.setDaemon(True)
+        self.registry_refresh_thread.daemon = True
         self.registry_refresh_thread.start()
 
     def _exit_handler(self):

--- a/sdk/python/feast/infra/registry/proto_registry_utils.py
+++ b/sdk/python/feast/infra/registry/proto_registry_utils.py
@@ -68,10 +68,13 @@ def registry_proto_cache_with_tags(func):
 
 
 def init_project_metadata(cached_registry_proto: RegistryProto, project: str):
-    new_project_uuid = f"{uuid.uuid4()}"
-    cached_registry_proto.project_metadata.append(
-        ProjectMetadata(project_name=project, project_uuid=new_project_uuid).to_proto()
-    )
+    if project is not None:
+        new_project_uuid = f"{uuid.uuid4()}"
+        cached_registry_proto.project_metadata.append(
+            ProjectMetadata(
+                project_name=project, project_uuid=new_project_uuid
+            ).to_proto()
+        )
 
 
 def get_project_metadata(

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -369,6 +369,7 @@ def test_idempotent_featureview_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
+        ttl=timedelta(days=10),
     )
     python_obj.materialization_intervals = [
         (datetime.now() - timedelta(days=10), datetime.now() - timedelta(days=9)),

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -417,7 +417,6 @@ def test_idempotent_featureview_with_streaming_source_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=kafka_source,
-        ttl=timedelta(days=0),
     )
     feature_view_model = FeatureViewModel.from_feature_view(feature_view)
     feature_view_b = feature_view_model.to_feature_view()
@@ -497,7 +496,6 @@ def test_idempotent_featureview_with_confluent_streaming_source_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=kafka_source,
-        ttl=timedelta(days=0),
     )
     feature_view_model = FeatureViewModel.from_feature_view(feature_view)
     feature_view_b = feature_view_model.to_feature_view()
@@ -527,7 +525,6 @@ def test_idempotent_featureview_with_confluent_streaming_source_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
-        ttl=timedelta(days=0),
     )
     python_obj.materialization_intervals = [
         (datetime.now() - timedelta(days=10), datetime.now() - timedelta(days=9)),
@@ -782,7 +779,6 @@ def test_idempotent_feature_service_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
-        ttl=timedelta(days=0),
     )
 
     spark_source_2 = SparkSource(

--- a/sdk/python/tests/unit/test_pydantic_models.py
+++ b/sdk/python/tests/unit/test_pydantic_models.py
@@ -447,6 +447,7 @@ def test_idempotent_featureview_with_streaming_source_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
+        ttl=timedelta(days=0),
     )
     python_obj.materialization_intervals = [
         (datetime.now() - timedelta(days=10), datetime.now() - timedelta(days=9)),
@@ -526,6 +527,7 @@ def test_idempotent_featureview_with_confluent_streaming_source_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
+        ttl=timedelta(days=0),
     )
     python_obj.materialization_intervals = [
         (datetime.now() - timedelta(days=10), datetime.now() - timedelta(days=9)),
@@ -780,6 +782,7 @@ def test_idempotent_feature_service_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source,
+        ttl=timedelta(days=0),
     )
 
     spark_source_2 = SparkSource(
@@ -797,6 +800,7 @@ def test_idempotent_feature_service_conversion():
             Field(name="feature2", dtype=Float32),
         ],
         source=spark_source_2,
+        ttl=timedelta(days=10),
     )
 
     python_obj = FeatureService(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
1. timedelta is serialized and deserialized differently in V1. Changes made to make it compatible with V1 using field_serializer and field_validator. In V1 version, time delta is serialized to number of seconds and now its serialized to [±]P[DD]DT[HH]H[MM]M[SS]S ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format for timedelta)
2. setDaemon() is deprecated so using daemon property as recommended
3. parse_obj() and json() are deprecated in Pydantic V2. Using the recommended methods. 