### PR TITLE
fix: Reuse online store for materialization writes

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/spark/spark_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/spark/spark_materialization_engine.py
@@ -233,6 +233,7 @@ def _map_by_partition(
     iterator,
     spark_serialized_artifacts: _SparkSerializedArtifacts,
 ):
+    feature_view, online_store, repo_config = spark_serialized_artifacts.unserialize()
     """Load pandas df to online store"""
     for pdf in iterator:
         pdf_row_count = pdf.shape[0]
@@ -240,16 +241,9 @@ def _map_by_partition(
         # convert to pyarrow table
         if pdf_row_count == 0:
             print("INFO!!! Dataframe has 0 records to process")
-            return
+            continue
 
         table = pyarrow.Table.from_pandas(pdf)
-
-        # unserialize artifacts
-        (
-            feature_view,
-            online_store,
-            repo_config,
-        ) = spark_serialized_artifacts.unserialize()
 
         if feature_view.batch_source.field_mapping is not None:
             # Spark offline store does the field mapping during pull_latest_from_table_or_query

--- a/sdk/python/feast/infra/materialization/contrib/spark/spark_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/spark/spark_materialization_engine.py
@@ -241,7 +241,7 @@ def _map_by_partition(
         # convert to pyarrow table
         if pdf_row_count == 0:
             print("INFO!!! Dataframe has 0 records to process")
-            continue
+            return
 
         table = pyarrow.Table.from_pandas(pdf)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR allows instances of the OnlineStore to be shared from within the spark materialization engine. This means a new connection to the store doesn't need to be created for each write.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
