### PR TITLE
feat: Lazy Infra Creation with online_store Option Set to True

### DIFF
--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -71,7 +71,9 @@ class ExpediaProvider(PassthroughProvider):
         materialization_update: bool = False,
     ):
         if self.online_store:
-            if materialization_update or not getattr(self.repo_config.online_store, "lazy_table_creation", False):
+            if materialization_update or not getattr(
+                self.repo_config.online_store, "lazy_table_creation", False
+            ):
                 self.online_store.update(
                     config=self.repo_config,
                     tables_to_delete=tables_to_delete,

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -68,24 +68,8 @@ class ExpediaProvider(PassthroughProvider):
         entities_to_delete: Sequence[Entity],
         entities_to_keep: Sequence[Entity],
         partial: bool,
-        materialization_update: bool = False,
     ):
-        scylla_no_lazy_table_creation = (
-            self.repo_config.online_store.type == "scylladb"
-            and not getattr(self.repo_config.online_store, "lazy_table_creation", False)
-        )
-
         if self.online_store:
-            if materialization_update or scylla_no_lazy_table_creation:
-                self.online_store.update(
-                    config=self.repo_config,
-                    tables_to_delete=tables_to_delete,
-                    tables_to_keep=tables_to_keep,
-                    entities_to_keep=entities_to_keep,
-                    entities_to_delete=entities_to_delete,
-                    partial=partial,
-                )
-
             if tables_to_delete:
                 logger.info(
                     f"Data associated to {[feature_view.name for feature_view in tables_to_delete]} feature views will be deleted from the online store based on ttl defined if the entities are not shared with other feature views"

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -68,8 +68,10 @@ class ExpediaProvider(PassthroughProvider):
         entities_to_delete: Sequence[Entity],
         entities_to_keep: Sequence[Entity],
         partial: bool,
-        materialization_update: bool = False,
+        **kwargs
     ):
+        materialization_update = kwargs.get("materialization_update", False)
+
         if self.online_store:
             if self.online_store.type == "scylladb" and materialization_update:
                 self.online_store.update(

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -70,8 +70,9 @@ class ExpediaProvider(PassthroughProvider):
         partial: bool,
         materialization_update: bool = False,
     ):
-        scylla_no_lazy_table_creation = self.repo_config.online_store.type == "scylladb" and not getattr(
-            self.repo_config.online_store, "lazy_table_creation", False
+        scylla_no_lazy_table_creation = (
+            self.repo_config.online_store.type == "scylladb"
+            and not getattr(self.repo_config.online_store, "lazy_table_creation", False)
         )
 
         if self.online_store:

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -68,8 +68,19 @@ class ExpediaProvider(PassthroughProvider):
         entities_to_delete: Sequence[Entity],
         entities_to_keep: Sequence[Entity],
         partial: bool,
+        materialization_update: bool = False,
     ):
         if self.online_store:
+            if self.online_store.type == "scylladb" and materialization_update:
+                self.online_store.update(
+                    config=self.repo_config,
+                    tables_to_delete=tables_to_delete,
+                    tables_to_keep=tables_to_keep,
+                    entities_to_keep=entities_to_keep,
+                    entities_to_delete=entities_to_delete,
+                    partial=partial,
+                )
+
             if tables_to_delete:
                 logger.info(
                     f"Data associated to {[feature_view.name for feature_view in tables_to_delete]} feature views will be deleted from the online store based on ttl defined if the entities are not shared with other feature views"

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -71,7 +71,7 @@ class ExpediaProvider(PassthroughProvider):
         materialization_update: bool = False,
     ):
         if self.online_store:
-            if self.online_store.type == "scylladb" and materialization_update:
+            if materialization_update or not getattr(self.repo_config.online_store, "lazy_table_creation", False):
                 self.online_store.update(
                     config=self.repo_config,
                     tables_to_delete=tables_to_delete,

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -68,10 +68,8 @@ class ExpediaProvider(PassthroughProvider):
         entities_to_delete: Sequence[Entity],
         entities_to_keep: Sequence[Entity],
         partial: bool,
-        **kwargs
+        materialization_update: bool = False,
     ):
