### PR TITLE
fix: Add support for tags in HttpRegistry list methods when allow_cache is true

### DIFF
--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -212,7 +212,7 @@ class HttpRegistry(BaseRegistry):
         if allow_cache:
             self._check_if_registry_refreshed()
             return proto_registry_utils.list_entities(
-                self.cached_registry_proto, project
+                self.cached_registry_proto, project, tags
             )
         try:
             url = f"{self.base_url}/projects/{project}/entities"
@@ -317,7 +317,7 @@ class HttpRegistry(BaseRegistry):
         if allow_cache:
             self._check_if_registry_refreshed()
             return proto_registry_utils.list_data_sources(
-                self.cached_registry_proto, project
+                self.cached_registry_proto, project, tags
             )
         try:
             url = f"{self.base_url}/projects/{project}/data_sources"
@@ -421,7 +421,7 @@ class HttpRegistry(BaseRegistry):
         if allow_cache:
             self._check_if_registry_refreshed()
             return proto_registry_utils.list_feature_services(
-                self.cached_registry_proto, project
+                self.cached_registry_proto, project, tags
             )
         try:
             url = f"{self.base_url}/projects/{project}/feature_services"
@@ -509,7 +509,7 @@ class HttpRegistry(BaseRegistry):
         if allow_cache:
             self._check_if_registry_refreshed()
             return proto_registry_utils.list_feature_views(
-                self.cached_registry_proto, project
+                self.cached_registry_proto, project, tags
             )
         try:
             url = f"{self.base_url}/projects/{project}/feature_views"
@@ -553,7 +553,7 @@ class HttpRegistry(BaseRegistry):
         if allow_cache:
             self._check_if_registry_refreshed()
             return proto_registry_utils.list_on_demand_feature_views(
-                self.cached_registry_proto, project
+                self.cached_registry_proto, project, tags
             )
         try:
             url = f"{self.base_url}/projects/{project}/on_demand_feature_views"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
1. tags argument need to be passed to Proto_registry_utils class to get the list of items from cache object