### PR TITLE
feat: Add serviceConfig to java-serving-client

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -134,16 +134,14 @@
 
     <!-- Release Java library on Sonatype https://central.sonatype.org/pages/apache-maven.html -->
     <distributionManagement>
-        <repository>
-            <id>eg-artylab-releases</id>
-            <name>EG Artylab Releases Repository</name>
-            <url>https://artylab.expedia.biz/eg-maven-release-local</url>
-        </repository>
         <snapshotRepository>
-            <id>eg-artylab-snapshots</id>
-            <name>EG Artifactory Snapshot Repository</name>
-            <url>https://artylab.expedia.biz/eg-maven-snapshot-local</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <profiles>
@@ -158,6 +156,21 @@
                     <family>mac</family>
                 </os>
             </activation>
+        </profile>
+        <profile>
+            <id>eg-release-dev</id>
+            <distributionManagement>
+                <repository>
+                    <id>eg-artylab-releases</id>
+                    <name>EG Artylab Releases Repository</name>
+                    <url>https://artylab.expedia.biz/eg-maven-release-local</url>
+                </repository>
+                <snapshotRepository>
+                    <id>eg-artylab-snapshots</id>
+                    <name>EG Artifactory Snapshot Repository</name>
+                    <url>https://artylab.expedia.biz/eg-maven-snapshot-local</url>
+                </snapshotRepository>
+            </distributionManagement>
         </profile>
     </profiles>
 
@@ -439,6 +452,20 @@
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
                     </additionalClasspathElements>
+                </configuration>
+            </plugin>
+            <!-- nexus-staging-maven-plugin configures Maven to deploy to OSSRH Nexus Repository Manager -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <!-- autoReleaseAfterClose is true as the release should be automated via continuous integration -->
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
             <!--

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -134,14 +134,16 @@
 
     <!-- Release Java library on Sonatype https://central.sonatype.org/pages/apache-maven.html -->
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>eg-artylab-releases</id>
+            <name>EG Artylab Releases Repository</name>
+            <url>https://artylab.expedia.biz/eg-maven-release-local</url>
         </repository>
+        <snapshotRepository>
+            <id>eg-artylab-snapshots</id>
+            <name>EG Artifactory Snapshot Repository</name>
+            <url>https://artylab.expedia.biz/eg-maven-snapshot-local</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <profiles>
@@ -437,20 +439,6 @@
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
                     </additionalClasspathElements>
-                </configuration>
-            </plugin>
-            <!-- nexus-staging-maven-plugin configures Maven to deploy to OSSRH Nexus Repository Manager -->
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <!-- autoReleaseAfterClose is true as the release should be automated via continuous integration -->
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
             <!--

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -158,6 +158,7 @@
             </activation>
         </profile>
         <profile>
+            <!-- DO NOT MERGE TO EG-FEAST. This is used by the maven-deploy lifecycle to push to artylab. -->
             <id>eg-release-dev</id>
             <distributionManagement>
                 <repository>

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -92,7 +92,7 @@ public class FeastClient implements AutoCloseable {
   }
 
   /**
-   * Create an authenticated client to access Feast Serving.
+   * Create an authenticated client to access Feast Serving with HTTP config values.
    *
    * @param url URL of Feast serving GRPC server
    * @param securityConfig security options to configure the Feast client. See {@link
@@ -101,13 +101,14 @@ public class FeastClient implements AutoCloseable {
    * @param serviceConfig see https://grpc.io/docs/guides/service-config/
    * @return {@link FeastClient}
    */
-  public static FeastClient createSecureWithTarget(
+  public static FeastClient createSecure(
       String url,
+      int port,
       SecurityConfig securityConfig,
       long requestTimeout,
       Map<String, Object> serviceConfig) {
     NettyChannelBuilder nettyChannelBuilder =
-        NettyChannelBuilder.forTarget(url).defaultServiceConfig(serviceConfig);
+        NettyChannelBuilder.forAddress(url, port).defaultServiceConfig(serviceConfig);
 
     if (securityConfig.isTLSEnabled()) {
       nettyChannelBuilder.useTransportSecurity();
@@ -128,7 +129,7 @@ public class FeastClient implements AutoCloseable {
    * @return {@link FeastClient}
    */
   public static FeastClient createSecure(
-      String host, int port, SecurityConfig securityConfig, long requestTimeout, Optional<Map<String, Object>> serviceConfig) {
+      String host, int port, SecurityConfig securityConfig, long requestTimeout) {
 
     if (requestTimeout < 0) {
       throw new IllegalArgumentException("Request timeout can't be negative");
@@ -146,7 +147,6 @@ public class FeastClient implements AutoCloseable {
               NettyChannelBuilder.forAddress(host, port)
                   .useTransportSecurity()
                   .sslContext(GrpcSslContexts.forClient().trustManager(certificateFile).build())
-                  .defaultServiceConfig(serviceConfig.get())
                   .build();
         } catch (SSLException e) {
           throw new IllegalArgumentException(

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -92,6 +92,31 @@ public class FeastClient implements AutoCloseable {
   }
 
   /**
+   * Create an authenticated client to access Feast Serving.
+   *
+   * @param url URL of Feast serving GRPC server
+   * @param securityConfig security options to configure the Feast client. See {@link
+   *     SecurityConfig}
+   * @param requestTimeout grpc deadline/netty http2 timeout
+   * @param serviceConfig see https://grpc.io/docs/guides/service-config/
+   * @return {@link FeastClient}
+   */
+  public static FeastClient createSecureWithTarget(
+      String url,
+      SecurityConfig securityConfig,
+      long requestTimeout,
+      Map<String, Object> serviceConfig) {
+    NettyChannelBuilder nettyChannelBuilder =
+        NettyChannelBuilder.forTarget(url).defaultServiceConfig(serviceConfig);
+
+    if (securityConfig.isTLSEnabled()) {
+      nettyChannelBuilder.useTransportSecurity();
+    }
+
+    return new FeastClient(nettyChannelBuilder.build(), Optional.empty(), requestTimeout);
+  }
+
+  /**
    * Create an authenticated client that can access Feast serving with authentication enabled.
    *
    * @param host hostname or ip address of Feast serving GRPC server

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -128,7 +128,7 @@ public class FeastClient implements AutoCloseable {
    * @return {@link FeastClient}
    */
   public static FeastClient createSecure(
-      String host, int port, SecurityConfig securityConfig, long requestTimeout) {
+      String host, int port, SecurityConfig securityConfig, long requestTimeout, Optional<Map<String, Object>> serviceConfig) {
 
     if (requestTimeout < 0) {
       throw new IllegalArgumentException("Request timeout can't be negative");
@@ -146,6 +146,7 @@ public class FeastClient implements AutoCloseable {
               NettyChannelBuilder.forAddress(host, port)
                   .useTransportSecurity()
                   .sslContext(GrpcSslContexts.forClient().trustManager(certificateFile).build())
+                  .defaultServiceConfig(serviceConfig.get())
                   .build();
         } catch (SSLException e) {
           throw new IllegalArgumentException(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it: (NOT DO NOT MERGE POM.XML TO EG-FEAST)
1/ Add [serviceConfig](https://grpc.io/docs/guides/service-config/)  to client. This allows a consumer to specify HTTP 2.0 specifications, such as configuring retries/timeout/etc.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
N/A