-        materialization_update = kwargs.get("materialization_update", False)
-
         if self.online_store:
             if self.online_store.type == "scylladb" and materialization_update:
                 self.online_store.update(

--- a/sdk/python/feast/expediagroup/provider/expedia.py
+++ b/sdk/python/feast/expediagroup/provider/expedia.py
@@ -70,10 +70,12 @@ class ExpediaProvider(PassthroughProvider):
         partial: bool,
         materialization_update: bool = False,
     ):
+        scylla_no_lazy_table_creation = self.repo_config.online_store.type == "scylladb" and not getattr(
+            self.repo_config.online_store, "lazy_table_creation", False
+        )
+
         if self.online_store:
-            if materialization_update or not getattr(
-                self.repo_config.online_store, "lazy_table_creation", False
-            ):
+            if materialization_update or scylla_no_lazy_table_creation:
                 self.online_store.update(
                     config=self.repo_config,
                     tables_to_delete=tables_to_delete,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -991,14 +991,15 @@ class FeatureStore:
         )
         tables_to_keep: List[FeatureView] = views_to_update + sfvs_to_update  # type: ignore
 
-        self._get_provider().update_infra(
-            project=self.project,
-            tables_to_delete=tables_to_delete,
-            tables_to_keep=tables_to_keep,
-            entities_to_delete=entities_to_delete if not partial else [],
-            entities_to_keep=entities_to_update,
-            partial=partial,
-        )
+        if not getattr(self.config.online_store, "lazy_table_creation", False):
+            self._get_provider().update_infra(
+                project=self.project,
+                tables_to_delete=tables_to_delete,
+                tables_to_keep=tables_to_keep,
+                entities_to_delete=entities_to_delete if not partial else [],
+                entities_to_keep=entities_to_update,
+                partial=partial,
+            )
 
         self._registry.commit()
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1256,7 +1256,10 @@ class FeatureStore:
             feature_views
         )
 
-        if getattr(self.config.online_store, "lazy_table_creation", False) and self.config.provider == "expedia":
+        if (
+            getattr(self.config.online_store, "lazy_table_creation", False)
+            and self.config.provider == "expedia"
+        ):
             # feature_views_to_delete = self._get_feature_views_to_delete()
             # don't delete any tables for now
 
@@ -1267,7 +1270,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
-                materialization_update=True, # type: ignore
+                materialization_update=True,  # type: ignore
             )
 
         _print_materialization_log(
@@ -1366,7 +1369,10 @@ class FeatureStore:
             feature_views
         )
 
-        if getattr(self.config.online_store, "lazy_table_creation", False) and self.config.provider == "expedia":
+        if (
+            getattr(self.config.online_store, "lazy_table_creation", False)
+            and self.config.provider == "expedia"
+        ):
             # feature_views_to_delete = self._get_feature_views_to_delete()
             # don't delete any tables for now
 
@@ -1377,7 +1383,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
-                materialization_update=True, # type: ignore
+                materialization_update=True,  # type: ignore
             )
 
         _print_materialization_log(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1267,7 +1267,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
-                materialization_update=True,
+                materialization_update=True, # type: ignore
             )
 
         _print_materialization_log(
@@ -1377,7 +1377,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
-                materialization_update=True,
+                materialization_update=True, # type: ignore
             )
 
         _print_materialization_log(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1257,23 +1257,6 @@ class FeatureStore:
             feature_views
         )
 
