### PR TITLE
fix: Using correct CQL Statement for scylla read calls

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -423,7 +423,6 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	if len(uniqueNames) != 1 {
 		return nil, fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
 	}
-	log.Info().Msgf("BatchedKeysOnlineRead: Number of entity keys %d", len(entityKeys))
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
@@ -448,7 +447,6 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	nKeys := len(serializedEntityKeys)
 	batchSize := c.keyBatchSize
 	nBatches := int(math.Ceil(float64(nKeys) / float64(batchSize)))
-	log.Info().Msgf("BatchedKeysOnlineRead: Total number of serializedEntityKeys: %d, Batch size: %d, Total batches: %d\n", nKeys, batchSize, nBatches)
 	batches := make([][]any, nBatches)
 	nAssigned := 0
 	for i := 0; i < nBatches; i++ {

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -257,7 +257,8 @@ func (c *CassandraOnlineStore) getMultiKeyCQLStatement(tableName string, feature
 	for i := 0; i < nkeys; i++ {
 		keyPlaceholders[i] = "?"
 	}
-
+	fmt.Printf("Number of keys: %d\n", nkeys)
+	fmt.Printf("Number of placeholders: %d\n", len(keyPlaceholders))
 	return fmt.Sprintf(
 		`SELECT "entity_key", "feature_name", "event_ts", "value" FROM %s WHERE "entity_key" IN (%s) AND "feature_name" IN (%s)`,
 		tableName,
@@ -449,13 +450,14 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	nKeys := len(serializedEntityKeys)
 	batchSize := c.keyBatchSize
 	nBatches := int(math.Ceil(float64(nKeys) / float64(batchSize)))
-
+	fmt.Printf("Total number of keys: %d, Batch size: %d, Total batches: %d\n", nKeys, batchSize, nBatches)
 	batches := make([][]any, nBatches)
 	nAssigned := 0
 	for i := 0; i < nBatches; i++ {
 		thisBatchSize := int(math.Min(float64(batchSize), float64(nKeys-nAssigned)))
 		nAssigned += thisBatchSize
 		batches[i] = make([]any, thisBatchSize)
+		fmt.Printf("Batch %d size: %d\n", i+1, thisBatchSize)
 		for j := 0; j < thisBatchSize; j++ {
 			batches[i][j] = serializedEntityKeys[i*batchSize+j]
 		}

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -472,7 +472,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	var cqlStatement string
 	for _, batch := range batches {
 		currentBatchLength = len(batch)
-		if len(batch) != prevBatchLength {
+		if currentBatchLength != prevBatchLength {
 			cqlStatement = c.getMultiKeyCQLStatement(tableName, featureNames, currentBatchLength)
 			prevBatchLength = currentBatchLength
 		}

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -423,7 +423,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	if len(uniqueNames) != 1 {
 		return nil, fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
 	}
-	log.Info().Msgf("BatchedKeysOnlineRead: Number of entity keys %d", entityKeys)
+	log.Info().Msgf("BatchedKeysOnlineRead: Number of entity keys %d", len(entityKeys))
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
@@ -474,9 +474,9 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 			cqlStatement = c.getMultiKeyCQLStatement(tableName, featureNames, currentBatchLength)
 			prevBatchLength = currentBatchLength
 		}
-		go func(keyBatch []any, cqlStatement string) {
+		go func(keyBatch []any, statement string) {
 			defer waitGroup.Done()
-			iter := c.session.Query(cqlStatement, keyBatch...).WithContext(ctx).Iter()
+			iter := c.session.Query(statement, keyBatch...).WithContext(ctx).Iter()
 
 			scanner := iter.Scanner()
 			var entityKey string

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -425,7 +425,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	if len(uniqueNames) != 1 {
 		return nil, fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
 	}
-
+	fmt.Printf("Input entityKeys:%d", len(entityKeys))
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
@@ -450,7 +450,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	nKeys := len(serializedEntityKeys)
 	batchSize := c.keyBatchSize
 	nBatches := int(math.Ceil(float64(nKeys) / float64(batchSize)))
-	fmt.Printf("Total number of keys: %d, Batch size: %d, Total batches: %d\n", nKeys, batchSize, nBatches)
+	fmt.Printf("Total number of serializedEntityKeys: %d, Batch size: %d, Total batches: %d\n", nKeys, batchSize, nBatches)
 	batches := make([][]any, nBatches)
 	nAssigned := 0
 	for i := 0; i < nBatches; i++ {

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -453,7 +453,6 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 		thisBatchSize := int(math.Min(float64(batchSize), float64(nKeys-nAssigned)))
 		nAssigned += thisBatchSize
 		batches[i] = make([]any, thisBatchSize)
-		fmt.Printf("Batch %d size: %d\n", i+1, thisBatchSize)
 		for j := 0; j < thisBatchSize; j++ {
 			batches[i][j] = serializedEntityKeys[i*batchSize+j]
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Moving the batch length caching logic outside of go routine.

# Which issue(s) this PR fixes:
Fixes the intermittent issue thats happening in the feature server go routine.
Error: failed to scan features: gocql: expected 47 values send got 50","time":"2025-01-30T16:32:39Z","message":"Error getting feature vector"


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
