### PR TITLE
fix: Table name format is backward compatible

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -42,6 +42,7 @@ type CassandraOnlineStore struct {
 	// The version of the table name format
 	tableNameFormatVersion int
 
+	// Caches table names instead of generating the table name every time
 	tableNameCache sync.Map
 }
 
@@ -61,8 +62,6 @@ const (
 	V2_TABLE_NAME_FORMAT_MAX_LENGTH = 48
 	BASE62_CHAR_SET                 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
-
-const ()
 
 // toBase62 converts a big integer to a base62 string.
 func toBase62(num *big.Int) string {

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
 	"strings"
 	"sync"
@@ -38,6 +39,9 @@ type CassandraOnlineStore struct {
 	// The number of keys to include in a single CQL query for retrieval from the database
 	keyBatchSize int
 
+	// The version of the table name format
+	tableNameFormatVersion int
+
 	tableNameCache sync.Map
 }
 
@@ -54,8 +58,36 @@ type CassandraConfig struct {
 }
 
 const (
-	SCYLLADB_MAX_TABLE_NAME_LENGTH = 48
+	V2_TABLE_NAME_FORMAT_MAX_LENGTH = 48
+	BASE62_CHAR_SET                 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
+
+const ()
+
+// toBase62 converts a big integer to a base62 string.
+func toBase62(num *big.Int) string {
+	if num.Sign() == 0 {
+		return "0"
+	}
+
+	base := big.NewInt(62)
+	result := []string{}
+	zero := big.NewInt(0)
+	remainder := new(big.Int)
+
+	for num.Cmp(zero) > 0 {
+		num.DivMod(num, base, remainder)
+		result = append([]string{string(BASE62_CHAR_SET[remainder.Int64()])}, result...)
+	}
+
+	return strings.Join(result, "")
+}
+
+// base62Encode converts a byte slice to a Base62 string.
+func base62Encode(data []byte) string {
+	num := new(big.Int).SetBytes(data)
+	return toBase62(num)
+}
 
 func parseStringField(config map[string]any, fieldName string, defaultValue string) (string, error) {
 	rawValue, ok := config[fieldName]
@@ -232,38 +264,68 @@ func NewCassandraOnlineStore(project string, config *registry.RepoConfig, online
 	}
 	store.keyBatchSize = cassandraConfig.keyBatchSize
 
+	// parse tableNameFormatVersion
+	tableNameFormatVersion, ok := onlineStoreConfig["table_name_format_version"]
+	if !ok {
+		tableNameFormatVersion = 1
+		log.Warn().Msg("table_name_format_version not specified: Using 1 instead")
+	}
+	store.tableNameFormatVersion = tableNameFormatVersion.(int)
+
 	return &store, nil
 }
 
-func (c *CassandraOnlineStore) getFqTableName(keySpace string, project string, featureViewName string) string {
+// fqTableNameV2 generates a fully qualified table name with Base62 hashing.
+func getFqTableNameV2(keyspace string, project string, featureViewName string) string {
+	dbTableName := fmt.Sprintf("%s_%s", project, featureViewName)
+
+	if len(dbTableName) <= V2_TABLE_NAME_FORMAT_MAX_LENGTH {
+		return dbTableName
+	}
+
+	// Truncate project & feature view name
+	prjPrefixMaxLen := 5
+	fvPrefixMaxLen := 5
+	truncatedProject := project[:min(len(project), prjPrefixMaxLen)]
+	truncatedFv := featureViewName[:min(len(featureViewName), fvPrefixMaxLen)]
+
+	projectToHash := project[len(truncatedProject):]
+	fvToHash := featureViewName[len(truncatedFv):]
+
+	projectHashBytes := md5.Sum([]byte(projectToHash))
+	fvHashBytes := md5.Sum([]byte(fvToHash))
+
+	// Compute MD5 hash and encode to Base62
+	projectHash := base62Encode(projectHashBytes[:])
+	fvHash := base62Encode(fvHashBytes[:])
+
+	// Format final table name (48 - 3 underscores - 5 prj prefix - 5 fv prefix) / 2 = ~17 each
+	dbTableName = fmt.Sprintf("%s_%s_%s_%s",
+		truncatedProject, projectHash[:17], truncatedFv, fvHash[:18])
+
+	return dbTableName
+}
+
+func (c *CassandraOnlineStore) getFqTableName(keySpace string, project string, featureViewName string, tableNameVersion int) (string, error) {
 	var dbTableName string
 
 	tableName := fmt.Sprintf("%s_%s", project, featureViewName)
 
 	if cacheValue, found := c.tableNameCache.Load(tableName); found {
-		return fmt.Sprintf(`"%s"."%s"`, keySpace, cacheValue.(string))
+		return fmt.Sprintf(`"%s"."%s"`, keySpace, cacheValue.(string)), nil
 	}
 
-	if len(tableName) <= SCYLLADB_MAX_TABLE_NAME_LENGTH {
+	if tableNameVersion == 1 {
 		dbTableName = tableName
+	} else if tableNameVersion == 2 {
+		dbTableName = getFqTableNameV2(keySpace, project, featureViewName)
 	} else {
-		projectHashBytes := md5.Sum([]byte(project))
-		projectHash := hex.EncodeToString(projectHashBytes[:])[:7]
-
-		dbTableHashBytes := md5.Sum([]byte(tableName))
-		dbTableHash := hex.EncodeToString(dbTableHashBytes[:])[:8]
-
-		// Shorten FeatureView name if it exceeds 30 characters
-		if len(featureViewName) > 30 {
-			featureViewName = featureViewName[:30]
-		}
-
-		dbTableName = fmt.Sprintf("p%s_%s_%s", projectHash, featureViewName, dbTableHash)
+		return "", fmt.Errorf("unknown table name format version: %d", tableNameVersion)
 	}
 
 	c.tableNameCache.Store(tableName, dbTableName)
 
-	return fmt.Sprintf(`"%s"."%s"`, keySpace, dbTableName)
+	return fmt.Sprintf(`"%s"."%s"`, keySpace, dbTableName), nil
 }
 
 func (c *CassandraOnlineStore) getSingleKeyCQLStatement(tableName string, featureNames []string) string {
@@ -341,7 +403,10 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 	featureViewName := featureViewNames[0]
 
 	// Prepare the query
-	tableName := c.getFqTableName(c.clusterConfigs.Keyspace, c.project, featureViewName)
+	tableName, err := c.getFqTableName(c.clusterConfigs.Keyspace, c.project, featureViewName, c.tableNameFormatVersion)
+	if err != nil {
+		return nil, err
+	}
 	cqlStatement := c.getSingleKeyCQLStatement(tableName, featureNames)
 
 	var waitGroup sync.WaitGroup
@@ -486,7 +551,10 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	featureViewName := featureViewNames[0]
 
 	// Prepare the query
-	tableName := c.getFqTableName(c.clusterConfigs.Keyspace, c.project, featureViewName)
+	tableName, err := c.getFqTableName(c.clusterConfigs.Keyspace, c.project, featureViewName, c.tableNameFormatVersion)
+	if err != nil {
+		return nil, err
+	}
 
 	// Key batching
 	nKeys := len(serializedEntityKeys)

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -20,6 +20,7 @@ Cassandra/Astra DB online store for Feast.
 
 import hashlib
 import logging
+import string
 import time
 from datetime import datetime
 from functools import partial
@@ -99,7 +100,7 @@ CQL_TEMPLATE_MAP = {
     "create": (CREATE_TABLE_CQL_TEMPLATE, False),
 }
 
-SCYLLADB_MAX_TABLE_NAME_LENGTH = 48
+V2_TABLE_NAME_FORMAT_MAX_LENGTH = 48
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -205,6 +206,14 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     """
     The maximum number of write batches per second. Value 0 means no rate limiting.
     For spark materialization engine, this configuration is per executor task.
+    """
+
+    table_name_format_version: Optional[StrictInt] = 1
+    """
+    Version of the table name format. This is used to determine the format of the table name.
+    Version 1: <project>_<feature_view_name>
+    Version 2: Limits the length of the table name to 48 characters.
+    Table names should be quoted to make them case sensitive.
     """
 
 
@@ -386,7 +395,10 @@ class CassandraOnlineStore(OnlineStore):
 
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
-        fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+        table_name_version = online_store_config.table_name_format_version
+        fqtable = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table, table_name_version
+        )
 
         insert_cql = self._get_cql_statement(
             config,
@@ -539,27 +551,77 @@ class CassandraOnlineStore(OnlineStore):
             self._drop_table(config, project, table)
 
     @staticmethod
-    def _fq_table_name(keyspace: str, project: str, table: FeatureView) -> str:
+    def _fq_table_name_v2(keyspace: str, project: str, feature_view_name: str) -> str:
         """
         Generate a fully-qualified table name,
         including quotes and keyspace.
-        Scylladb has a limit of 48 characters for table names.
+        Limits table name to 48 characters.
+        """
+        db_table_name = f"{project}_{feature_view_name}"
+
+        def base62encode(input: bytes) -> str:
+            """Convert bytes to a base62 string."""
+
+            def to_base62(num):
+                """
+                Converts a number to a base62 string.
+                """
+                chars = string.digits + string.ascii_lowercase + string.ascii_uppercase
+                if num == 0:
+                    return "0"
+
+                result = []
+                while num:
+                    num, remainder = divmod(num, 62)
+                    result.append(chars[remainder])
+
+                return "".join(reversed(result))
+
+            byte_to_num = int.from_bytes(input, byteorder="big")
+            return to_base62(byte_to_num)
+
+        if len(db_table_name) <= V2_TABLE_NAME_FORMAT_MAX_LENGTH:
+            return f'"{keyspace}"."{db_table_name}"'
+        else:
+            # we are using quotes for table name to make it case sensitive.
+            # So we can pack more bytes into the string by including capital letters.
+            # So using base62(0-9a-zA-Z) encoding instead of base36 (0-9a-z) encoding.
+            prj_prefix_maxlen = 5
+            fv_prefix_maxlen = 5
+            truncated_project = project[:prj_prefix_maxlen]
+            truncated_fv = feature_view_name[:fv_prefix_maxlen]
+
+            project_to_hash = project[len(truncated_project) :]
+            fv_to_hash = feature_view_name[len(truncated_fv) :]
+
+            project_hash = base62encode(hashlib.md5(project_to_hash.encode()).digest())
+            fv_hash = base62encode(hashlib.md5(fv_to_hash.encode()).digest())
+
+            # (48 - 3 underscores - 5 prj prefix - 5 fv prefix) / 2 = 17.5
+            db_table_name = (
+                f"{truncated_project}_{project_hash[:17]}_{truncated_fv}_{fv_hash[:18]}"
+            )
+            return f'"{keyspace}"."{db_table_name}"'
+
+    @staticmethod
+    def _fq_table_name(
+        keyspace: str, project: str, table: FeatureView, table_name_version: int
+    ) -> str:
+        """
+        Generate a fully-qualified table name,
+        including quotes and keyspace.
         """
         feature_view_name = table.name
         db_table_name = f"{project}_{feature_view_name}"
-        if len(db_table_name) <= SCYLLADB_MAX_TABLE_NAME_LENGTH:
+        if table_name_version == 1:
             return f'"{keyspace}"."{db_table_name}"'
 
-        project_hash = hashlib.md5(project.encode()).hexdigest()[:7]
-        table_name_hash = hashlib.md5(db_table_name.encode()).hexdigest()[:8]
-
-        # Shorten table name if it exceeds 30 characters
-        if len(feature_view_name) > 30:
-            feature_view_name = feature_view_name[:30]
-
-        # Table name should start with a character so we are adding 'p' as prefix.
-        # p represents project.
-        return f'"{keyspace}"."p{project_hash}_{feature_view_name}_{table_name_hash}"'
+        elif table_name_version == 2:
+            return CassandraOnlineStore._fq_table_name_v2(
+                keyspace, project, feature_view_name
+            )
+        else:
+            raise ValueError(f"Unknown table name format version: {table_name_version}")
 
     def _read_rows_by_entity_keys(
         self,
@@ -574,7 +636,10 @@ class CassandraOnlineStore(OnlineStore):
         """
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
-        fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+        table_name_version = config.online_store.table_name_format_version
+        fqtable = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table, table_name_version
+        )
         projection_columns = "*" if columns is None else ", ".join(columns)
         select_cql = self._get_cql_statement(
             config,
@@ -611,7 +676,10 @@ class CassandraOnlineStore(OnlineStore):
         """Handle the CQL (low-level) deletion of a table."""
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
-        fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+        table_name_version = config.online_store.table_name_format_version
+        fqtable = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table, table_name_version
+        )
         drop_cql = self._get_cql_statement(config, "drop", fqtable)
         logger.info(f"Deleting table {fqtable}.")
         session.execute(drop_cql)
@@ -620,7 +688,10 @@ class CassandraOnlineStore(OnlineStore):
         """Handle the CQL (low-level) creation of a table."""
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
-        fqtable = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+        table_name_version = config.online_store.table_name_format_version
+        fqtable = CassandraOnlineStore._fq_table_name(
+            keyspace, project, table, table_name_version
+        )
         create_cql = self._get_cql_statement(
             config,
             "create",

--- a/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
@@ -13,18 +13,42 @@ def file_source():
     return file_source
 
 
-def test_fq_table_name_within_limit(file_source):
+def test_fq_table_name_v1_within_limit(file_source):
     keyspace = "test_keyspace"
     project = "test_project"
     table = FeatureView(name="test_feature_view", source=file_source)
 
     expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
-    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table, 1)
 
     assert expected_table_name == actual_table_name
 
 
-def test_fq_table_name_exceeds_limit(file_source):
+def test_fq_table_name_v1_exceeds_limit(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project"
+    table = FeatureView(
+        name="test_feature_view_with_a_very_long_name_exceeding_limit",
+        source=file_source,
+    )
+    expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table, 1)
+
+    assert expected_table_name == actual_table_name
+
+
+def test_fq_table_name_v2_within_limit(file_source):
+    keyspace = "test_keyspace"
+    project = "test_project"
+    table = FeatureView(name="test_feature_view", source=file_source)
+
+    expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table, 2)
+
+    assert expected_table_name == actual_table_name
+
+
+def test_fq_table_name_v2_exceeds_limit(file_source):
     keyspace = "test_keyspace"
     project = "test_project"
     table = FeatureView(
@@ -32,32 +56,18 @@ def test_fq_table_name_exceeds_limit(file_source):
         source=file_source,
     )
     expected_table_name = (
-        f'"{keyspace}"."p6e72a69_test_feature_view_with_a_very__4d479508"'
+        f'"{keyspace}"."test__29UZUpJQRijDZsYzl_test__5Ur8Mv5QutEG23Cp2C"'
     )
-    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
+    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table, 2)
 
     assert expected_table_name == actual_table_name
 
 
-def test_fq_table_name_edge_case(file_source):
+def test_fq_table_name_invalid_version(file_source):
     keyspace = "test_keyspace"
     project = "test_project"
-    table = FeatureView(name="a" * 30, source=file_source)
+    table = FeatureView(name="test_feature_view", source=file_source)
 
-    expected_table_name = f'"{keyspace}"."{project}_{table.name}"'
-    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
-
-    assert expected_table_name == actual_table_name
-
-
-def test_fq_table_name_edge_case_exceeds_limit(file_source):
-    keyspace = "test_keyspace"
-    project = "test_project_edge"
-    table = FeatureView(name="a" * 31, source=file_source)
-
-    expected_table_name = (
-        f'"{keyspace}"."pfd98066_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_625ed0fd"'
-    )
-    actual_table_name = CassandraOnlineStore._fq_table_name(keyspace, project, table)
-
-    assert expected_table_name == actual_table_name
+    with pytest.raises(ValueError) as excinfo:
+        CassandraOnlineStore._fq_table_name(keyspace, project, table, 3)
+    assert "Unknown table name format version: 3" in str(excinfo.value)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
1. Made it backward compatible with current implementation of feast by introducing `table_name_format_version`. Defaulted to 1. 
2. Further compressing the md5 output with base62 encoding. All the table names are used in double quotes so they are case sensitive. 
3. Raise exception if the given table_name_format_version is invalid


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
