### PR TITLE
feat: Add Support for Range Query Retrievals in Go Grpc Server

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -155,37 +155,47 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		},
 	}
 
-	ts1 := timestamp.Timestamp{Seconds: now.Unix() - 86400*3}
-	ts2 := timestamp.Timestamp{Seconds: now.Unix() - 86400*2}
-	ts3 := timestamp.Timestamp{Seconds: now.Unix() - 86400*1}
-
 	mockRangeFeatureData := [][]onlinestore.RangeFeatureData{
 		{
 			{
-				FeatureView:     "driver_stats",
-				FeatureName:     "conv_rate",
-				Values:          []interface{}{0.85, 0.87, 0.89},
-				EventTimestamps: []timestamp.Timestamp{ts1, ts2, ts3},
+				FeatureView: "driver_stats",
+				FeatureName: "conv_rate",
+				Values:      []interface{}{0.85, 0.87, 0.89},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: now.Unix() - 86400*3},
+					{Seconds: now.Unix() - 86400*2},
+					{Seconds: now.Unix() - 86400*1},
+				},
 			},
 			{
-				FeatureView:     "driver_stats",
-				FeatureName:     "acc_rate",
-				Values:          []interface{}{0.91, 0.92, 0.94},
-				EventTimestamps: []timestamp.Timestamp{ts1, ts2, ts3},
+				FeatureView: "driver_stats",
+				FeatureName: "acc_rate",
+				Values:      []interface{}{0.91, 0.92, 0.94},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: now.Unix() - 86400*3},
+					{Seconds: now.Unix() - 86400*2},
+					{Seconds: now.Unix() - 86400*1},
+				},
 			},
 		},
 		{
 			{
-				FeatureView:     "driver_stats",
-				FeatureName:     "conv_rate",
-				Values:          []interface{}{0.78, 0.80},
-				EventTimestamps: []timestamp.Timestamp{ts1, ts3},
+				FeatureView: "driver_stats",
+				FeatureName: "conv_rate",
+				Values:      []interface{}{0.78, 0.80},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: now.Unix() - 86400*3},
+					{Seconds: now.Unix() - 86400*1},
+				},
 			},
 			{
-				FeatureView:     "driver_stats",
-				FeatureName:     "acc_rate",
-				Values:          []interface{}{0.85, 0.88},
-				EventTimestamps: []timestamp.Timestamp{ts1, ts3},
+				FeatureView: "driver_stats",
+				FeatureName: "acc_rate",
+				Values:      []interface{}{0.85, 0.88},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: now.Unix() - 86400*3},
+					{Seconds: now.Unix() - 86400*1},
+				},
 			},
 		},
 	}

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -2,15 +2,22 @@ package feast
 
 import (
 	"context"
-	"path/filepath"
-	"runtime"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
 	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
 	"github.com/feast-dev/feast/go/internal/feast/registry"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
 )
 
 // Return absolute path to the test_repo registry regardless of the working directory
@@ -69,4 +76,272 @@ func TestGetOnlineFeaturesRedis(t *testing.T) {
 		ctx, featureNames, nil, entities, map[string]*types.RepeatedValue{}, true)
 	assert.Nil(t, err)
 	assert.Len(t, response, 4) // 3 Features + 1 entity = 4 columns (feature vectors) in response