-        if (
-            getattr(self.config.online_store, "lazy_table_creation", False)
-            and self.config.provider == "expedia"
-        ):
-            # feature_views_to_delete = self._get_feature_views_to_delete()
-            # don't delete any tables for now
-
-            self._get_provider().update_infra(
-                project=self.project,
-                tables_to_delete=[],
-                tables_to_keep=feature_views_to_materialize,
-                entities_to_delete=[],
-                entities_to_keep=[],
-                partial=True,
-                materialization_update=True,  # type: ignore
-            )
-
         _print_materialization_log(
             None,
             end_date,
@@ -1369,23 +1352,6 @@ class FeatureStore:
         feature_views_to_materialize = self._get_feature_views_to_materialize(
             feature_views
         )
-
-        if (
-            getattr(self.config.online_store, "lazy_table_creation", False)
-            and self.config.provider == "expedia"
-        ):
-            # feature_views_to_delete = self._get_feature_views_to_delete()
-            # don't delete any tables for now
-
-            self._get_provider().update_infra(
-                project=self.project,
-                tables_to_delete=[],
-                tables_to_keep=feature_views_to_materialize,
-                entities_to_delete=[],
-                entities_to_keep=[],
-                partial=True,
-                materialization_update=True,  # type: ignore
-            )
 
         _print_materialization_log(
             start_date,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1255,6 +1255,20 @@ class FeatureStore:
         feature_views_to_materialize = self._get_feature_views_to_materialize(
             feature_views
         )
+
+        if getattr(self.config.online_store, "lazy_table_creation", False):
+            # feature_views_to_delete = self._get_feature_views_to_delete()
+            # don't delete any tables for now
+
+            self._get_provider().update_infra(
+                project=self.project,
+                tables_to_delete=[],
+                tables_to_keep=feature_views_to_materialize,
+                entities_to_delete=[],
+                entities_to_keep=[],
+                partial=True,
+            )
+
         _print_materialization_log(
             None,
             end_date,
@@ -1350,6 +1364,20 @@ class FeatureStore:
         feature_views_to_materialize = self._get_feature_views_to_materialize(
             feature_views
         )
+
+        if getattr(self.config.online_store, "lazy_table_creation", False):
+            # feature_views_to_delete = self._get_feature_views_to_delete()
+            # don't delete any tables for now
+
+            self._get_provider().update_infra(
+                project=self.project,
+                tables_to_delete=[],
+                tables_to_keep=feature_views_to_materialize,
+                entities_to_delete=[],
+                entities_to_keep=[],
+                partial=True,
+            )
+
         _print_materialization_log(
             start_date,
             end_date,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1256,7 +1256,7 @@ class FeatureStore:
             feature_views
         )
 
-        if getattr(self.config.online_store, "lazy_table_creation", False):
+        if getattr(self.config.online_store, "lazy_table_creation", False) and self.config.provider == "expedia":
             # feature_views_to_delete = self._get_feature_views_to_delete()
             # don't delete any tables for now
 
@@ -1267,6 +1267,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
+                materialization_update=True,
             )
 
         _print_materialization_log(
@@ -1365,7 +1366,7 @@ class FeatureStore:
             feature_views
         )
 
-        if getattr(self.config.online_store, "lazy_table_creation", False):
+        if getattr(self.config.online_store, "lazy_table_creation", False) and self.config.provider == "expedia":
             # feature_views_to_delete = self._get_feature_views_to_delete()
             # don't delete any tables for now
 
@@ -1376,6 +1377,7 @@ class FeatureStore:
                 entities_to_delete=[],
                 entities_to_keep=[],
                 partial=True,
+                materialization_update=True,
             )
 
         _print_materialization_log(

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -467,13 +467,6 @@ class CassandraOnlineStore(OnlineStore):
         """
         project = config.project
 
-        if getattr(config.online_store, "lazy_table_creation", False):
-            logger.info(
-                f"Lazy table creation enabled. Skipping table creation for {project} online store."
-            )
-            # create tables during materialization
-            return
-
         for table in tables_to_keep:
             self._create_table(config, project, table)
         for table in tables_to_delete:

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -88,7 +88,7 @@ CREATE_TABLE_CQL_TEMPLATE = """
         event_ts        TIMESTAMP,
         created_ts      TIMESTAMP,
         PRIMARY KEY ((entity_key), feature_name)
-    ) WITH CLUSTERING ORDER BY (feature_name ASC);
+    ) WITH CLUSTERING ORDER BY (feature_name ASC) {optional_ttl_clause};
 """
 
 DROP_TABLE_CQL_TEMPLATE = "DROP TABLE IF EXISTS {fqtable};"
@@ -152,6 +152,12 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
 
     request_timeout: Optional[StrictFloat] = None
     """Request timeout in seconds."""
+
+    ttl: Optional[StrictInt] = None
+    '''Time to live option'''
+
+    lazy_table_creation: Optional[bool] = False
+    """If True, tables will be created on during materialization, rather than registration."""
 
     class CassandraLoadBalancingPolicy(FeastConfigBaseModel):
         """
