### PR TITLE
feat: Add hybrid server type, spins up both http/gRPC servers

### DIFF
--- a/go/embedded/online_features.go
+++ b/go/embedded/online_features.go
@@ -383,7 +383,7 @@ func (s *OnlineFeatureService) StartHttpServerWithLogging(host string, port int,
 		log.Println("HTTP server terminated")
 	}()
 
-	return ser.Serve(host, port)
+	return ser.Serve(host, port, server.defaultHttpHandlers(ser))
 }
 
 func (s *OnlineFeatureService) StopHttpServer() {

--- a/go/embedded/online_features.go
+++ b/go/embedded/online_features.go
@@ -383,7 +383,7 @@ func (s *OnlineFeatureService) StartHttpServerWithLogging(host string, port int,
 		log.Println("HTTP server terminated")
 	}()
 
-	return ser.Serve(host, port, server.defaultHttpHandlers(ser))
+	return ser.Serve(host, port, server.DefaultHttpHandlers(ser))
 }
 
 func (s *OnlineFeatureService) StopHttpServer() {

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -17,7 +17,6 @@ import (
 
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	_ "go.uber.org/automaxprocs"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	grpcTrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
 )
@@ -212,10 +211,8 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 }
 
 // Register services used by the grpcServingServiceServer.
-// Any middleware configs should be specified here.
 func (s *grpcServingServiceServer) RegisterServices() (*grpc.Server, *health.Server) {
 	grpcPromMetrics := grpcPrometheus.NewServerMetrics()
-	// mustRegister publishes to the defaultRegistrar
 	prometheus.MustRegister(grpcPromMetrics)
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(grpcTrace.UnaryServerInterceptor(), grpcPromMetrics.UnaryServerInterceptor()),

--- a/go/internal/feast/server/hybrid_server.go
+++ b/go/internal/feast/server/hybrid_server.go
@@ -11,7 +11,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-var defaultCheckTimeout = 10 * time.Second
+var defaultCheckTimeout = 2 * time.Second
 
 // Register default HTTP handlers specific to the hybrid server configuration.
 func DefaultHybridHandlers(s *httpServer, hs *health.Server) []Handler {
@@ -31,13 +31,11 @@ func DefaultHybridHandlers(s *httpServer, hs *health.Server) []Handler {
 	}
 }
 
-// Closure that injects health.Server during registration of http.Handler
+// This function wraps an http.Handler that is registered during hybrid server creation.
+// Calls the grpc.server healthcheck check endpoint
 func combinedHealthCheck(hs *health.Server) http.HandlerFunc {
-	// This function should be registered within the httpHandler.
-	// Calls the grpc.server healthcheck check endpoint. Saves us a call to gRPC dial.
-
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(context.Background(), defaultCheckTimeout)
+		ctx, cancel := context.WithTimeout(r.Context(), defaultCheckTimeout)
 		defer cancel()
 
 		req := &healthpb.HealthCheckRequest{

--- a/go/internal/feast/server/hybrid_server.go
+++ b/go/internal/feast/server/hybrid_server.go
@@ -1,0 +1,67 @@
+// These contain configs/methods that are used by the hybrid server function.
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var defaultCheckTimeout = 10 * time.Second
+
+// Register default HTTP handlers specific to the hybrid server configuration.
+func DefaultHybridHandlers(s *httpServer, hs *health.Server) []Handler {
+	return []Handler{
+		{
+			path:        "/get-online-features",
+			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeatures)),
+		},
+		{
+			path:        "/metrics",
+			handlerFunc: promhttp.Handler(),
+		},
+		{
+			path:        "/health",
+			handlerFunc: http.HandlerFunc(combinedHealthCheck(hs)),
+		},
+	}
+}
+
+// Closure that injects health.Server during registration of http.Handler
+func combinedHealthCheck(hs *health.Server) http.HandlerFunc {
+	// This function should be registered within the httpHandler.
+	// Calls the grpc.server healthcheck check endpoint. Saves us a call to gRPC dial.
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(d, defaultCheckTimeout)
+		defer cancel()
+
+		req := &healthpb.HealthCheckRequest{
+			Service: "", // Empty string means that it will simply check overall servingStatus
+		}
+
+		resp, err := hs.Check(ctx, req)
+		if err != nil {
+			http.Error(w, "gRPC health check failed", http.StatusInternalServerError)
+			return
+		}
+
+		// Use to map servingStatus to httpStatus
+		var status int
+		switch resp.Status {
+		case healthpb.HealthCheckResponse_SERVING:
+			status = http.StatusOK
+		case healthpb.HealthCheckResponse_NOT_SERVING:
+			status = http.StatusServiceUnavailable
+		default:
+			status = http.StatusInternalServerError
+		}
+
+		w.WriteHeader(status)
+		w.Write([]byte(resp.Status.String()))
+	}
+}