+}
+
+// MockOnlineStore implements the OnlineStore interface for testing without a real online store
+type MockOnlineStore struct {
+	mock.Mock
+}
+
+func (m *MockOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]onlinestore.FeatureData, error) {
+	args := m.Called(ctx, entityKeys, featureViewNames, featureNames)
+	return args.Get(0).([][]onlinestore.FeatureData), args.Error(1)
+}
+
+func (m *MockOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]onlinestore.RangeFeatureData, error) {
+	args := m.Called(ctx, entityRows, featureViewNames, featureNames, sortKeyFilters, reverseSortOrder, limit)
+	return args.Get(0).([][]onlinestore.RangeFeatureData), args.Error(1)
+}
+
+func (m *MockOnlineStore) Destruct() {
+	m.Called()
+}
+
+func TestGetOnlineFeaturesRange(t *testing.T) {
+	mockStore := new(MockOnlineStore)
+
+	// Set up test entities and feature views without using a registry
+	testEntity := &model.Entity{
+		Name:    "driver",
+		JoinKey: "driver_id",
+	}
+
+	sortKey := &model.SortKey{
+		FieldName: "event_timestamp",
+		ValueType: types.ValueType_UNIX_TIMESTAMP,
+	}
+
+	sortedFV := &model.SortedFeatureView{
+		FeatureView: &model.FeatureView{
+			Base: &model.BaseFeatureView{
+				Name: "driver_stats",
+			},
+			EntityNames: []string{"driver"},
+			Ttl:         &durationpb.Duration{Seconds: 86400},
+		},
+		SortKeys: []*model.SortKey{sortKey},
+	}
+
+	ctx := context.Background()
+	featureRefs := []string{"driver_stats:conv_rate", "driver_stats:acc_rate"}
+
+	entityValues := map[string]*types.RepeatedValue{
+		"driver_id": {
+			Val: []*types.Value{
+				{Val: &types.Value_Int64Val{Int64Val: 1001}},
+				{Val: &types.Value_Int64Val{Int64Val: 1002}},
+			},
+		},
+	}
+
+	now := time.Now()
+	oneWeekAgo := now.AddDate(0, 0, -7)
+
+	sortKeyFilters := []*serving.SortKeyFilter{
+		{
+			SortKeyName: "event_timestamp",
+			RangeStart: &types.Value{
+				Val: &types.Value_UnixTimestampVal{
+					UnixTimestampVal: oneWeekAgo.Unix(),
+				},
+			},
+			RangeEnd: &types.Value{
+				Val: &types.Value_UnixTimestampVal{
+					UnixTimestampVal: now.Unix(),
+				},
+			},
+			StartInclusive: true,
+			EndInclusive:   true,
+		},
+	}
+
+	ts1 := timestamp.Timestamp{Seconds: now.Unix() - 86400*3}
+	ts2 := timestamp.Timestamp{Seconds: now.Unix() - 86400*2}
+	ts3 := timestamp.Timestamp{Seconds: now.Unix() - 86400*1}
+
+	mockRangeFeatureData := [][]onlinestore.RangeFeatureData{
+		{
+			{
+				FeatureView:     "driver_stats",
+				FeatureName:     "conv_rate",
+				Values:          []interface{}{0.85, 0.87, 0.89},
+				EventTimestamps: []timestamp.Timestamp{ts1, ts2, ts3},
+			},
+			{
+				FeatureView:     "driver_stats",
+				FeatureName:     "acc_rate",
+				Values:          []interface{}{0.91, 0.92, 0.94},
+				EventTimestamps: []timestamp.Timestamp{ts1, ts2, ts3},
+			},
+		},
+		{
+			{
+				FeatureView:     "driver_stats",
+				FeatureName:     "conv_rate",
+				Values:          []interface{}{0.78, 0.80},
+				EventTimestamps: []timestamp.Timestamp{ts1, ts3},
+			},
+			{
+				FeatureView:     "driver_stats",
+				FeatureName:     "acc_rate",
+				Values:          []interface{}{0.85, 0.88},
+				EventTimestamps: []timestamp.Timestamp{ts1, ts3},
+			},
+		},
+	}
+
+	featureViewNamesMatcher := mock.MatchedBy(func(views []string) bool {
+		for _, view := range views {
+			if view != "driver_stats" {
+				return false
+			}
+		}
+		return len(views) > 0
+	})
+
+	mockStore.On("OnlineReadRange",
+		mock.Anything,
+		mock.AnythingOfType("[]*types.EntityKey"),
+		featureViewNamesMatcher,
+		[]string{"conv_rate", "acc_rate"},
+		sortKeyFilters,
+		false,
+		int32(0),
+	).Return(mockRangeFeatureData, nil)
+
+	result, err := testGetOnlineFeaturesRange(
+		ctx,
+		mockStore,
+		featureRefs,
+		[]*model.Entity{testEntity},
+		[]*model.SortedFeatureView{sortedFV},
+		entityValues,
+		sortKeyFilters,
+		false,
+		0,
+		nil,
+		true,
+	)
+
+	// Sort the result by name, so we can assert by index consistently
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, 3, len(result), "Should have 3 vectors (1 entity + 2 features)")
+	assert.Equal(t, "driver_id", result[0].Name)
+	assert.Equal(t, "driver_stats__acc_rate", result[1].Name)
+	assert.Equal(t, "driver_stats__conv_rate", result[2].Name)
+	assert.Equal(t, 2, len(result[1].RangeStatuses))
+	assert.Equal(t, 3, len(result[1].RangeStatuses[0]))
+	assert.Equal(t, 2, len(result[1].RangeStatuses[1]))
+	mockStore.AssertExpectations(t)
+}
+
+// This is a test helper function that mimics the core logic of FeatureStore.GetOnlineFeaturesRange
+// but accepts test data directly instead of using a registry
+// TODO: Refactor to use the real online store when the OnlineReadRange method is implemented.
+func testGetOnlineFeaturesRange(
+	ctx context.Context,
+	store onlinestore.OnlineStore,
+	featureRefs []string,
+	entities []*model.Entity,
+	sortedViews []*model.SortedFeatureView,
+	joinKeyToEntityValues map[string]*types.RepeatedValue,
+	sortKeyFilters []*serving.SortKeyFilter,
+	reverseSortOrder bool,
+	limit int32,
+	requestData map[string]*types.RepeatedValue,
+	fullFeatureNames bool) ([]*onlineserving.RangeFeatureVector, error) {
+
+	entityNameToJoinKeyMap := make(map[string]string)
+	for _, entity := range entities {
+		entityNameToJoinKeyMap[entity.Name] = entity.JoinKey
+	}
+
+	expectedJoinKeysSet := make(map[string]interface{})
+	for _, joinKey := range entityNameToJoinKeyMap {
+		expectedJoinKeysSet[joinKey] = nil
+	}
+
+	sortedFeatureViews := make([]*onlineserving.SortedFeatureViewAndRefs, 0)
+	for _, view := range sortedViews {
+		viewFeatures := make([]string, 0)
+		for _, featureRef := range featureRefs {
+			viewName, featureName, _ := onlineserving.ParseFeatureReference(featureRef)
+			if viewName == view.Base.Name {
+				viewFeatures = append(viewFeatures, featureName)
+			}
+		}
+
+		if len(viewFeatures) > 0 {
+			sortedFeatureViews = append(sortedFeatureViews, &onlineserving.SortedFeatureViewAndRefs{
+				View:        view,
+				FeatureRefs: viewFeatures,
+			})
+		}
+	}
+
+	numRows, err := onlineserving.ValidateEntityValues(joinKeyToEntityValues, requestData, expectedJoinKeysSet)
+	if err != nil {
+		return nil, err
+	}
+
+	err = onlineserving.ValidateSortKeyFilters(sortKeyFilters, sortedFeatureViews)
+	if err != nil {
+		return nil, err
+	}
+
+	arrowAllocator := memory.NewGoAllocator()
+	entityColumns, err := onlineserving.EntitiesToRangeFeatureVectors(
+		joinKeyToEntityValues, arrowAllocator, numRows)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*onlineserving.RangeFeatureVector, 0, len(entityColumns))
+	result = append(result, entityColumns...)
+
+	groupedRangeRefs, err := onlineserving.GroupSortedFeatureRefs(
+		sortedFeatureViews,
+		joinKeyToEntityValues,
+		entityNameToJoinKeyMap,
+		sortKeyFilters,
+		reverseSortOrder,
+		limit,
+		fullFeatureNames)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, groupRef := range groupedRangeRefs {
+		featureData, err := store.OnlineReadRange(
+			ctx,
+			groupRef.EntityKeys,
+			groupRef.FeatureViewNames,
+			groupRef.FeatureNames,
+			groupRef.SortKeyFilters,
+			groupRef.ReverseSortOrder,
+			groupRef.Limit)
+		if err != nil {
+			return nil, err
+		}
+
+		vectors, err := onlineserving.TransposeRangeFeatureRowsIntoColumns(
+			featureData,
+			groupRef,
+			sortedFeatureViews,
+			arrowAllocator,
+			numRows,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, vectors...)
+	}
+
+	return result, nil
 }

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -1,11 +1,16 @@
 package onlineserving
 
 import (
-	"testing"
-
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/protos/feast/core"
@@ -366,4 +371,291 @@ func TestUnpackFeatureViewsByReferences(t *testing.T) {
 		map[string]*model.OnDemandFeatureView{"odfv": onDemandView})
 
 	assertCorrectUnpacking(t, fvs, sortedFvs, odfvs, err)
+}
+
+func TestValidateSortKeyFilters(t *testing.T) {
+	sortKey1 := createSortKey("timestamp", core.SortOrder_DESC, types.ValueType_UNIX_TIMESTAMP)
+	sortKey2 := createSortKey("price", core.SortOrder_ASC, types.ValueType_DOUBLE)
+	sortKey3 := createSortKey("name", core.SortOrder_ASC, types.ValueType_STRING)
+
+	sfv1 := createSortedFeatureView("sfv1", []string{"driver"},
+		[]*core.SortKey{sortKey1, sortKey2},
+		createFeature("f1", types.ValueType_DOUBLE))
+
+	sfv2 := createSortedFeatureView("sfv2", []string{"customer"},
+		[]*core.SortKey{sortKey3},
+		createFeature("f2", types.ValueType_STRING))
+
+	sortedViews := []*SortedFeatureViewAndRefs{
+		{View: sfv1, FeatureRefs: []string{"f1"}},
+		{View: sfv2, FeatureRefs: []string{"f2"}},
+	}
+
+	validFilters := []*serving.SortKeyFilter{
+		{
+			SortKeyName:    "timestamp",
+			RangeStart:     &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1640995200}},
+			RangeEnd:       &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1672531200}},
+			StartInclusive: true,
+			EndInclusive:   false,
+		},
+		{
+			SortKeyName:    "price",
+			RangeStart:     &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 10.5}},
+			RangeEnd:       &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 50.0}},
+			StartInclusive: true,
+			EndInclusive:   true,
+		},
+	}
+
+	err := ValidateSortKeyFilters(validFilters, sortedViews)
+	assert.NoError(t, err, "Valid filters should not produce an error")
+
+	nonExistentKeyFilter := []*serving.SortKeyFilter{
+		{
+			SortKeyName: "non_existent_key",
+			RangeStart:  &types.Value{Val: &types.Value_Int64Val{Int64Val: 123}},
+		},
+	}
+
+	err = ValidateSortKeyFilters(nonExistentKeyFilter, sortedViews)
+	assert.Error(t, err, "Non-existent sort key should produce an error")
+	assert.Contains(t, err.Error(), "not found in any of the requested sorted feature views")
+
+	typeMismatchFilter := []*serving.SortKeyFilter{
+		{
+			SortKeyName: "timestamp",
+			RangeStart:  &types.Value{Val: &types.Value_StringVal{StringVal: "2022-01-01"}},
+		},
+	}
+
+	err = ValidateSortKeyFilters(typeMismatchFilter, sortedViews)
+	assert.Error(t, err, "Type mismatch should produce an error")
+	assert.Contains(t, err.Error(), "has incompatible type")
+}
+
+func TestGroupSortedFeatureRefs(t *testing.T) {
+	sortKey1 := createSortKey("timestamp", core.SortOrder_DESC, types.ValueType_UNIX_TIMESTAMP)
+	viewA := createSortedFeatureView("viewA", []string{"driver", "customer"},
+		[]*core.SortKey{sortKey1},
+		createFeature("featureA", types.ValueType_DOUBLE),
+		createFeature("featureB", types.ValueType_DOUBLE))
+
+	viewB := createSortedFeatureView("viewB", []string{"driver", "customer"},
+		[]*core.SortKey{sortKey1},
+		createFeature("featureC", types.ValueType_DOUBLE),
+		createFeature("featureD", types.ValueType_DOUBLE))
+
+	viewC := createSortedFeatureView("viewC", []string{"driver"},
+		[]*core.SortKey{sortKey1},
+		createFeature("featureE", types.ValueType_DOUBLE))
+
+	viewD := createSortedFeatureView("viewD", []string{"customer"},
+		[]*core.SortKey{sortKey1},
+		createFeature("featureF", types.ValueType_DOUBLE))
+
+	if viewA.Base != nil && viewA.Base.Projection == nil {
+		viewA.Base.Projection = &model.FeatureViewProjection{
+			NameAlias: "aliasViewA",
+		}
+	}
+
+	sortKeyFilters := []*serving.SortKeyFilter{
+		{
+			SortKeyName:    "timestamp",
+			RangeStart:     &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1640995200}},
+			RangeEnd:       &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1672531200}},
+			StartInclusive: true,
+			EndInclusive:   false,
+		},
+	}
+
+	refGroups, err := GroupSortedFeatureRefs(
+		[]*SortedFeatureViewAndRefs{
+			{View: viewA, FeatureRefs: []string{"featureA", "featureB"}},
+			{View: viewB, FeatureRefs: []string{"featureC", "featureD"}},
+			{View: viewC, FeatureRefs: []string{"featureE"}},
+			{View: viewD, FeatureRefs: []string{"featureF"}},
+		},
+		map[string]*types.RepeatedValue{
+			"driver_id": {Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 0}},
+				{Val: &types.Value_Int32Val{Int32Val: 0}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+			}},
+			"customer_id": {Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 2}},
+				{Val: &types.Value_Int32Val{Int32Val: 3}},
+				{Val: &types.Value_Int32Val{Int32Val: 3}},
+				{Val: &types.Value_Int32Val{Int32Val: 4}},
+			}},
+		},
+		map[string]string{
+			"driver":   "driver_id",
+			"customer": "customer_id",
+		},
+		sortKeyFilters,
+		false,
+		10,
+		true,
+	)
+
+	t.Logf("GroupSortedFeatureRefs returned %d groups", len(refGroups))
+	for i, group := range refGroups {
+		t.Logf("Group %d:", i)
+		t.Logf("  Features: %v", group.FeatureNames)
+		t.Logf("  AliasedNames: %v", group.AliasedFeatureNames)
+	}
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, refGroups, "Should return at least one group")
+
+	for _, group := range refGroups {
+		assert.Equal(t, sortKeyFilters, group.SortKeyFilters)
+		assert.Equal(t, false, group.ReverseSortOrder)
+		assert.Equal(t, int32(10), group.Limit)
+	}
+
+	featureAFound := false
+	featureCFound := false
+	featureEFound := false
+
+	for _, group := range refGroups {
+		for _, feature := range group.FeatureNames {
+			if feature == "featureA" {
+				featureAFound = true
+			}
+			if feature == "featureC" {
+				featureCFound = true
+			}
+			if feature == "featureE" {
+				featureEFound = true
+			}
+		}
+	}
+
+	assert.True(t, featureAFound, "Feature A should be present in results")
+	assert.True(t, featureCFound, "Feature C should be present in results")
+	assert.True(t, featureEFound, "Feature E should be present in results")
+}
+
+func TestEntitiesToRangeFeatureVectors(t *testing.T) {
+	entityColumns := map[string]*types.RepeatedValue{
+		"driver_id": {Val: []*types.Value{
+			{Val: &types.Value_Int32Val{Int32Val: 1}},
+			{Val: &types.Value_Int32Val{Int32Val: 2}},
+			{Val: &types.Value_Int32Val{Int32Val: 3}},
+		}},
+		"customer_id": {Val: []*types.Value{
+			{Val: &types.Value_StringVal{StringVal: "A"}},
+			{Val: &types.Value_StringVal{StringVal: "B"}},
+			{Val: &types.Value_StringVal{StringVal: "C"}},
+		}},
+	}
+
+	arrowAllocator := memory.NewGoAllocator()
+	numRows := 3
+
+	vectors, err := EntitiesToRangeFeatureVectors(entityColumns, arrowAllocator, numRows)
+
+	assert.NoError(t, err)
+	assert.Len(t, vectors, 2)
+
+	var driverVector, customerVector *RangeFeatureVector
+	for _, vector := range vectors {
+		if vector.Name == "driver_id" {
+			driverVector = vector
+		} else if vector.Name == "customer_id" {
+			customerVector = vector
+		}
+	}
+
+	require.NotNil(t, driverVector)
+	assert.Equal(t, "driver_id", driverVector.Name)
+	assert.Len(t, driverVector.RangeStatuses, numRows)
+	assert.Len(t, driverVector.RangeTimestamps, numRows)
+
+	for i := 0; i < numRows; i++ {
+		assert.Len(t, driverVector.RangeStatuses[i], 1)
+		assert.Equal(t, serving.FieldStatus_PRESENT, driverVector.RangeStatuses[i][0])
+		assert.Len(t, driverVector.RangeTimestamps[i], 1)
+	}
+
+	require.NotNil(t, customerVector)
+	assert.Equal(t, "customer_id", customerVector.Name)
+	assert.Len(t, customerVector.RangeStatuses, numRows)
+	assert.Len(t, customerVector.RangeTimestamps, numRows)
+
+	assert.NotNil(t, driverVector.RangeValues)
+	assert.NotNil(t, customerVector.RangeValues)
+
+	driverVector.RangeValues.Release()
+	customerVector.RangeValues.Release()
+}
+
+func TestTransposeRangeFeatureRowsIntoColumns(t *testing.T) {
+	arrowAllocator := memory.NewGoAllocator()
+	numRows := 2
+
+	sortKey1 := createSortKey("timestamp", core.SortOrder_DESC, types.ValueType_UNIX_TIMESTAMP)
+	sfv := createSortedFeatureView("testView", []string{"driver"}, []*core.SortKey{sortKey1},
+		createFeature("f1", types.ValueType_DOUBLE))
+
+	sortedViews := []*SortedFeatureViewAndRefs{
+		{View: sfv, FeatureRefs: []string{"f1"}},
+	}
+
+	groupRef := &GroupedRangeFeatureRefs{
+		FeatureNames:        []string{"f1"},
+		FeatureViewNames:    []string{"testView"},
+		AliasedFeatureNames: []string{"testView__f1"},
+		Indices:             [][]int{{0}, {1}},
+	}
+
+	nowTime := time.Now()
+	yesterdayTime := nowTime.Add(-24 * time.Hour)
+
+	featureData := [][]onlinestore.RangeFeatureData{
+		{
+			{
+				FeatureView: "testView",
+				FeatureName: "f1",
+				Values:      []interface{}{42.5, 43.2},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: nowTime.Unix()},
+					{Seconds: yesterdayTime.Unix()},
+				},
+			},
+		},
+		{
+			{
+				FeatureView: "testView",
+				FeatureName: "f1",
+				Values:      []interface{}{99.9},
+				EventTimestamps: []timestamp.Timestamp{
+					{Seconds: nowTime.Unix()},
+				},
+			},
+		},
+	}
+
+	vectors, err := TransposeRangeFeatureRowsIntoColumns(featureData, groupRef, sortedViews, arrowAllocator, numRows)
+
+	assert.NoError(t, err)
+	assert.Len(t, vectors, 1)
+	vector := vectors[0]
+	assert.Equal(t, "testView__f1", vector.Name)
+	assert.Len(t, vector.RangeStatuses, numRows)
+	assert.Len(t, vector.RangeTimestamps, numRows)
+	assert.Len(t, vector.RangeStatuses[0], 2)
+	assert.Len(t, vector.RangeTimestamps[0], 2)
+	assert.Equal(t, serving.FieldStatus_PRESENT, vector.RangeStatuses[0][0])
+	assert.Len(t, vector.RangeStatuses[1], 1)
+	assert.Len(t, vector.RangeTimestamps[1], 1)
+	assert.Equal(t, serving.FieldStatus_PRESENT, vector.RangeStatuses[1][0])
+	assert.NotNil(t, vector.RangeValues)
+	vector.RangeValues.Release()
 }

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -685,6 +685,10 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 	}
 }
 
