### PR TITLE
fix: add python-snappy compression dependency

### DIFF
--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -55,7 +55,7 @@ azure-core==1.32.0
     # via
     #   azure-identity
     #   azure-storage-blob
-azure-identity==1.19.0
+azure-identity==1.20.0
     # via eg-feast (setup.py)
 azure-storage-blob==12.24.1
     # via eg-feast (setup.py)
@@ -130,6 +130,8 @@ comm==0.2.2
     #   ipywidgets
 coverage[toml]==7.6.12
     # via pytest-cov
+cramjam==2.9.1
+    # via python-snappy
 cryptography==42.0.8
     # via
     #   eg-feast (setup.py)
@@ -733,6 +735,8 @@ python-dotenv==1.0.1
 python-json-logger==3.2.1
     # via jupyter-events
 python-keycloak==4.2.2
+    # via eg-feast (setup.py)
+python-snappy==0.7.3
     # via eg-feast (setup.py)
 pytz==2025.1
     # via

--- a/sdk/python/requirements/py3.11-ci-requirements.txt
+++ b/sdk/python/requirements/py3.11-ci-requirements.txt
@@ -53,7 +53,7 @@ azure-core==1.32.0
     # via
     #   azure-identity
     #   azure-storage-blob
-azure-identity==1.19.0
+azure-identity==1.20.0
     # via eg-feast (setup.py)
 azure-storage-blob==12.24.1
     # via eg-feast (setup.py)
@@ -128,6 +128,8 @@ comm==0.2.2
     #   ipywidgets
 coverage[toml]==7.6.12
     # via pytest-cov
+cramjam==2.9.1
+    # via python-snappy
 cryptography==42.0.8
     # via
     #   eg-feast (setup.py)
@@ -724,6 +726,8 @@ python-dotenv==1.0.1
 python-json-logger==3.2.1
     # via jupyter-events
 python-keycloak==4.2.2
+    # via eg-feast (setup.py)
+python-snappy==0.7.3
     # via eg-feast (setup.py)
 pytz==2025.1
     # via

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -55,7 +55,7 @@ azure-core==1.32.0
     # via
     #   azure-identity
     #   azure-storage-blob
-azure-identity==1.19.0
+azure-identity==1.20.0
     # via eg-feast (setup.py)
 azure-storage-blob==12.24.1
     # via eg-feast (setup.py)
@@ -132,6 +132,8 @@ comm==0.2.2
     #   ipywidgets
 coverage[toml]==7.6.12
     # via pytest-cov
+cramjam==2.9.1
+    # via python-snappy
 cryptography==42.0.8
     # via
     #   eg-feast (setup.py)
@@ -746,6 +748,8 @@ python-dotenv==1.0.1
 python-json-logger==3.2.1
     # via jupyter-events
 python-keycloak==4.2.2
+    # via eg-feast (setup.py)
+python-snappy==0.7.3
     # via eg-feast (setup.py)
 pytz==2025.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ HBASE_REQUIRED = [
 CASSANDRA_REQUIRED = [
     "cassandra-driver>=3.24.0,<4",
     "lz4",
+    "python-snappy",
 ]
 
 GE_REQUIRED = ["great_expectations>=0.15.41"]
@@ -123,6 +124,7 @@ GE_REQUIRED = ["great_expectations>=0.15.41"]
 SCYLLADB_REQUIRED = [
     "scylla-driver>=3.24.0,<4",
     "lz4",
+    "python-snappy",
 ]
 
 AZURE_REQUIRED = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
Cassandra/Scylladb supports two types of compressions (lz4 and python-snappy). Driver chooses the compression based on the version supported by server. If server supports both, lz4 is used. 


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
