### PR TITLE
fix: Correct type conversion for table name format version

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -269,7 +269,7 @@ func NewCassandraOnlineStore(project string, config *registry.RepoConfig, online
 		tableNameFormatVersion = 1
 		log.Warn().Msg("table_name_format_version not specified: Using 1 instead")
 	}
-	store.tableNameFormatVersion = tableNameFormatVersion.(int)
+	store.tableNameFormatVersion = int(tableNameFormatVersion.(float64))
 
 	return &store, nil
 }

--- a/go/internal/feast/registry/repoconfig_test.go
+++ b/go/internal/feast/registry/repoconfig_test.go
@@ -337,3 +337,49 @@ func TestGetLoggingOptions_InvalidType(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, logging.DefaultOptions, *options)
 }
+
+func TestNewRepoConfigForScyllaDBFromJSON(t *testing.T) {
+	// Create a temporary directory for the test
+	dir, err := os.MkdirTemp("", "feature_repo_*")
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.RemoveAll(dir))
+	}()
+
+	// Define a JSON string for the test
+	registry_path := filepath.Join(dir, "data/registry.db")
+
+	configJSON := `{
+        "project": "feature_repo",
+        "registry": "$REGISTRY_PATH",
+        "provider": "local",
+        "online_store": {
+            "type": "scylladb",
+            "hosts": ["localhost:9042"],
+			"key_batch_size": 85,
+			"table_name_format_version": 2
+        }
+    }`
+
+	replacements := map[string]string{
+		"$REGISTRY_PATH": registry_path,
+	}
+
+	// Replace the variables in the JSON string
+	for variable, replacement := range replacements {
+		configJSON = strings.ReplaceAll(configJSON, variable, replacement)
+	}
+
+	// Call the function under test
+	config, _ := NewRepoConfigFromJSON(dir, configJSON)
+	registryConfig, err := config.GetRegistryConfig()
+	// Assert that there was no error and that the config was correctly parsed
+	assert.Nil(t, err)
+	// assert.Equal(t, "feature_repo", config.Project)
+	assert.Equal(t, filepath.Join(dir, "data/registry.db"), registryConfig.Path)
+	assert.Equal(t, "local", config.Provider)
+	assert.Equal(t, float64(85), config.OnlineStore["key_batch_size"])
+	assert.Equal(t, float64(2), config.OnlineStore["table_name_format_version"])
+	assert.Equal(t, int(85), int(config.OnlineStore["key_batch_size"].(float64)))
+	assert.Equal(t, int(2), int(config.OnlineStore["table_name_format_version"].(float64)))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
fix: Correct type conversion for table name format version. By default it's casted to float64. We need to cast it from float64 to int. We need to add tests to NewCassandraOnlineStore function to fully fix the problem. 


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
