### PR TITLE
fix: Make Sorted feature view hashable

### DIFF
--- a/sdk/python/feast/sorted_feature_view.py
+++ b/sdk/python/feast/sorted_feature_view.py
@@ -63,6 +63,9 @@ class SortedFeatureView(FeatureView):
         if not _skip_validation:
             self.ensure_valid()
 
+    def __hash__(self):
+        return super().__hash__()
+
     def __copy__(self):
         sfv = SortedFeatureView(
             name=self.name,


### PR DESCRIPTION
I am trying to register a sorted feature view, but its failing:
https://github.expedia.biz/eg-ai-platform/mlpfs-scylladb-perf-test/actions/runs/34957239/job/54371136

And I am thinking its because hash() is not implemented for the sorted feature view. Hence I added it in this PR.