### PR TITLE
fix: Using typing.get_type_hints and set transformation service health status

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -5,5 +5,5 @@ To build and run the Go Feature Server locally, create a feature_store.yaml file
 
 ```bash
     go build -o feast ./go/main.go
-    ./feast --type=http --port 
+    ./feast --type=http --port=8080
 ```

--- a/go/internal/feast/registry/repoconfig_test.go
+++ b/go/internal/feast/registry/repoconfig_test.go
@@ -44,6 +44,40 @@ online_store:
 	assert.Empty(t, config.Flags)
 }
 
+func TestNewRepoConfigWithEnvironmentVariables(t *testing.T) {
+	dir, err := os.MkdirTemp("", "feature_repo_*")
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.RemoveAll(dir))
+	}()
+	filePath := filepath.Join(dir, "feature_store.yaml")
+	data := []byte(`
+project: feature_repo
+registry: "data/registry.db"
+provider: local
+online_store:
+ type: redis
+ connection_string: ${REDIS_CONNECTION_STRING}
+`)
+	err = os.WriteFile(filePath, data, 0666)
+	assert.Nil(t, err)
+	os.Setenv("REDIS_CONNECTION_STRING", "localhost:6380")
+	config, err := NewRepoConfigFromFile(dir)
+	registryConfig, err := config.GetRegistryConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "feature_repo", config.Project)
+	assert.Equal(t, dir, config.RepoPath)
+	assert.Equal(t, "data/registry.db", registryConfig.Path)
+	assert.Equal(t, "local", config.Provider)
+	assert.Equal(t, map[string]interface{}{
+		"type":              "redis",
+		"connection_string": "localhost:6380",
+	}, config.OnlineStore)
+	assert.Empty(t, config.OfflineStore)
+	assert.Empty(t, config.FeatureServer)
+	assert.Empty(t, config.Flags)
+}
+
 func TestNewRepoConfigRegistryMap(t *testing.T) {
 	dir, err := os.MkdirTemp("", "feature_repo_*")
 	assert.Nil(t, err)

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -3,7 +3,7 @@ import functools
 import inspect
 import warnings
 from types import FunctionType
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, get_type_hints
 
 import dill
 import pandas as pd
@@ -227,15 +227,19 @@ class OnDemandFeatureView(BaseFeatureView):
             )
 
         feature_transformation = FeatureTransformationProto(
-            user_defined_function=self.feature_transformation.to_proto()
-            if isinstance(
-                self.feature_transformation,
-                (PandasTransformation, PythonTransformation),
-            )
-            else None,
-            substrait_transformation=self.feature_transformation.to_proto()
-            if isinstance(self.feature_transformation, SubstraitTransformation)
-            else None,
+            user_defined_function=(
+                self.feature_transformation.to_proto()
+                if isinstance(
+                    self.feature_transformation,
+                    (PandasTransformation, PythonTransformation),
+                )
+                else None
+            ),
+            substrait_transformation=(
+                self.feature_transformation.to_proto()
+                if isinstance(self.feature_transformation, SubstraitTransformation)
+                else None
+            ),
         )
         spec = OnDemandFeatureViewSpec(
             name=self.name,
@@ -631,7 +635,15 @@ def on_demand_feature_view(
             obj.__module__ = "__main__"
 
     def decorator(user_function):
-        return_annotation = inspect.signature(user_function).return_annotation
+        # get_type_hints will resolve the forward references based on the
+        # current global and local namespace, giving you the actual type
+        # objects instead of strings.
+
+        # signature function to get the return annotation, can sometimes
+        # return it as a string if the annotation itself was defined using
+        # forward references
+
+        return_annotation = get_type_hints(user_function).get("return", inspect._empty)
         udf_string = dill.source.getsource(user_function)
         mainify(user_function)
         if mode == "pandas":

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -5,8 +7,14 @@ from textwrap import dedent
 from typing import Optional
 
 import assertpy
+from tests.utils.cli_repo_creator import CliRunner
 
-from feast.repo_operations import get_ignore_files, get_repo_files, read_feastignore
+from feast.repo_operations import (
+    get_ignore_files,
+    get_repo_files,
+    parse_repo,
+    read_feastignore,
+)
 
 
 @contextmanager
@@ -140,3 +148,49 @@ def test_feastignore_with_stars2():
                 (repo_root / "foo1/c.py").resolve(),
             ]
         )