@@ -225,14 +231,21 @@ class CassandraOnlineStore(OnlineStore):
             return self._session
         if not self._session:
             # configuration consistency checks
-            hosts = online_store_config.hosts
             secure_bundle_path = online_store_config.secure_bundle_path
-            port = online_store_config.port or 9042
+            port = 19042 if online_store_config.type == "scylladb" else (
+                online_store_config.port or 9042)
             keyspace = online_store_config.keyspace
             username = online_store_config.username
             password = online_store_config.password
             protocol_version = online_store_config.protocol_version
+            if online_store_config.type == "scylladb":
+                # Using the shard aware functionality
+                if online_store_config.load_balancing is None:
+                    online_store_config.load_balancing = "TokenAwarePolicy(DCAwareRoundRobinPolicy)"
+                if online_store_config.protocol_version is None:
+                    protocol_version = 4
 
+            hosts = online_store_config.hosts
             db_directions = hosts or secure_bundle_path
             if not db_directions or not keyspace:
                 raise CassandraInvalidConfig(E_CASSANDRA_NOT_CONFIGURED)
@@ -450,6 +463,10 @@ class CassandraOnlineStore(OnlineStore):
         """
         project = config.project
 
+        if config.online_config.lazy_table_creation:
+            # create tables during materialization
+            return
+
         for table in tables_to_keep:
             self._create_table(config, project, table)
         for table in tables_to_delete:
@@ -562,7 +579,10 @@ class CassandraOnlineStore(OnlineStore):
         fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
         create_cql = self._get_cql_statement(config, "create", fqtable)
         logger.info(f"Creating table {fqtable}.")
-        session.execute(create_cql)
+        if config.online_config.ttl:
+            session.execute(create_cql, parameters=config.online_config.ttl)
+        else:
+            session.execute(create_cql)
 
     def _get_cql_statement(
         self, config: RepoConfig, op_name: str, fqtable: str, **kwargs
@@ -579,9 +599,15 @@ class CassandraOnlineStore(OnlineStore):
         """
         session: Session = self._get_session(config)
         template, prepare = CQL_TEMPLATE_MAP[op_name]
+        if op_name == "create" and config.online_config.ttl:
+            ttl_clause = " WITH default_time_to_live = ?"
+        else:
+            ttl_clause = None
+
         statement = template.format(
             fqtable=fqtable,
-            **kwargs,
+            optional_ttl_clause=ttl_clause,
+            **kwargs
         )
         if prepare:
             # using the statement itself as key (no problem with that)

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -239,9 +239,10 @@ class CassandraOnlineStore(OnlineStore):
             password = online_store_config.password
             protocol_version = online_store_config.protocol_version
             if online_store_config.type == "scylladb":
-                # Using the shard aware functionality
                 if online_store_config.load_balancing is None:
-                    online_store_config.load_balancing = "TokenAwarePolicy(DCAwareRoundRobinPolicy)"
+                    online_store_config.load_balancing = CassandraOnlineStoreConfig.CassandraLoadBalancingPolicy(
+                        load_balancing_policy="TokenAwarePolicy(DCAwareRoundRobinPolicy)"
+                    )
                 if online_store_config.protocol_version is None:
                     protocol_version = 4
 

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -124,7 +124,7 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     and password being the Client ID and Client Secret of the database token.
     """
 
-    type: Literal["cassandra"] = "cassandra"
+    type: Literal["cassandra", "scylladb"] = "cassandra"
     """Online store type selector."""
 
     # settings for connection to Cassandra / Astra DB
@@ -463,7 +463,8 @@ class CassandraOnlineStore(OnlineStore):
         """
         project = config.project
 
