### PR TITLE
fix: Correct apply_project in HttpRegistry

### DIFF
--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -757,6 +757,18 @@ class HttpRegistry(BaseRegistry):
         project: Project,
         commit: bool = True,
     ):  # type: ignore[return]
+        """
+        We were not applying projects before the addition of the line below this comment.
+        When either validating features or trying to register them, the feature-store-feast-sdk would fail.
+        cli.py --> validate.py --> instantiating FeatureStore obj --> instantiating HttpRegistry obj --> apply_project()
+        No project was applied.
+        We then query the feature store registry and get back a 404 for the project.
+        Using apply_project_metadata(project.name) restores functionality.
+
+
+        Update this with correct implimentation for Project Objects later.
+        """
+        self.apply_project_metadata(project.name)
         return None
 
     def delete_project(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

When trying to validate/register features with the most up to date version of eg-feast (after ScyllaDB additions and Project Object additions), users were getting failures because of 404s when trying to retrieve their project.

[Slack thread](https://expedia.slack.com/archives/C0425D3PS72/p1733206078407869)

This applies the project_metadata once again to solve the issue.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://jira.expedia.biz/browse/EAPC-15745


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
