### PR TITLE
fix: Adding min required protobuf version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install-python-ci-dependencies-uv-venv:
 	python setup.py build_python_protos --inplace
 
 install-protoc-dependencies:
-	pip install "protobuf<5" "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
+	pip install "protobuf>=4.24.0,<5.0.0" "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
 
 lock-python-ci-dependencies:
 	uv pip compile --system --no-strip-extras setup.py --extra ci --output-file sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "protobuf<5",
+  "protobuf>=4.24.0,<5.0.0",
   "grpcio-tools>=1.56.2,<2",
   "mypy-protobuf>=3.1",
   "pybindgen==0.22.0",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ REQUIRED = [
     "click>=7.0.0,<9.0.0",
     "colorama>=0.3.9,<1",
     "dill~=0.3.0",
-    "protobuf<5",
+    "protobuf>=4.24.0,<5.0.0",
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",
@@ -170,7 +170,7 @@ CI_REQUIRED = (
         "virtualenv==20.23.0",
         "cryptography>=35.0,<43",
         "ruff>=0.3.3",
-        "protobuf<5",
+        "protobuf>=4.24.0,<5.0.0",
         "mypy-protobuf>=3.1",
         "grpcio-tools>=1.56.2,<2",
         "grpcio-testing>=1.56.2,<2",
@@ -505,7 +505,7 @@ setup(
     setup_requires=[
         # snowflake udf packages refer to conda packages, not pypi libraries. Conda stack is still on protobuf 4
         # So we are adding protobuf<5 as a requirement
-        "protobuf<5",
+        "protobuf>=4.24.0,<5.0.0",
         "grpcio-tools>=1.56.2,<2",
         "mypy-protobuf>=3.1",
         "pybindgen==0.22.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Databricks images coming with protobuf 3.19.4. It meets the protobuf<5.0.0 requirements. so it's not overwriting the dependency. This will fix the issue. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