+func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (c *CassandraOnlineStore) Destruct() {
 	c.session.Close()
 }

--- a/go/internal/feast/onlinestore/onlinestore.go
+++ b/go/internal/feast/onlinestore/onlinestore.go
@@ -16,6 +16,14 @@ type FeatureData struct {
 	Value     types.Value
 }
 
+type RangeFeatureData struct {
+	FeatureView     string
+	FeatureName     string
+	Values          []interface{}
+	Statuses        []serving.FieldStatus
+	EventTimestamps []timestamp.Timestamp
+}
+
 type OnlineStore interface {
 	// OnlineRead reads multiple features (specified in featureReferences) for multiple
 	// entity keys (specified in entityKeys) and returns an array of array of features,
@@ -36,6 +44,7 @@ type OnlineStore interface {
 	// => allocate memory for each field once in OnlineRead
 	// and reuse them in GetOnlineFeaturesResponse?
 	OnlineRead(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]FeatureData, error)
+	OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error)
 	// Destruct must be call once user is done using OnlineStore
 	// This is to comply with the Connector since we have to close the plugin
 	Destruct()

--- a/go/internal/feast/onlinestore/redisonlinestore.go
+++ b/go/internal/feast/onlinestore/redisonlinestore.go
@@ -332,6 +332,10 @@ func (r *RedisOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.E
 	return results, nil
 }
 
