### PR TITLE
feat: Add sorted feature view to registry calls and feature server for Go

### DIFF
--- a/go/internal/feast/registry/http_test.go
+++ b/go/internal/feast/registry/http_test.go
@@ -369,6 +369,13 @@ func TestGetRegistryProto(t *testing.T) {
 				},
 			}
 			data, err = proto.Marshal(featureViewList)
+		case "/projects/test_project/sorted_feature_views":
+			sortedFeatureViewList := &core.SortedFeatureViewList{
+				SortedFeatureViews: []*core.SortedFeatureView{
+					{Spec: &core.SortedFeatureViewSpec{Name: "test_sorted_feature_view"}},
+				},
+			}
+			data, err = proto.Marshal(sortedFeatureViewList)
 		case "/projects/test_project/on_demand_feature_views":
 			odFeatureViewList := &core.OnDemandFeatureViewList{
 				Ondemandfeatureviews: []*core.OnDemandFeatureView{
@@ -414,6 +421,8 @@ func TestGetRegistryProto(t *testing.T) {
 	assert.Equal(t, "test_datasource", registry.DataSources[0].Name)
 	assert.Equal(t, 1, len(registry.FeatureViews))
 	assert.Equal(t, "test_feature_view", registry.FeatureViews[0].Spec.Name)
+	assert.Equal(t, 1, len(registry.SortedFeatureViews))
+	assert.Equal(t, "test_sorted_feature_view", registry.SortedFeatureViews[0].Spec.Name)
 	assert.Equal(t, 1, len(registry.OnDemandFeatureViews))
 	assert.Equal(t, "test_view", registry.OnDemandFeatureViews[0].Spec.Name)
 	assert.Equal(t, 1, len(registry.FeatureServices))

--- a/go/internal/feast/server/logging/featureserviceschema.go
+++ b/go/internal/feast/server/logging/featureserviceschema.go
@@ -18,7 +18,7 @@ type FeatureServiceSchema struct {
 }
 
 func GenerateSchemaFromFeatureService(fs FeatureStore, featureServiceName string) (*FeatureServiceSchema, error) {
-	entityMap, fvMap, odFvMap, err := fs.GetFcosMap()
+	entityMap, fvMap, sortedFvMap, odFvMap, err := fs.GetFcosMap()
 	if err != nil {
 		return nil, err
 	}
@@ -28,10 +28,15 @@ func GenerateSchemaFromFeatureService(fs FeatureStore, featureServiceName string
 		return nil, err
 	}
 
-	return generateSchema(featureService, entityMap, fvMap, odFvMap)
+	return generateSchema(featureService, entityMap, fvMap, sortedFvMap, odFvMap)
 }
 
-func generateSchema(featureService *model.FeatureService, entityMap map[string]*model.Entity, fvMap map[string]*model.FeatureView, odFvMap map[string]*model.OnDemandFeatureView) (*FeatureServiceSchema, error) {
+func generateSchema(
+	featureService *model.FeatureService,
+	entityMap map[string]*model.Entity,
+	fvMap map[string]*model.FeatureView,
+	sortedFvMap map[string]*model.SortedFeatureView,
+	odFvMap map[string]*model.OnDemandFeatureView) (*FeatureServiceSchema, error) {
 	joinKeys := make([]string, 0)
 	features := make([]string, 0)
 	requestData := make([]string, 0)
@@ -53,6 +58,27 @@ func generateSchema(featureService *model.FeatureService, entityMap map[string]*
 				allFeatureTypes[fullFeatureName] = f.Dtype
 			}
 			for _, entityColumn := range fv.EntityColumns {
+				var joinKey string
+				if joinKeyAlias, ok := featureProjection.JoinKeyMap[entityColumn.Name]; ok {
+					joinKey = joinKeyAlias
+				} else {
+					joinKey = entityColumn.Name
+				}
+
+				if _, ok := joinKeysSet[joinKey]; !ok {
+					joinKeys = append(joinKeys, joinKey)
+				}
+
+				joinKeysSet[joinKey] = nil
+				entityJoinKeyToType[joinKey] = entityColumn.Dtype
+			}
+		} else if sortedFv, ok := sortedFvMap[featureViewName]; ok {
+			for _, f := range featureProjection.Features {
+				fullFeatureName := getFullFeatureName(featureProjection.NameToUse(), f.Name)
+				features = append(features, fullFeatureName)
+				allFeatureTypes[fullFeatureName] = f.Dtype
+			}
+			for _, entityColumn := range sortedFv.EntityColumns {
 				var joinKey string
 				if joinKeyAlias, ok := featureProjection.JoinKeyMap[entityColumn.Name]; ok {
 					joinKey = joinKeyAlias

--- a/go/internal/feast/server/logging/service.go
+++ b/go/internal/feast/server/logging/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FeatureStore interface {
-	GetFcosMap() (map[string]*model.Entity, map[string]*model.FeatureView, map[string]*model.OnDemandFeatureView, error)
+	GetFcosMap() (map[string]*model.Entity, map[string]*model.FeatureView, map[string]*model.SortedFeatureView, map[string]*model.OnDemandFeatureView, error)
 	GetFeatureService(name string) (*model.FeatureService, error)
 }
 

--- a/go/internal/test/go_integration_test_utils.go
+++ b/go/internal/test/go_integration_test_utils.go
@@ -242,3 +242,10 @@ func CreateFeatureView(base *model.BaseFeatureView, ttl *durationpb.Duration, en
 		EntityColumns: entityColumns,
 	}
 }
+
+func CreateSortedFeatureView(base *model.BaseFeatureView, ttl *durationpb.Duration, entities []string, entityColumns []*model.Field, sortKeys []*model.SortKey) *model.SortedFeatureView {
+	return &model.SortedFeatureView{
+		FeatureView: CreateFeatureView(base, ttl, entities, entityColumns),
+		SortKeys:    sortKeys,
+	}
+}

--- a/protos/feast/core/SortedFeatureView.proto
+++ b/protos/feast/core/SortedFeatureView.proto
@@ -23,7 +23,6 @@ option java_outer_classname = "SortedFeatureViewProto";
 option java_package = "feast.proto.core";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
 import "feast/core/DataSource.proto";
 import "feast/core/Entity.proto";
 import "feast/core/Feature.proto";
@@ -118,4 +117,8 @@ message SortOrder {
         // Descending sorting order.
         DESC = 2;
     }
+}
+
+message SortedFeatureViewList {
+    repeated SortedFeatureView sorted_feature_views = 1;
 }


### PR DESCRIPTION
# What this PR does / why we need it:
Add SortedFeatureView to registry calls and feature service in Go feature server

# Which issue(s) this PR fixes:
- add missing list proto for SortedFeatureView
- add SortedFeatureView to registry calls and caching
- add SortedFeatureView to feature service
- add SortedFeatureView to feature/refs lookup

# Misc