-        if config.online_config.lazy_table_creation:
+        if getattr(config.online_store, "lazy_table_creation", False):
+            logger.info(f"Lazy table creation enabled. Skipping table creation for {project} online store.")
             # create tables during materialization
             return
 

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -154,7 +154,10 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     """Request timeout in seconds."""
 
     lazy_table_creation: Optional[bool] = False
-    """If True, tables will be created on during materialization, rather than registration."""
+    """
+    If True, tables will be created on during materialization, rather than registration.
+    Table deletion is not currently supported in this mode.
+    """
 
     class CassandraLoadBalancingPolicy(FeastConfigBaseModel):
         """

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -154,7 +154,7 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     """Request timeout in seconds."""
 
     ttl: Optional[StrictInt] = None
-    '''Time to live option'''
+    """Time to live option"""
 
     lazy_table_creation: Optional[bool] = False
     """If True, tables will be created on during materialization, rather than registration."""
@@ -232,8 +232,11 @@ class CassandraOnlineStore(OnlineStore):
         if not self._session:
             # configuration consistency checks
             secure_bundle_path = online_store_config.secure_bundle_path
-            port = 19042 if online_store_config.type == "scylladb" else (
-                online_store_config.port or 9042)
+            port = (
+                19042
+                if online_store_config.type == "scylladb"
+                else (online_store_config.port or 9042)
+            )
             keyspace = online_store_config.keyspace
             username = online_store_config.username
             password = online_store_config.password
@@ -465,7 +468,9 @@ class CassandraOnlineStore(OnlineStore):
         project = config.project
 
         if getattr(config.online_store, "lazy_table_creation", False):
-            logger.info(f"Lazy table creation enabled. Skipping table creation for {project} online store.")
+            logger.info(
+                f"Lazy table creation enabled. Skipping table creation for {project} online store."
+            )
             # create tables during materialization
             return
 
@@ -607,9 +612,7 @@ class CassandraOnlineStore(OnlineStore):
             ttl_clause = None
 
         statement = template.format(
-            fqtable=fqtable,
-            optional_ttl_clause=ttl_clause,
-            **kwargs
+            fqtable=fqtable, optional_ttl_clause=ttl_clause, **kwargs
         )
         if prepare:
             # using the statement itself as key (no problem with that)

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -88,7 +88,7 @@ CREATE_TABLE_CQL_TEMPLATE = """
         event_ts        TIMESTAMP,
         created_ts      TIMESTAMP,
         PRIMARY KEY ((entity_key), feature_name)
