### PR TITLE
build: Explicit protobuf build version; consistent build/setup deps

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -97,7 +97,6 @@ jobs:
         # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
         run: |
           pip install -U pip setuptools wheel twine
-          make install-protoc-dependencies
           make build-ui
           git status
           git restore go.mod go.sum

--- a/Makefile
+++ b/Makefile
@@ -395,10 +395,10 @@ install-go-ci-dependencies:
 	go install github.com/go-python/gopy
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
-install-protoc-dependencies:
-	pip install --ignore-installed "protobuf>=4.24.0,<5" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1.0
+# install-protoc-dependencies:
+# 	pip install --ignore-installed "protobuf>=4.24.0,<5" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1.0
 
-compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
+compile-protos-go: install-go-proto-dependencies
 	python setup.py build_go_protos
 
 install-feast-ci-locally:

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,6 @@ install-go-ci-dependencies:
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
 compile-protos-go: install-go-proto-dependencies
-	pip install --ignore-installed "protobuf==4.25.4" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
 	python setup.py build_go_protos
 
 install-feast-ci-locally:

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ install-go-ci-dependencies:
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
 install-protoc-dependencies:
-	pip install --ignore-installed "protobuf==4.24.0" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
+	pip install --ignore-installed "protobuf==4.25.4" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
 
 compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
 	python setup.py build_go_protos

--- a/Makefile
+++ b/Makefile
@@ -395,10 +395,10 @@ install-go-ci-dependencies:
 	go install github.com/go-python/gopy
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
-# install-protoc-dependencies:
-# 	pip install --ignore-installed "protobuf>=4.24.0,<5" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1.0
+install-protoc-dependencies:
+	pip install --ignore-installed "protobuf==4.24.0" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
 
-compile-protos-go: install-go-proto-dependencies
+compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
 	python setup.py build_go_protos
 
 install-feast-ci-locally:

--- a/Makefile
+++ b/Makefile
@@ -395,10 +395,8 @@ install-go-ci-dependencies:
 	go install github.com/go-python/gopy
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
-install-protoc-dependencies:
+compile-protos-go: install-go-proto-dependencies
 	pip install --ignore-installed "protobuf==4.25.4" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
-
-compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
 	python setup.py build_go_protos
 
 install-feast-ci-locally:

--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,7 @@ install-go-ci-dependencies:
 	python -m pip install "pybindgen==0.22.1" "protobuf>=4.24.0,<5"
 
 compile-protos-go: install-go-proto-dependencies
+	pip install --ignore-installed "protobuf==4.25.4" "grpcio-tools>=1.56.2,<2" mypy-protobuf==3.1
 	python setup.py build_go_protos
 
 install-feast-ci-locally:

--- a/environment-setup.md
+++ b/environment-setup.md
@@ -13,7 +13,6 @@ pip install cryptography -U
 conda install protobuf
 conda install pymssql
 pip install -e ".[dev]"
-make install-protoc-dependencies PYTHON=3.9
 make install-python-ci-dependencies PYTHON=3.9
 ```
 4. start the docker daemon

--- a/protos/feast/registry/RegistryServer.proto
+++ b/protos/feast/registry/RegistryServer.proto
@@ -67,7 +67,6 @@ service RegistryServer{
   rpc Commit (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Refresh (RefreshRequest) returns (google.protobuf.Empty) {}
   rpc Proto (google.protobuf.Empty) returns (feast.core.Registry) {}
-
 }
 
 message RefreshRequest {

--- a/protos/feast/registry/RegistryServer.proto
+++ b/protos/feast/registry/RegistryServer.proto
@@ -67,6 +67,7 @@ service RegistryServer{
   rpc Commit (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Refresh (RefreshRequest) returns (google.protobuf.Empty) {}
   rpc Proto (google.protobuf.Empty) returns (feast.core.Registry) {}
+  
 }
 
 message RefreshRequest {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,15 @@
 [build-system]
-requires = ["setuptools>=60", "wheel", "setuptools_scm>=6.2", "grpcio", "grpcio-tools>=1.47.0", "mypy-protobuf==3.1", "sphinx!=4.0.0"]
+requires = [
+  "grpcio-tools>=1.56.2,<2",
+  "grpcio>=1.56.2,<2",
+  "mypy-protobuf==3.1",
+  "protobuf==4.24.0",
+  "pybindgen==0.22.0",
+  "setuptools>=60",
+  "setuptools_scm>=6.2",
+  "sphinx!=4.0.0",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "grpcio-tools>=1.56.2,<2",
   "grpcio>=1.56.2,<2",
   "mypy-protobuf==3.1",
-  "protobuf==4.24.0",
+  "protobuf==4.25.4",
   "pybindgen==0.22.0",
   "setuptools>=60",
   "setuptools_scm>=6.2",

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,7 @@ setup(
         "grpcio-tools>=1.56.2,<2",
         "grpcio>=1.56.2,<2",
         "mypy-protobuf==3.1",
-        "protobuf==4.24.0",
+        "protobuf==4.25.4",
         "pybindgen==0.22.0",
         "setuptools_scm>=6.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -498,11 +498,12 @@ setup(
     entry_points={"console_scripts": ["feast=feast.cli:cli"]},
     use_scm_version=use_scm_version,
     setup_requires=[
-        "setuptools_scm",
-        "grpcio>=1.56.2,<2",
         "grpcio-tools>=1.56.2,<2",
-        "mypy-protobuf>=3.1",
+        "grpcio>=1.56.2,<2",
+        "mypy-protobuf==3.1",
+        "protobuf==4.24.0",
         "pybindgen==0.22.0",
+        "setuptools_scm>=6.2",
     ],
     cmdclass={
         "build_python_protos": BuildPythonProtosCommand,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

Runtime issues were being thrown in projects depending on Feast because of incompatible protobuf and grpcio-tools versions and how they were installed.

This PR forces compatibility between the two by adding them to the setup dependencies, and pins the protobuf version to 4.25.4, which is required by our Go unit tests.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

No Jira ticket but follows: https://github.com/feast-dev/feast/pull/4472

# Fixes