+func (r *RedisOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
+	return nil, errors.New("not implemented")
+}
+
 // Dummy destruct function to conform with plugin OnlineStore interface
 func (r *RedisOnlineStore) Destruct() {
 

--- a/go/internal/feast/onlinestore/sqliteonlinestore.go
+++ b/go/internal/feast/onlinestore/sqliteonlinestore.go
@@ -121,6 +121,10 @@ func (s *SqliteOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 	return results, nil
 }
 
+func (s *SqliteOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
+	return nil, errors.New("not implemented")
+}
+
 // Gets a sqlite connection and sets it to the online store and also returns a pointer to the connection.
 func (s *SqliteOnlineStore) getConnection() (*sql.DB, error) {
 	s.db_mu.Lock()

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -82,6 +82,105 @@ var (
 	}
 )
 
+var (
+	REPEATED_PROTO_VALUES = []*types.RepeatedValue{
+		{Val: []*types.Value{}},
+		{Val: []*types.Value{nil_or_null_val}},
+		{Val: []*types.Value{nil_or_null_val, nil_or_null_val}},
+		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{Int32Val: 20}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, nil_or_null_val}},
+		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_Int32Val{Int32Val: 20}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, nil_or_null_val, {Val: &types.Value_Int32Val{Int32Val: 30}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 10}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 10}}, {Val: &types.Value_Int64Val{Int64Val: 20}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 10}}, nil_or_null_val}},
+		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_Int64Val{Int64Val: 20}}}},
+		{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 9223372036854775807}}, {Val: &types.Value_Int64Val{Int64Val: -9223372036854775808}}}},
+		{Val: []*types.Value{{Val: &types.Value_FloatVal{FloatVal: 1.0}}}},
+		{Val: []*types.Value{{Val: &types.Value_FloatVal{FloatVal: 1.0}}, {Val: &types.Value_FloatVal{FloatVal: 2.0}}}},
+		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_FloatVal{FloatVal: 2.0}}}},
+		{Val: []*types.Value{{Val: &types.Value_FloatVal{FloatVal: 1.0}}, {Val: &types.Value_FloatVal{FloatVal: 2.0}}, {Val: &types.Value_FloatVal{FloatVal: float32(math.NaN())}}}},
+		{Val: []*types.Value{{Val: &types.Value_DoubleVal{DoubleVal: 1.0}}}},
+		{Val: []*types.Value{{Val: &types.Value_DoubleVal{DoubleVal: 1.0}}, {Val: &types.Value_DoubleVal{DoubleVal: 2.0}}}},
+		{Val: []*types.Value{{Val: &types.Value_DoubleVal{DoubleVal: 1.0}}, nil_or_null_val}},
+		{Val: []*types.Value{{Val: &types.Value_DoubleVal{DoubleVal: 1.0}}, {Val: &types.Value_DoubleVal{DoubleVal: 2.0}}, {Val: &types.Value_DoubleVal{DoubleVal: math.NaN()}}}},
+		{Val: []*types.Value{{Val: &types.Value_StringVal{StringVal: "aaa"}}}},
+		{Val: []*types.Value{{Val: &types.Value_StringVal{StringVal: "aaa"}}, {Val: &types.Value_StringVal{StringVal: "bbb"}}}},
+		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_StringVal{StringVal: "bbb"}}}},
+		{Val: []*types.Value{{Val: &types.Value_StringVal{StringVal: ""}}, {Val: &types.Value_StringVal{StringVal: "non-empty"}}}},
+		{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}}},
+		{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}, {Val: &types.Value_BytesVal{BytesVal: []byte{4, 5, 6}}}}},
+		{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}, nil_or_null_val}},
+		{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{}}}, {Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}}},
+		{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}}},
+		{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}, {Val: &types.Value_BoolVal{BoolVal: false}}}},
+		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_BoolVal{BoolVal: false}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix() + 3600}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, nil_or_null_val}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: -9223372036854775808}}}},
+	}
+)
+
+var (
+	MULTIPLE_REPEATED_PROTO_VALUES = [][]*types.RepeatedValue{
+		{
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 20}}}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
+			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 30}}}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 100}}}},
+			{Val: []*types.Value{}},
+			{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 300}}}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_StringVal{StringVal: "row1"}}}},
+			{Val: []*types.Value{{Val: &types.Value_StringVal{StringVal: "row2"}}}},
+		},
+		{
+			{Val: []*types.Value{
+				{Val: &types.Value_FloatVal{FloatVal: 1.1}},
+				{Val: &types.Value_FloatVal{FloatVal: 2.2}},
+			}},
+			{Val: []*types.Value{
+				{Val: &types.Value_FloatVal{FloatVal: 3.3}},
+				{Val: &types.Value_FloatVal{FloatVal: 4.4}},
+			}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}}},
+			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: false}}}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}}},
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix() + 3600}}}},
+		},
+		{
+			{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}}},
+			{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{4, 5, 6}}}}},
+		},
+		{
+			{Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 10}},
+				nil_or_null_val,
+				{Val: &types.Value_Int32Val{Int32Val: 30}},
+			}},
+			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 40}},
+				{Val: &types.Value_Int32Val{Int32Val: 50}},
+			}},
+		},
+	}
+)
+
 func TestConversionBetweenProtoAndArrow(t *testing.T) {
 	pool := memory.NewGoAllocator()
 	for _, vector := range PROTO_VALUES {
@@ -102,5 +201,190 @@ func protoValuesEquals(t *testing.T, a, b []*types.Value) {
 	for idx, left := range a {
 		assert.Truef(t, proto.Equal(left, b[idx]),
 			"Arrays are not equal. Diff[%d] %v != %v", idx, left, b[idx])
+	}
+}
+
+func TestRepeatedValueRoundTrip(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	for i, repeatedValue := range REPEATED_PROTO_VALUES {
+		arrowArray, err := RepeatedProtoValuesToArrowArray([]*types.RepeatedValue{repeatedValue}, pool, 1)
+		assert.Nil(t, err, "Error creating Arrow array for case %d", i)
+
+		result, err := ArrowValuesToRepeatedProtoValues(arrowArray)
+		assert.Nil(t, err, "Error converting back for case %d", i)
+
+		assert.Equal(t, 1, len(result), "Should have 1 result for case %d", i)
+
+		if len(repeatedValue.Val) == 0 {
+			if len(result[0].Val) > 1 {
+				t.Errorf("Case %d: Expected empty value or single null, got %d values",
+					i, len(result[0].Val))
+			} else if len(result[0].Val) == 1 && result[0].Val[0] != nil && result[0].Val[0].Val != nil {
+				t.Errorf("Case %d: Expected null value, got a non-null value", i)
+			}
+			continue
+		}
+
+		for j := 0; j < len(repeatedValue.Val); j++ {
+			if repeatedValue.Val[j] != nil && repeatedValue.Val[j].Val != nil {
+				if j >= len(result[0].Val) {
+					continue
+				}
+
+				switch v := repeatedValue.Val[j].Val.(type) {
+				case *types.Value_FloatVal:
+					if math.IsNaN(float64(v.FloatVal)) {
+						assert.True(t, math.IsNaN(float64(result[0].Val[j].GetFloatVal())),
+							"Float NaN not preserved at index %d in case %d", j, i)
+					} else {
+						assert.Equal(t, v.FloatVal, result[0].Val[j].GetFloatVal(),
+							"Float value mismatch at index %d in case %d", j, i)
+					}
+				case *types.Value_DoubleVal:
+					if math.IsNaN(v.DoubleVal) {
+						assert.True(t, math.IsNaN(result[0].Val[j].GetDoubleVal()),
+							"Double NaN not preserved at index %d in case %d", j, i)
+					} else {
+						assert.Equal(t, v.DoubleVal, result[0].Val[j].GetDoubleVal(),
+							"Double value mismatch at index %d in case %d", j, i)
+					}
+				default:
+					assert.True(t, proto.Equal(repeatedValue.Val[j], result[0].Val[j]),
+						"Value mismatch at index %d in case %d", j, i)
+				}
+			}
+		}
+	}
+}
+
+func TestMultipleRepeatedValueRoundTrip(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	for i, batch := range MULTIPLE_REPEATED_PROTO_VALUES {
+		arrowArray, err := RepeatedProtoValuesToArrowArray(batch, pool, len(batch))
+		assert.Nil(t, err, "Error creating Arrow array for batch %d", i)
+
+		results, err := ArrowValuesToRepeatedProtoValues(arrowArray)
+		assert.Nil(t, err, "Error converting back for batch %d", i)
+
+		assert.Equal(t, len(batch), len(results),
+			"Row count mismatch for batch %d", i)
+
+		for j := 0; j < len(batch); j++ {
+			original := batch[j]
+			result := results[j]
+
+			if len(original.Val) == 0 {
+				if len(result.Val) > 1 {
+					t.Errorf("Batch %d, row %d: Expected empty value or single null, got %d values",
+						i, j, len(result.Val))
+				} else if len(result.Val) == 1 && result.Val[0] != nil && result.Val[0].Val != nil {
+					t.Errorf("Batch %d, row %d: Expected null value, got a non-null value", i, j)
+				}
+				continue
+			}
+
+			for k := 0; k < len(original.Val); k++ {
+				if original.Val[k] != nil && original.Val[k].Val != nil {
+					if k >= len(result.Val) {
+						continue
+					}
+
+					switch v := original.Val[k].Val.(type) {
+					case *types.Value_FloatVal:
+						if math.IsNaN(float64(v.FloatVal)) {
+							assert.True(t, math.IsNaN(float64(result.Val[k].GetFloatVal())),
+								"Float NaN not preserved in batch %d, row %d, index %d", i, j, k)
+						} else {
+							assert.Equal(t, v.FloatVal, result.Val[k].GetFloatVal(),
+								"Float value mismatch in batch %d, row %d, index %d", i, j, k)
+						}
+					case *types.Value_DoubleVal:
+						if math.IsNaN(v.DoubleVal) {
+							assert.True(t, math.IsNaN(result.Val[k].GetDoubleVal()),
+								"Double NaN not preserved in batch %d, row %d, index %d", i, j, k)
+						} else {
+							assert.Equal(t, v.DoubleVal, result.Val[k].GetDoubleVal(),
+								"Double value mismatch in batch %d, row %d, index %d", i, j, k)
+						}
+					default:
+						assert.True(t, proto.Equal(original.Val[k], result.Val[k]),
+							"Value mismatch in batch %d, row %d, index %d", i, j, k)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestEmptyAndNullRepeatedValues(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	testCases := [][]*types.RepeatedValue{
+		{},
+		{{Val: []*types.Value{}}},
+		{{Val: []*types.Value{}}, {Val: []*types.Value{}}},
+		{{Val: []*types.Value{nil_or_null_val}}},
+		{{Val: []*types.Value{nil_or_null_val, nil_or_null_val}}},
+		{{Val: []*types.Value{}}, {Val: []*types.Value{nil_or_null_val}}},
+	}
+
+	for i, testCase := range testCases {
+		arrowArray, err := RepeatedProtoValuesToArrowArray(testCase, pool, len(testCase))
+		assert.Nil(t, err, "Error creating Arrow array for case %d", i)
+
+		result, err := ArrowValuesToRepeatedProtoValues(arrowArray)
+		assert.Nil(t, err, "Error converting back for case %d", i)
+
+		assert.Equal(t, len(testCase), len(result),
+			"Row count mismatch for case %d", i)
+
+		for j := 0; j < len(testCase); j++ {
+			if j < len(result) {
+				if len(testCase[j].Val) == 0 {
+					if len(result[j].Val) == 1 {
+						if result[j].Val[0] != nil && result[j].Val[0].Val != nil {
+							t.Errorf("Case %d, row %d: Expected empty value or null, got non-null value", i, j)
+						}
+					} else if len(result[j].Val) > 1 {
+						t.Errorf("Case %d, row %d: Expected empty or single null, got %d values",
+							i, j, len(result[j].Val))
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestProtoValuesToRepeatedConversion(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	testCases := [][]*types.Value{
+		{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{Int32Val: 20}}},
+		{{Val: &types.Value_StringVal{StringVal: "test"}}},
+		{nil_or_null_val, {Val: &types.Value_BoolVal{BoolVal: true}}},
+	}
+
+	for i, protoValues := range testCases {
+		arrowArray, err := ProtoValuesToArrowArray(protoValues, pool, len(protoValues))
+		assert.Nil(t, err, "Error creating Arrow array for case %d", i)
+
+		result, err := ArrowValuesToRepeatedProtoValues(arrowArray)
+		assert.Nil(t, err, "Error converting to RepeatedProtoValues for case %d", i)
+		assert.Equal(t, len(protoValues), len(result),
+			"Result count mismatch for case %d", i)
+
+		for j := 0; j < len(protoValues); j++ {
+			if protoValues[j] != nil && protoValues[j].Val != nil {
+				assert.Equal(t, 1, len(result[j].Val),
+					"Expected single value in RepeatedValue for case %d, row %d", i, j)
+
+				if len(result[j].Val) > 0 {
+					assert.True(t, proto.Equal(protoValues[j], result[j].Val[0]),
+						"Value mismatch in case %d, row %d", i, j)
+				}
+			}
+		}
 	}
 }

--- a/protos/feast/serving/GrpcServer.proto
+++ b/protos/feast/serving/GrpcServer.proto
@@ -31,4 +31,5 @@ service GrpcFeatureServer {
     rpc Push (PushRequest) returns (PushResponse) {};
     rpc WriteToOnlineStore (WriteToOnlineStoreRequest) returns (WriteToOnlineStoreResponse);
     rpc GetOnlineFeatures (feast.serving.GetOnlineFeaturesRequest) returns (feast.serving.GetOnlineFeaturesResponse);
+    rpc GetOnlineFeaturesRange (feast.serving.GetOnlineFeaturesRangeRequest) returns (feast.serving.GetOnlineFeaturesRangeResponse);
 }

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -115,6 +115,10 @@ message GetOnlineFeaturesResponseMetadata {
     FeatureList feature_names = 1;
 }
 
+message RepeatedFieldStatus {
+    repeated FieldStatus status = 1;
+}
+
 enum FieldStatus {
     // Status is unset for this field.
     INVALID = 0;
@@ -184,7 +188,7 @@ message GetOnlineFeaturesRangeResponse {
     message RangeFeatureVector {
         // Each values entry contains multiple values for a feature
         repeated feast.types.RepeatedValue values = 1;
-        repeated feast.types.RepeatedValue statuses = 2;
-        repeated google.protobuf.Timestamp event_timestamps = 3;
+        repeated RepeatedFieldStatus statuses = 2;
+        repeated feast.types.RepeatedValue event_timestamps = 3;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR adds support for range queries on sorted featureviews within the go grpc server. It adds the GetOnlineFeaturesRanges to the grpc server and the go feature store. Important to note that we're currently not supporting OnDemadFeatureViews or Feature Service usage with GetOnlineFeaturesRange.
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
