### PR TITLE
fix: Fixing go static analyzer warnings

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -380,7 +380,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 			var eventTs time.Time
 			var valueStr []byte
 			var deserializedValue types.Value
-			rowFeatures := make(map[string]FeatureData)
+			rowFeatures := make(map[string]*FeatureData)
 			for scanner.Next() {
 				err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 				if err != nil {
@@ -394,7 +394,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 
 				if deserializedValue.Val != nil {
 					// Convert the value to a FeatureData struct
-					rowFeatures[featureName] = FeatureData{
+					rowFeatures[featureName] = &FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featureName,
@@ -413,9 +413,20 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 			}
 
 			for _, featName := range featureNames {
-				featureData, ok := rowFeatures[featName]
-				if !ok {
-					featureData = FeatureData{
+
+				if featureData, exists := rowFeatures[featName]; exists {
+					results[rowIdx][featureNamesToIdx[featName]] = FeatureData{
+						Reference: serving.FeatureReferenceV2{
+							FeatureViewName: featureData.Reference.FeatureViewName,
+							FeatureName:     featureData.Reference.FeatureName,
+						},
+						Timestamp: timestamppb.Timestamp{Seconds: featureData.Timestamp.Seconds, Nanos: featureData.Timestamp.Nanos},
+						Value: types.Value{
+							Val: featureData.Value.Val,
+						},
+					}
+				} else {
+					results[rowIdx][featureNamesToIdx[featName]] = FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featName,
@@ -427,7 +438,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 						},
 					}
 				}
-				results[rowIdx][featureNamesToIdx[featName]] = featureData
+
 			}
 		}(serializedEntityKey)
 	}
@@ -516,7 +527,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 			var valueStr []byte
 			var deserializedValue types.Value
 			// key 1: entityKey - key 2: featureName
-			batchFeatures := make(map[string]map[string]FeatureData)
+			batchFeatures := make(map[string]map[string]*FeatureData)
 			for scanner.Next() {
 				err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 				if err != nil {
@@ -530,9 +541,9 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 
 				if deserializedValue.Val != nil {
 					if batchFeatures[entityKey] == nil {
-						batchFeatures[entityKey] = make(map[string]FeatureData)
+						batchFeatures[entityKey] = make(map[string]*FeatureData)
 					}
-					batchFeatures[entityKey][featureName] = FeatureData{
+					batchFeatures[entityKey][featureName] = &FeatureData{
 						Reference: serving.FeatureReferenceV2{
 							FeatureViewName: featureViewName,
 							FeatureName:     featureName,
@@ -553,9 +564,20 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 			for _, serializedEntityKey := range keyBatch {
 				for _, featName := range featureNames {
 					keyString := serializedEntityKey.(string)
-					featureData, ok := batchFeatures[keyString][featName]
-					if !ok {
-						featureData = FeatureData{
+
+					if featureData, exists := batchFeatures[keyString][featName]; exists {
+						results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = FeatureData{
+							Reference: serving.FeatureReferenceV2{
+								FeatureViewName: featureData.Reference.FeatureViewName,
+								FeatureName:     featureData.Reference.FeatureName,
+							},
+							Timestamp: timestamppb.Timestamp{Seconds: featureData.Timestamp.Seconds, Nanos: featureData.Timestamp.Nanos},
+							Value: types.Value{
+								Val: featureData.Value.Val,
+							},
+						}
+					} else {
+						results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = FeatureData{
 							Reference: serving.FeatureReferenceV2{
 								FeatureViewName: featureViewName,
 								FeatureName:     featName,
@@ -567,7 +589,6 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 							},
 						}
 					}
-					results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = featureData
 				}
 			}
 		}(batch, cqlStatement)

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -17,8 +17,8 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/gocql/gocql"
-	"github.com/golang/protobuf/proto"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	gocqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
Fixes go static analyzer warnings. Warning is `assignment copies lock value to results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]]: github.com/feast-dev/feast/go/internal/feast/onlinestore.FeatureData contains github.com/feast-dev/feast/go/protos/feast/serving.FeatureReferenceV2 contains google.golang.org/protobuf/runtime/protoimpl.MessageState contains sync.Mutex`


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