+
+
+def test_parse_repo():
+    "Test to ensure that the repo is parsed correctly"
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as temp_dir:
+        # Make sure the path is absolute by resolving any symlinks
+        temp_path = Path(temp_dir).resolve()
+        result = runner.run(["init", "my_project"], cwd=temp_path)
+        repo_path = Path(temp_path / "my_project" / "feature_repo")
+        assert result.returncode == 0
+
+        repo_contents = parse_repo(repo_path)
+
+        assert len(repo_contents.data_sources) == 3
+        assert len(repo_contents.feature_views) == 2
+        assert len(repo_contents.on_demand_feature_views) == 2
+        assert len(repo_contents.stream_feature_views) == 0
+        assert len(repo_contents.entities) == 2
+        assert len(repo_contents.feature_services) == 3
+
+
+def test_parse_repo_with_future_annotations():
+    "Test to ensure that the repo is parsed correctly"
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as temp_dir:
+        # Make sure the path is absolute by resolving any symlinks
+        temp_path = Path(temp_dir).resolve()
+        result = runner.run(["init", "my_project"], cwd=temp_path)
+        repo_path = Path(temp_path / "my_project" / "feature_repo")
+        assert result.returncode == 0
+
+        with open(repo_path / "example_repo.py", "r") as f:
+            existing_content = f.read()
+
+        with open(repo_path / "example_repo.py", "w") as f:
+            f.write("from __future__ import annotations" + "\n" + existing_content)
+
+        repo_contents = parse_repo(repo_path)
+
+        assert len(repo_contents.data_sources) == 3
+        assert len(repo_contents.feature_views) == 2
+        assert len(repo_contents.on_demand_feature_views) == 2
+        assert len(repo_contents.stream_feature_views) == 0
+        assert len(repo_contents.entities) == 2
+        assert len(repo_contents.feature_services) == 3

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 from typing import Optional
 
 import assertpy
-from tests.utils.cli_repo_creator import CliRunner
 
 from feast.repo_operations import (
     get_ignore_files,
@@ -15,6 +14,7 @@ from feast.repo_operations import (
     parse_repo,
     read_feastignore,
 )
+from tests.utils.cli_repo_creator import CliRunner
 
 
 @contextmanager
@@ -171,7 +171,7 @@ def test_parse_repo():
 
 
 def test_parse_repo_with_future_annotations():
-    "Test to ensure that the repo is parsed correctly"
+    "Test to ensure that the repo is parsed correctly when using future annotations"
     runner = CliRunner()
     with tempfile.TemporaryDirectory(dir=os.getcwd()) as temp_dir:
         # Make sure the path is absolute by resolving any symlinks

--- a/setup.py
+++ b/setup.py
@@ -11,23 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import glob
-import json
 import os
 import pathlib
 import re
 import shutil
 import subprocess
 import sys
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from subprocess import CalledProcessError
 
-from setuptools import Command, Extension, find_packages, setup
+from setuptools import Command, find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
-from setuptools.command.install import install
 
 NAME = "eg-feast"
 DESCRIPTION = "EG-specific Python SDK for Feast"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
1. Updated go ReadMe file
2. Added a test case in Go code to verify Environment variables are substituted when converting feature_store.yaml to RepoConfig
3. Using typing.get_type_hints instead of inspect.signature method to resolve forward references. inspect.signature returning string when return annotation is defined as forward reference. By importing `from __future__ import annotations` in feature definitions file, we can defer annotation which will return as string with inspect.signature.  
4.  Setting health service status for transformation service