### PR TITLE
fix: Fix Scylladb table name limitation

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -380,7 +380,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 			var eventTs time.Time
 			var valueStr []byte
 			var deserializedValue types.Value
-			rowFeatures := make(map[string]*FeatureData)
+			rowFeatures := make(map[string]FeatureData)
 			for scanner.Next() {
 				err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 				if err != nil {
@@ -394,7 +394,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 
 				if deserializedValue.Val != nil {
 					// Convert the value to a FeatureData struct
-					rowFeatures[featureName] = &FeatureData{
+					rowFeatures[featureName] = FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featureName,
@@ -413,20 +413,9 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 			}
 
 			for _, featName := range featureNames {
-
-				if featureData, exists := rowFeatures[featName]; exists {
-					results[rowIdx][featureNamesToIdx[featName]] = FeatureData{
-						Reference: serving.FeatureReferenceV2{
-							FeatureViewName: featureData.Reference.FeatureViewName,
-							FeatureName:     featureData.Reference.FeatureName,
-						},
-						Timestamp: timestamppb.Timestamp{Seconds: featureData.Timestamp.Seconds, Nanos: featureData.Timestamp.Nanos},
-						Value: types.Value{
-							Val: featureData.Value.Val,
-						},
-					}
-				} else {
-					results[rowIdx][featureNamesToIdx[featName]] = FeatureData{
+				featureData, ok := rowFeatures[featName]
+				if !ok {
+					featureData = FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featName,
@@ -438,7 +427,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 						},
 					}
 				}
-
+				results[rowIdx][featureNamesToIdx[featName]] = featureData
 			}
 		}(serializedEntityKey)
 	}
@@ -527,7 +516,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 			var valueStr []byte
 			var deserializedValue types.Value
 			// key 1: entityKey - key 2: featureName
-			batchFeatures := make(map[string]map[string]*FeatureData)
+			batchFeatures := make(map[string]map[string]FeatureData)
 			for scanner.Next() {
 				err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 				if err != nil {
@@ -541,9 +530,9 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 
 				if deserializedValue.Val != nil {
 					if batchFeatures[entityKey] == nil {
-						batchFeatures[entityKey] = make(map[string]*FeatureData)
+						batchFeatures[entityKey] = make(map[string]FeatureData)
 					}
-					batchFeatures[entityKey][featureName] = &FeatureData{
+					batchFeatures[entityKey][featureName] = FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featureName,
@@ -564,20 +553,9 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 			for _, serializedEntityKey := range keyBatch {
 				for _, featName := range featureNames {
 					keyString := serializedEntityKey.(string)
-
-					if featureData, exists := batchFeatures[keyString][featName]; exists {
-						results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = FeatureData{
-							Reference: serving.FeatureReferenceV2{
-								FeatureViewName: featureData.Reference.FeatureViewName,
-								FeatureName:     featureData.Reference.FeatureName,
-							},
-							Timestamp: timestamppb.Timestamp{Seconds: featureData.Timestamp.Seconds, Nanos: featureData.Timestamp.Nanos},
-							Value: types.Value{
-								Val: featureData.Value.Val,
-							},
-						}
-					} else {
-						results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = FeatureData{
+					featureData, ok := batchFeatures[keyString][featName]
+					if !ok {
+						featureData = FeatureData{
 							Reference: serving.FeatureReferenceV2{
 								FeatureViewName: featureViewName,
 								FeatureName:     featName,
@@ -589,6 +567,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 							},
 						}
 					}
+					results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = featureData
 				}
 			}
 		}(batch, cqlStatement)

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -84,7 +84,7 @@ CREATE_TABLE_CQL_TEMPLATE = """
         created_ts      TIMESTAMP,
         PRIMARY KEY ((entity_key), feature_name)
     ) WITH CLUSTERING ORDER BY (feature_name ASC)
-    AND COMMENT="project={project}, feature_view={feature_view}";
+    AND COMMENT='project={project}, feature_view={feature_view}';
 """
 
 DROP_TABLE_CQL_TEMPLATE = "DROP TABLE IF EXISTS {fqtable};"

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -18,6 +18,7 @@
 Cassandra/Astra DB online store for Feast.
 """
 
+import hashlib
 import logging
 import time
 from datetime import datetime
@@ -82,7 +83,8 @@ CREATE_TABLE_CQL_TEMPLATE = """
         event_ts        TIMESTAMP,
         created_ts      TIMESTAMP,
         PRIMARY KEY ((entity_key), feature_name)
-    ) WITH CLUSTERING ORDER BY (feature_name ASC);
+    ) WITH CLUSTERING ORDER BY (feature_name ASC)
+    AND COMMENT="project={project}, feature_view={feature_view}";
 """
 
 DROP_TABLE_CQL_TEMPLATE = "DROP TABLE IF EXISTS {fqtable};"
@@ -96,6 +98,8 @@ CQL_TEMPLATE_MAP = {
     "drop": (DROP_TABLE_CQL_TEMPLATE, False),
     "create": (CREATE_TABLE_CQL_TEMPLATE, False),
 }
+
+SCYLLADB_MAX_TABLE_NAME_LENGTH = 48
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -539,8 +543,23 @@ class CassandraOnlineStore(OnlineStore):
         """
         Generate a fully-qualified table name,
         including quotes and keyspace.
+        Scylladb has a limit of 48 characters for table names.
         """
-        return f'"{keyspace}"."{project}_{table.name}"'
+        feature_view_name = table.name
+        db_table_name = f"{project}_{feature_view_name}"
+        if len(db_table_name) <= SCYLLADB_MAX_TABLE_NAME_LENGTH:
+            return f'"{keyspace}"."{db_table_name}"'
+
+        project_hash = hashlib.md5(project.encode()).hexdigest()[:7]
+        table_name_hash = hashlib.md5(db_table_name.encode()).hexdigest()[:8]
+
+        # Shorten table name if it exceeds 30 characters
+        if len(feature_view_name) > 30:
+            feature_view_name = feature_view_name[:30]
+
+        # Table name should start with a character so we are adding 'p' as prefix.
+        # p represents project.
+        return f'"{keyspace}"."p{project_hash}_{feature_view_name}_{table_name_hash}"'
 
     def _read_rows_by_entity_keys(
         self,
@@ -602,8 +621,16 @@ class CassandraOnlineStore(OnlineStore):
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
         fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
-        create_cql = self._get_cql_statement(config, "create", fqtable)
-        logger.info(f"Creating table {fqtable} in keyspace {keyspace}.")
+        create_cql = self._get_cql_statement(
+            config,
+            "create",
+            fqtable,
+            project=project,
+            feature_view=table.name,
+        )
+        logger.info(
+            f"Creating table {fqtable} in keyspace {keyspace} if not exists using {create_cql}."
+        )
         session.execute(create_cql)
 
     def _get_cql_statement(

--- a/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
@@ -1,0 +1,65 @@
+import unittest
+
+from feast import FeatureView
+from feast.infra.online_stores.contrib.cassandra_online_store.cassandra_online_store import (
+    CassandraOnlineStore,
+)
+
+
+class TestCassandraOnlineStore(unittest.TestCase):
+    def test_fq_table_name_within_limit(self):
+        keyspace = "test_keyspace"
+        project = "test_project"
+        table = FeatureView(name="test_feature_view")
+
+        expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+        actual_table_name = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table
+        )
+
+        self.assertEqual(expected_table_name, actual_table_name)
+
+    def test_fq_table_name_exceeds_limit(self):
+        keyspace = "test_keyspace"
+        project = "test_project"
+        table = FeatureView(
+            name="test_feature_view_with_a_very_long_name_exceeding_limit"
+        )
+        expected_table_name = (
+            f'"{keyspace}"."p6e72a69_test_feature_view_with_a_very__4d479508"'
+        )
+        actual_table_name = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table
+        )
+
+        self.assertEqual(expected_table_name, actual_table_name)
+
+    def test_fq_table_name_edge_case(self):
+        keyspace = "test_keyspace"
+        project = "test_project"
+        table = FeatureView(name="a" * 30)
+
+        expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+        actual_table_name = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table
+        )
+
+        self.assertEqual(expected_table_name, actual_table_name)
+
+    def test_fq_table_name_edge_case_exceeds_limit(self):
+        keyspace = "test_keyspace"
+        project = "test_project_edge"
+        table = FeatureView(name="a" * 31)
+
+        expected_table_name = (
+            f'"{keyspace}"."pfd98066_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_625ed0fd"'
+        )
+        actual_table_name = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table
+        )
+
+        self.assertEqual(expected_table_name, actual_table_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
@@ -1,65 +1,63 @@
-import unittest
+import pytest
 
 from feast import FeatureView
+from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.online_stores.contrib.cassandra_online_store.cassandra_online_store import (
     CassandraOnlineStore,
 )
 
 
-class TestCassandraOnlineStore(unittest.TestCase):
-    def test_fq_table_name_within_limit(self):
-        keyspace = "test_keyspace"
-        project = "test_project"
-        table = FeatureView(name="test_feature_view")
-
-        expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
-        actual_table_name = CassandraOnlineStore._fq_table_name(
-            keyspace, project, table
-        )
-
-        self.assertEqual(expected_table_name, actual_table_name)
-
-    def test_fq_table_name_exceeds_limit(self):
-        keyspace = "test_keyspace"
-        project = "test_project"
-        table = FeatureView(
-            name="test_feature_view_with_a_very_long_name_exceeding_limit"
-        )
-        expected_table_name = (
-            f'"{keyspace}"."p6e72a69_test_feature_view_with_a_very__4d479508"'
-        )
-        actual_table_name = CassandraOnlineStore._fq_table_name(
-            keyspace, project, table
-        )
-
-        self.assertEqual(expected_table_name, actual_table_name)
-
-    def test_fq_table_name_edge_case(self):
-        keyspace = "test_keyspace"
-        project = "test_project"
-        table = FeatureView(name="a" * 30)
-
-        expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
-        actual_table_name = CassandraOnlineStore._fq_table_name(
-            keyspace, project, table
-        )
-
-        self.assertEqual(expected_table_name, actual_table_name)
-
-    def test_fq_table_name_edge_case_exceeds_limit(self):
-        keyspace = "test_keyspace"
-        project = "test_project_edge"
-        table = FeatureView(name="a" * 31)
-
-        expected_table_name = (
-            f'"{keyspace}"."pfd98066_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_625ed0fd"'
-        )
-        actual_table_name = CassandraOnlineStore._fq_table_name(
-            keyspace, project, table
-        )
-
-        self.assertEqual(expected_table_name, actual_table_name)
+@pytest.fixture
+def file_source():
+    file_source = FileSource(name="my_file_source", path="test.parquet")
+    return file_source
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_fq_table_name_within_limit(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project"
+    table = FeatureView(name="test_feature_view", source=file_source)
+
+    expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+
+    assert expected_table_name == actual_table_name
+
+
+def test_fq_table_name_exceeds_limit(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project"
+    table = FeatureView(
+        name="test_feature_view_with_a_very_long_name_exceeding_limit",
+        source=file_source,
+    )
+    expected_table_name = (
+        f'"{keyspace}"."p6e72a69_test_feature_view_with_a_very__4d479508"'
+    )
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+
+    assert expected_table_name == actual_table_name
+
+
+def test_fq_table_name_edge_case(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project"
+    table = FeatureView(name="a" * 30, source=file_source)
+
+    expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+
+    assert expected_table_name == actual_table_name
+
+
+def test_fq_table_name_edge_case_exceeds_limit(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project_edge"
+    table = FeatureView(name="a" * 31, source=file_source)
+
+    expected_table_name = (
+        f'"{keyspace}"."pfd98066_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_625ed0fd"'
+    )
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+
+    assert expected_table_name == actual_table_name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
Scylladb has a limit of 48 characters for table names. With this approach, trying to use hash of the table name and project name to control it. Validation module validates the table name for the given project and feature view names if it has any conflicts. 


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