-    ) WITH CLUSTERING ORDER BY (feature_name ASC) {optional_ttl_clause};
+    ) WITH CLUSTERING ORDER BY (feature_name ASC);
 """
 
 DROP_TABLE_CQL_TEMPLATE = "DROP TABLE IF EXISTS {fqtable};"
@@ -152,9 +152,6 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
 
     request_timeout: Optional[StrictFloat] = None
     """Request timeout in seconds."""
-
-    ttl: Optional[StrictInt] = None
-    """Time to live option"""
 
     lazy_table_creation: Optional[bool] = False
     """If True, tables will be created on during materialization, rather than registration."""
@@ -231,25 +228,14 @@ class CassandraOnlineStore(OnlineStore):
             return self._session
         if not self._session:
             # configuration consistency checks
+            hosts = online_store_config.hosts
             secure_bundle_path = online_store_config.secure_bundle_path
-            port = (
-                19042
-                if online_store_config.type == "scylladb"
-                else (online_store_config.port or 9042)
-            )
+            port = online_store_config.port or 9042
             keyspace = online_store_config.keyspace
             username = online_store_config.username
             password = online_store_config.password
             protocol_version = online_store_config.protocol_version
-            if online_store_config.type == "scylladb":
-                if online_store_config.load_balancing is None:
-                    online_store_config.load_balancing = CassandraOnlineStoreConfig.CassandraLoadBalancingPolicy(
-                        load_balancing_policy="TokenAwarePolicy(DCAwareRoundRobinPolicy)"
-                    )
-                if online_store_config.protocol_version is None:
-                    protocol_version = 4
 
-            hosts = online_store_config.hosts
             db_directions = hosts or secure_bundle_path
             if not db_directions or not keyspace:
                 raise CassandraInvalidConfig(E_CASSANDRA_NOT_CONFIGURED)
@@ -579,10 +565,7 @@ class CassandraOnlineStore(OnlineStore):
         fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
         create_cql = self._get_cql_statement(config, "create", fqtable)
         logger.info(f"Creating table {fqtable}.")
-        if config.online_config.ttl:
-            session.execute(create_cql, parameters=config.online_config.ttl)
-        else:
-            session.execute(create_cql)
+        session.execute(create_cql)
 
     def _get_cql_statement(
         self, config: RepoConfig, op_name: str, fqtable: str, **kwargs
@@ -599,13 +582,9 @@ class CassandraOnlineStore(OnlineStore):
         """
         session: Session = self._get_session(config)
         template, prepare = CQL_TEMPLATE_MAP[op_name]
-        if op_name == "create" and config.online_config.ttl:
-            ttl_clause = " WITH default_time_to_live = ?"
-        else:
-            ttl_clause = None
-
         statement = template.format(
-            fqtable=fqtable, optional_ttl_clause=ttl_clause, **kwargs
+            fqtable=fqtable,
+            **kwargs,
         )
         if prepare:
             # using the statement itself as key (no problem with that)

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -62,6 +62,7 @@ ONLINE_STORE_CLASS_FOR_TYPE = {
     "postgres": "feast.infra.online_stores.contrib.postgres.PostgreSQLOnlineStore",
     "hbase": "feast.infra.online_stores.contrib.hbase_online_store.hbase.HbaseOnlineStore",
     "cassandra": "feast.infra.online_stores.contrib.cassandra_online_store.cassandra_online_store.CassandraOnlineStore",
+    "scylladb": "feast.infra.online_stores.contrib.cassandra_online_store.cassandra_online_store.CassandraOnlineStore",
     "mysql": "feast.infra.online_stores.contrib.mysql_online_store.mysql.MySQLOnlineStore",
     "hazelcast": "feast.infra.online_stores.contrib.hazelcast_online_store.hazelcast_online_store.HazelcastOnlineStore",
     "milvus": "feast.expediagroup.vectordb.milvus_online_store.MilvusOnlineStore",

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,10 @@ CASSANDRA_REQUIRED = [
 
 GE_REQUIRED = ["great_expectations>=0.15.41"]
 
+SCYLLADB_REQUIRED = [
+    "scylla-driver>=3.24.0,<4",
+]
+
 AZURE_REQUIRED = [
     "azure-storage-blob>=0.37.0",
     "azure-identity>=1.6.1",
@@ -477,6 +481,7 @@ setup(
         "hbase": HBASE_REQUIRED,
         "docs": DOCS_REQUIRED,
         "cassandra": CASSANDRA_REQUIRED,
+        "scylladb": SCYLLADB_REQUIRED,
         "hazelcast": HAZELCAST_REQUIRED,
         "grpcio": GRPCIO_REQUIRED,
         "ibis": IBIS_REQUIRED,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
This PR is includes the addition of `lazy_table_creation` to `CassandraOnlineStoreConfig`.

`lazy_table_creation` is used in `feature_story.py`'s `apply` method to defer infra creation to the Materialization stage, found in this PR: https://github.com/ExpediaGroup/feast/pull/147.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://jira.expedia.biz/browse/EAPC-14919


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