--- a/go/internal/feast/server/hybrid_server.go
+++ b/go/internal/feast/server/hybrid_server.go
@@ -37,7 +37,7 @@ func combinedHealthCheck(hs *health.Server) http.HandlerFunc {
 	// Calls the grpc.server healthcheck check endpoint. Saves us a call to gRPC dial.
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(d, defaultCheckTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultCheckTimeout)
 		defer cancel()
 
 		req := &healthpb.HealthCheckRequest{

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -1,18 +1,11 @@
 package server
 
 import (
-	"net/http"
 	"os"
 
 	"github.com/rs/zerolog"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
-
-// This represents mapping between
-type Handler struct {
-	path        string
-	handlerFunc http.Handler
-}
 
 func LogWithSpanContext(span tracer.Span) zerolog.Logger {
 	spanContext := span.Context()

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -1,10 +1,18 @@
 package server
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/rs/zerolog"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"os"
 )
+
+// This represents mapping between
+type Handler struct {
+	path        string
+	handlerFunc http.Handler
+}
 
 func LogWithSpanContext(span tracer.Span) zerolog.Logger {
 	spanContext := span.Context()

--- a/go/main.go
+++ b/go/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"google.golang.org/grpc/reflection"
 	"net"
 	"net/http"
 	"os"
@@ -15,33 +14,31 @@ import (
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/feast-dev/feast/go/internal/feast/server"
 	"github.com/feast-dev/feast/go/internal/feast/server/logging"
-	"github.com/feast-dev/feast/go/protos/feast/serving"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
-	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	_ "go.uber.org/automaxprocs"
-	grpcTrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 type ServerStarter interface {
-	StartHttpServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error
-	StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error
+	StartHttpServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error
+	StartGrpcServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error
+	StartHybridServer(fs *feast.FeatureStore, host string, httpPort int, grpcPort int, loggingService *logging.LoggingService) error
 }
 
 type RealServerStarter struct{}
 
-func (s *RealServerStarter) StartHttpServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error {
-	return StartHttpServer(fs, host, port, writeLoggedFeaturesCallback, loggingOpts)
+func (s *RealServerStarter) StartHttpServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error {
+	return StartHttpServer(fs, host, port, loggingService)
 }
 
-func (s *RealServerStarter) StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error {
-	return StartGrpcServer(fs, host, port, writeLoggedFeaturesCallback, loggingOpts)
+func (s *RealServerStarter) StartGrpcServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error {
+	return StartGrpcServer(fs, host, port, loggingService)
+}
+
+func (s *RealServerStarter) StartHybridServer(fs *feast.FeatureStore, host string, httpPort int, grpcPort int, loggingService *logging.LoggingService) error {
+	return StartHybridServer(fs, host, httpPort, grpcPort, loggingService)
 }
 
 func main() {
@@ -80,22 +77,23 @@ func main() {
 		log.Fatal().Stack().Err(err).Msg("Failed to get LoggingOptions")
 	}
 
+	loggingService, err := constructLoggingService(fs, nil, loggingOptions)
+	if err != nil {
+		log.Fatal().Stack().Err(err).Msg("Failed to create loggingService")
+	}
+
 	// TODO: writeLoggedFeaturesCallback is defaulted to nil. write_logged_features functionality needs to be
 	// implemented in Golang specific to OfflineStoreSink. Python Feature Server doesn't support this.
-	if serverType == "http" {
-		err = server.StartHttpServer(fs, host, port, nil, loggingOptions)
-	} else if serverType == "grpc" {
-		err = server.StartGrpcServer(fs, host, port, nil, loggingOptions)
-	} else if serverType == "hybrid" {
-		go func() {
-			err := server.StartHttpServer(fs, host, port, nil, loggingOptions)
-			if err != nil {
-				log.Fatal().Stack().Err(err).Msg("Failed to start HTTP server")
-			}
-		}()
-		err = server.StartGrpcServer(fs, host, grpcPort, nil, loggingOptions)
-	} else {
-		fmt.Println("Unknown server type. Please specify 'http' or 'grpc'.")
+	switch serverType {
+	case "http":
+		err = server.StartHttpServer(fs, host, port, loggingService)
+	case "grpc":
+		err = server.StartGrpcServer(fs, host, port, loggingService)
+	case "hybrid":
+		// hybrid starts both gRPC(on gRPC port) & http(on port)
+		err = server.StartHybridServer(fs, host, port, grpcPort, loggingService)
+	default:
+		fmt.Println("Unknown server type. Please specify 'http', 'grpc', or 'hybrid'.")
 	}
 
 	if err != nil {
@@ -125,16 +123,13 @@ func constructLoggingService(fs *feast.FeatureStore, writeLoggedFeaturesCallback
 	return loggingService, nil
 }
 
-// StartGprcServerWithLogging starts gRPC server with enabled feature logging
-func StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error {
+// StartGrpcServerWithLogging creates a gRPC server with enabled feature logging
+func StartGrpcServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error {
 	if strings.ToLower(os.Getenv("ENABLE_DATADOG_TRACING")) == "true" {
 		tracer.Start(tracer.WithRuntimeMetrics())
 		defer tracer.Stop()
 	}
-	loggingService, err := constructLoggingService(fs, writeLoggedFeaturesCallback, loggingOpts)
-	if err != nil {
-		return err
-	}
+
 	ser := server.NewGrpcServingServiceServer(fs, loggingService)
 	log.Info().Msgf("Starting a gRPC server on host %s port %d", host, port)
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
@@ -142,15 +137,7 @@ func StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedF
 		return err
 	}
 
-	grpcPromMetrics := grpcPrometheus.NewServerMetrics()
-	prometheus.MustRegister(grpcPromMetrics)
-	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(grpcTrace.UnaryServerInterceptor(), grpcPromMetrics.UnaryServerInterceptor()),
-	)
-	serving.RegisterServingServiceServer(grpcServer, ser)
-	healthService := health.NewServer()
-	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
-	reflection.Register(grpcServer)
+	grpcServer, _ := ser.RegisterServices()
 
 	// Running Prometheus metrics endpoint on a separate goroutine
 	go func() {
@@ -176,14 +163,10 @@ func StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedF
 	return grpcServer.Serve(lis)
 }
 
-// StartHttpServerWithLogging starts HTTP server with enabled feature logging
+// StartHttpServerWithLogging creates an HTTP server with enabled feature logging
 // Go does not allow direct assignment to package-level functions as a way to
 // mock them for tests
-func StartHttpServer(fs *feast.FeatureStore, host string, port int, writeLoggedFeaturesCallback logging.OfflineStoreWriteCallback, loggingOpts *logging.LoggingOptions) error {
-	loggingService, err := constructLoggingService(fs, writeLoggedFeaturesCallback, loggingOpts)
-	if err != nil {
-		return err
-	}
+func StartHttpServer(fs *feast.FeatureStore, host string, port int, loggingService *logging.LoggingService) error {
 	ser := server.NewHttpServer(fs, loggingService)
 	log.Info().Msgf("Starting a HTTP server on host %s, port %d", host, port)
 
@@ -191,7 +174,7 @@ func StartHttpServer(fs *feast.FeatureStore, host string, port int, writeLoggedF
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		// As soon as these signals are received from OS, try to gracefully stop the gRPC server
+		// As soon as these signals are received from OS, try to gracefully stop the HTTP server
 		<-stop
 		log.Info().Msg("Stopping the HTTP server...")
 		err := ser.Stop()
@@ -204,5 +187,59 @@ func StartHttpServer(fs *feast.FeatureStore, host string, port int, writeLoggedF
 		log.Info().Msg("HTTP server terminated")
 	}()
 
-	return ser.Serve(host, port)
+	return ser.Serve(host, port, server.DefaultHttpHandlers(ser))
+}
+
+// StartHybridServer creates a gRPCServer and HTTPServer on port: port, gRPC port: grpc
+// Stops both servers if a stop signal is recieved.
+func StartHybridServer(fs *feast.FeatureStore, host string, httpPort int, grpcPort int, loggingService *logging.LoggingService) error {
+	if strings.ToLower(os.Getenv("ENABLE_DATADOG_TRACING")) == "true" {
+		tracer.Start(tracer.WithRuntimeMetrics())
+		defer tracer.Stop()
+	}
+
+	ser := server.NewGrpcServingServiceServer(fs, loggingService)
+	log.Info().Msgf("Starting a gRPC server on host %s port %d", host, grpcPort)
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, grpcPort))
+	if err != nil {
+		return err
+	}
+
+	grpcSer, healthService := ser.RegisterServices()
+
+	if err != nil {
+		return err
+	}
+
+	httpSer := server.NewHttpServer(fs, loggingService)
+	log.Info().Msgf("Starting a HTTP server on host %s, port %d", host, httpPort)
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		// As soon as these signals are received from OS, try to gracefully stop the HTTP server
+		<-stop
+		log.Info().Msg("Stopping the HTTP server...")
+		err := httpSer.Stop()
+		if err != nil {
+			log.Error().Err(err).Msg("Error when stopping the HTTP server")
+		}
+
+		log.Info().Msg("Stopping the gRPC server...")
+		grpcSer.GracefulStop()
+
+		if loggingService != nil {
+			loggingService.Stop()
+		}
+		log.Info().Msg("HTTP server terminated")
+	}()
+
+	err = httpSer.Serve(host, httpPort, server.DefaultHybridHandlers(httpSer, healthService))
+
+	if err != nil {
+		return err
+	}
+
+	return grpcSer.Serve(lis)
 }


### PR DESCRIPTION
Changelist: 

1/ Created type `StartHybridServer` which starts both http/gRPC servers 
2/ Added combinedHealthCheck method. 

Context on combinedHealthCheck: 
Kubernetes does readiness/liveness probes via the health endpoint(note that both checks simply poll this endpoint). The general pattern is to configure a single probe per container. As we are creating two independent servers we need to have a combined health-check to validate that both servers are healthy. Kubernetes should probe via the /health endpoint and simply validates that the status is in 200-399.

https://grpc.io/docs/guides/health-checking/
https://github.com/kubernetes/kubernetes/blob/ef838fcc3fa3b43c2e67b4e43d71b6720fc61898/pkg/probe/grpc/grpc.go#L53

Looking for feedback here, there may be a better way to do this. One concern is latency increase as .Check calls should be frequent(defined by _periodSeconds_ helm chart value).

3/ Added defaultHttpHander & defaultHybridHandler. This makes it easier to modify the behavior between hybridServer/httpServer in terms of the handlers they provide while keeping the internals the same(both call httpServer.Serve). 