### PR TITLE
feat: Go range query implementation for scylladb

### DIFF
--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -290,7 +290,6 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 			groupRef.FeatureViewNames,
 			groupRef.FeatureNames,
 			groupRef.SortKeyFilters,
-			groupRef.ReverseSortOrder,
 			groupRef.Limit)
 		if err != nil {
 			return nil, err
@@ -503,8 +502,7 @@ func (fs *FeatureStore) readRangeFromOnlineStore(
 	entityRows []*prototypes.EntityKey,
 	requestedFeatureViewNames []string,
 	requestedFeatureNames []string,
-	sortKeyFilters []*serving.SortKeyFilter,
-	reverseSortOrder bool,
+	sortKeyFilters []*model.SortKeyFilter,
 	limit int32) ([][]onlinestore.RangeFeatureData, error) {
 
 	span, _ := tracer.StartSpanFromContext(ctx, "fs.readRangeFromOnlineStore")
@@ -525,7 +523,6 @@ func (fs *FeatureStore) readRangeFromOnlineStore(
 		requestedFeatureViewNames,
 		requestedFeatureNames,
 		sortKeyFilters,
-		reverseSortOrder,
 		limit)
 }
 

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -339,9 +339,9 @@ func (fs *FeatureStore) ParseFeatures(kind interface{}) (*Features, error) {
 		}
 		return &Features{FeaturesRefs: nil, FeatureService: featureService}, nil
 	case *serving.GetOnlineFeaturesRangeRequest_FeatureService:
-		return nil, errors.New("range requests only support feature refs")
+		return nil, errors.New("range requests only support 'kind' of a list of Features")
 	default:
-		return nil, errors.New("cannot parse 'kind' from request")
+		return nil, errors.New("cannot parse 'kind' of either a Feature Service or list of Features from request")
 	}
 }
 

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -258,6 +258,10 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 		return nil, err
 	}
 
+	if limit < 0 {
+		return nil, fmt.Errorf("limit must be non-negative, got %d", limit)
+	}
+
 	entitylessCase := checkEntitylessCase(requestedSortedFeatureViews)
 	addDummyEntityIfNeeded(entitylessCase, joinKeyToEntityValues, numRows)
 

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -270,16 +270,6 @@ func testGetOnlineFeaturesRange(
 	requestData map[string]*types.RepeatedValue,
 	fullFeatureNames bool) ([]*onlineserving.RangeFeatureVector, error) {
 
-	entityNameToJoinKeyMap := make(map[string]string)
-	for _, entity := range entities {
-		entityNameToJoinKeyMap[entity.Name] = entity.JoinKey
-	}
-
-	expectedJoinKeysSet := make(map[string]interface{})
-	for _, joinKey := range entityNameToJoinKeyMap {
-		expectedJoinKeysSet[joinKey] = nil
-	}
-
 	sortedFeatureViews := make([]*onlineserving.SortedFeatureViewAndRefs, 0)
 	for _, view := range sortedViews {
 		viewFeatures := make([]string, 0)
@@ -296,6 +286,11 @@ func testGetOnlineFeaturesRange(
 				FeatureRefs: viewFeatures,
 			})
 		}
+	}
+	entityNameToJoinKeyMap, expectedJoinKeysSet, err := onlineserving.GetEntityMapsForSortedViews(
+		sortedFeatureViews, entities)
+	if err != nil {
+		return nil, err
 	}
 
 	numRows, err := onlineserving.ValidateEntityValues(joinKeyToEntityValues, requestData, expectedJoinKeysSet)

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -88,8 +88,8 @@ func (m *MockOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.En
 	return args.Get(0).([][]onlinestore.FeatureData), args.Error(1)
 }
 
-func (m *MockOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]onlinestore.RangeFeatureData, error) {
-	args := m.Called(ctx, entityRows, featureViewNames, featureNames, sortKeyFilters, reverseSortOrder, limit)
+func (m *MockOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*model.SortKeyFilter, limit int32) ([][]onlinestore.RangeFeatureData, error) {
+	args := m.Called(ctx, entityRows, featureViewNames, featureNames, sortKeyFilters, limit)
 	return args.Get(0).([][]onlinestore.RangeFeatureData), args.Error(1)
 }
 
@@ -333,7 +333,6 @@ func testGetOnlineFeaturesRange(
 			groupRef.FeatureViewNames,
 			groupRef.FeatureNames,
 			groupRef.SortKeyFilters,
-			groupRef.ReverseSortOrder,
 			groupRef.Limit)
 		if err != nil {
 			return nil, err

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
 	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
 	"github.com/feast-dev/feast/go/internal/feast/registry"
+	"github.com/feast-dev/feast/go/protos/feast/core"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -109,6 +110,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	sortKey := &model.SortKey{
 		FieldName: "event_timestamp",
 		ValueType: types.ValueType_UNIX_TIMESTAMP,
+		Order:     model.NewSortOrderFromProto(core.SortOrder_ASC),
 	}
 
 	sortedFV := &model.SortedFeatureView{
@@ -153,6 +155,9 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 			StartInclusive: true,
 			EndInclusive:   true,
 		},
+	}
+	sortKeyFilterModels := []*model.SortKeyFilter{
+		model.NewSortKeyFilterFromProto(sortKeyFilters[0], core.SortOrder_ASC),
 	}
 
 	mockRangeFeatureData := [][]onlinestore.RangeFeatureData{
@@ -214,8 +219,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		mock.AnythingOfType("[]*types.EntityKey"),
 		featureViewNamesMatcher,
 		[]string{"conv_rate", "acc_rate"},
-		sortKeyFilters,
-		false,
+		sortKeyFilterModels,
 		int32(0),
 	).Return(mockRangeFeatureData, nil)
 

--- a/go/internal/feast/model/sortedfeatureview.go
+++ b/go/internal/feast/model/sortedfeatureview.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
 )
 
@@ -72,5 +73,25 @@ func (sfv *SortedFeatureView) NewSortedFeatureViewFromBase(base *BaseFeatureView
 	return &SortedFeatureView{
 		FeatureView: newFV,
 		SortKeys:    sfv.SortKeys,
+	}
+}
+
+type SortKeyFilter struct {
+	SortKeyName    string
+	RangeStart     interface{}
+	RangeEnd       interface{}
+	StartInclusive bool
+	EndInclusive   bool
+	Order          *SortOrder
+}
+
+func NewSortKeyFilterFromProto(proto *serving.SortKeyFilter, sortOrder core.SortOrder_Enum) *SortKeyFilter {
+	return &SortKeyFilter{
+		SortKeyName:    proto.GetSortKeyName(),
+		RangeStart:     proto.GetRangeStart(),
+		RangeEnd:       proto.GetRangeEnd(),
+		StartInclusive: proto.GetStartInclusive(),
+		EndInclusive:   proto.GetEndInclusive(),
+		Order:          NewSortOrderFromProto(sortOrder),
 	}
 }

--- a/go/internal/feast/model/sortedfeatureview.go
+++ b/go/internal/feast/model/sortedfeatureview.go
@@ -4,6 +4,7 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/core"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
+	types2 "github.com/feast-dev/feast/go/types"
 )
 
 type SortOrder struct {
@@ -55,6 +56,16 @@ func NewSortedFeatureViewFromProto(proto *core.SortedFeatureView) *SortedFeature
 		Base: NewBaseFeatureView(proto.GetSpec().GetName(), proto.GetSpec().GetFeatures()),
 		Ttl:  proto.GetSpec().GetTtl(),
 	}
+	if len(proto.Spec.Entities) == 0 {
+		baseFV.EntityNames = []string{DUMMY_ENTITY_NAME}
+	} else {
+		baseFV.EntityNames = proto.Spec.Entities
+	}
+	entityColumns := make([]*Field, len(proto.Spec.EntityColumns))
+	for i, entityColumn := range proto.Spec.EntityColumns {
+		entityColumns[i] = NewFieldFromProto(entityColumn)
+	}
+	baseFV.EntityColumns = entityColumns
 
 	// Convert each sort key from the proto.
 	sortKeys := make([]*SortKey, len(proto.GetSpec().GetSortKeys()))
@@ -88,8 +99,8 @@ type SortKeyFilter struct {
 func NewSortKeyFilterFromProto(proto *serving.SortKeyFilter, sortOrder core.SortOrder_Enum) *SortKeyFilter {
 	return &SortKeyFilter{
 		SortKeyName:    proto.GetSortKeyName(),
-		RangeStart:     proto.GetRangeStart(),
-		RangeEnd:       proto.GetRangeEnd(),
+		RangeStart:     types2.ValueTypeToGoType(proto.GetRangeStart()),
+		RangeEnd:       types2.ValueTypeToGoType(proto.GetRangeEnd()),
 		StartInclusive: proto.GetStartInclusive(),
 		EndInclusive:   proto.GetEndInclusive(),
 		Order:          NewSortOrderFromProto(sortOrder),

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -369,7 +369,9 @@ func GetEntityMapsForSortedViews(sortedViews []*SortedFeatureViewAndRefs, entiti
 		}
 
 		for _, entityName := range featureView.EntityNames {
-			joinKey := entitiesByName[entityName].JoinKey
+			entity := entitiesByName[entityName]
+			joinKey := entity.JoinKey
+
 			entityNameToJoinKeyMap[entityName] = joinKey
 
 			if alias, ok := joinKeyToAliasMap[joinKey]; ok {

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -6,18 +6,18 @@ import (
 	"fmt"
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
+	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
+	prototypes "github.com/feast-dev/feast/go/protos/feast/types"
+	"github.com/feast-dev/feast/go/types"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"sort"
 	"strings"
-
-	"github.com/feast-dev/feast/go/internal/feast/model"
-	"github.com/feast-dev/feast/go/internal/feast/onlinestore"
-	"github.com/feast-dev/feast/go/protos/feast/serving"
-	prototypes "github.com/feast-dev/feast/go/protos/feast/types"
-	"github.com/feast-dev/feast/go/types"
 )
 
 /*
@@ -96,9 +96,7 @@ type GroupedRangeFeatureRefs struct {
 	Indices [][]int
 
 	// Sort key filters to pass to OnlineReadRange
-	SortKeyFilters []*serving.SortKeyFilter
-	// Reverse sort order to pass to OnlineReadRange
-	ReverseSortOrder bool
+	SortKeyFilters []*model.SortKeyFilter
 	// Limit to pass to OnlineReadRange
 	Limit int32
 }
@@ -1033,6 +1031,10 @@ func GroupSortedFeatureRefs(
 	fullFeatureNames bool) ([]*GroupedRangeFeatureRefs, error) {
 
 	groups := make(map[string]*GroupedRangeFeatureRefs)
+	sortKeyFilterMap := make(map[string]*serving.SortKeyFilter)
+	for _, sortKeyFilter := range sortKeyFilters {
+		sortKeyFilterMap[sortKeyFilter.SortKeyName] = sortKeyFilter
+	}
 
 	for _, featuresAndView := range sortedViews {
 		joinKeys := make([]string, 0)
@@ -1086,6 +1088,35 @@ func GroupSortedFeatureRefs(
 			featureViewNames = append(featureViewNames, sfv.Base.Name)
 		}
 
+		sortKeyFilterModels := make([]*model.SortKeyFilter, 0)
+		sortKeyOrderMap := make(map[string]model.SortOrder)
+		for _, sortKey := range featuresAndView.View.SortKeys {
+			sortKeyOrderMap[sortKey.FieldName] = *sortKey.Order
+		}
+		for _, sortKey := range featuresAndView.View.SortKeys {
+			var sortOrder core.SortOrder_Enum
+			if reverseSortOrder {
+				if *sortKey.Order.Order.Enum() == core.SortOrder_ASC {
+					sortOrder = core.SortOrder_DESC
+				} else {
+					sortOrder = core.SortOrder_ASC
+				}
+			} else {
+				sortOrder = *sortKey.Order.Order.Enum()
+			}
+			var filterModel *model.SortKeyFilter
+			if filter, ok := sortKeyFilterMap[sortKey.FieldName]; ok {
+				filterModel = model.NewSortKeyFilterFromProto(filter, sortOrder)
+			} else {
+				// create empty filter model with only sort order
+				filterModel = &model.SortKeyFilter{
+					SortKeyName: sortKey.FieldName,
+					Order:       model.NewSortOrderFromProto(sortOrder),
+				}
+			}
+			sortKeyFilterModels = append(sortKeyFilterModels, filterModel)
+		}
+
 		if _, ok := groups[groupKey]; !ok {
 			joinKeysProto := entityKeysToProtos(joinKeysValuesProjection)
 			uniqueEntityRows, mappingIndices, err := getUniqueEntityRows(joinKeysProto)
@@ -1099,8 +1130,7 @@ func GroupSortedFeatureRefs(
 				AliasedFeatureNames: aliasedFeatureNames,
 				Indices:             mappingIndices,
 				EntityKeys:          uniqueEntityRows,
-				SortKeyFilters:      sortKeyFilters,
-				ReverseSortOrder:    reverseSortOrder,
+				SortKeyFilters:      sortKeyFilterModels,
 				Limit:               limit,
 			}
 

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -436,6 +436,7 @@ func TestValidateSortKeyFilters(t *testing.T) {
 
 func TestGroupSortedFeatureRefs(t *testing.T) {
 	sortKey1 := createSortKey("timestamp", core.SortOrder_DESC, types.ValueType_UNIX_TIMESTAMP)
+	sortKey2 := createSortKey("featureF", core.SortOrder_ASC, types.ValueType_DOUBLE)
 	viewA := createSortedFeatureView("viewA", []string{"driver", "customer"},
 		[]*core.SortKey{sortKey1},
 		createFeature("featureA", types.ValueType_DOUBLE),
@@ -451,7 +452,7 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 		createFeature("featureE", types.ValueType_DOUBLE))
 
 	viewD := createSortedFeatureView("viewD", []string{"customer"},
-		[]*core.SortKey{sortKey1},
+		[]*core.SortKey{sortKey2},
 		createFeature("featureF", types.ValueType_DOUBLE))
 
 	if viewA.Base != nil && viewA.Base.Projection == nil {
@@ -467,6 +468,11 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 			RangeEnd:       &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1672531200}},
 			StartInclusive: true,
 			EndInclusive:   false,
+		},
+		{
+			SortKeyName:  "featureF",
+			RangeEnd:     &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 1.5}},
+			EndInclusive: true,
 		},
 	}
 
@@ -514,8 +520,20 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 	assert.NotEmpty(t, refGroups, "Should return at least one group")
 
 	for _, group := range refGroups {
-		assert.Equal(t, sortKeyFilters, group.SortKeyFilters)
-		assert.Equal(t, false, group.ReverseSortOrder)
+		assert.Equal(t, 1, len(group.SortKeyFilters))
+		if group.SortKeyFilters[0].SortKeyName == "timestamp" {
+			assert.Equal(t, sortKeyFilters[0].SortKeyName, group.SortKeyFilters[0].SortKeyName)
+			assert.Equal(t, sortKeyFilters[0].RangeStart, group.SortKeyFilters[0].RangeStart)
+			assert.Equal(t, sortKeyFilters[0].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+			assert.Equal(t, sortKeyFilters[0].StartInclusive, group.SortKeyFilters[0].StartInclusive)
+			assert.Equal(t, sortKeyFilters[0].EndInclusive, group.SortKeyFilters[0].EndInclusive)
+			assert.Equal(t, "DESC", group.SortKeyFilters[0].Order.Order.String())
+		} else {
+			assert.Equal(t, sortKeyFilters[1].SortKeyName, group.SortKeyFilters[0].SortKeyName)
+			assert.Equal(t, sortKeyFilters[1].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+			assert.Equal(t, sortKeyFilters[1].EndInclusive, group.SortKeyFilters[0].EndInclusive)
+			assert.Equal(t, "ASC", group.SortKeyFilters[0].Order.Order.String())
+		}
 		assert.Equal(t, int32(10), group.Limit)
 	}
 
@@ -540,6 +558,95 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 	assert.True(t, featureAFound, "Feature A should be present in results")
 	assert.True(t, featureCFound, "Feature C should be present in results")
 	assert.True(t, featureEFound, "Feature E should be present in results")
+}
+
+func TestGroupSortedFeatureRefs_withReverseSortOrder(t *testing.T) {
+	sortKey1 := createSortKey("timestamp", core.SortOrder_DESC, types.ValueType_UNIX_TIMESTAMP)
+	sortKey2 := createSortKey("featureB", core.SortOrder_ASC, types.ValueType_DOUBLE)
+	viewA := createSortedFeatureView("viewA", []string{"driver", "customer"},
+		[]*core.SortKey{sortKey1, sortKey2},
+		createFeature("featureA", types.ValueType_DOUBLE),
+		createFeature("featureB", types.ValueType_DOUBLE))
+
+	sortKeyFilters := []*serving.SortKeyFilter{
+		{
+			SortKeyName:    "timestamp",
+			RangeStart:     &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1640995200}},
+			RangeEnd:       &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1672531200}},
+			StartInclusive: true,
+			EndInclusive:   false,
+		},
+	}
+
+	refGroups, err := GroupSortedFeatureRefs(
+		[]*SortedFeatureViewAndRefs{
+			{View: viewA, FeatureRefs: []string{"featureA", "featureB"}},
+		},
+		map[string]*types.RepeatedValue{
+			"driver_id": {Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 0}},
+				{Val: &types.Value_Int32Val{Int32Val: 0}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+			}},
+			"customer_id": {Val: []*types.Value{
+				{Val: &types.Value_Int32Val{Int32Val: 1}},
+				{Val: &types.Value_Int32Val{Int32Val: 2}},
+				{Val: &types.Value_Int32Val{Int32Val: 3}},
+				{Val: &types.Value_Int32Val{Int32Val: 3}},
+				{Val: &types.Value_Int32Val{Int32Val: 4}},
+			}},
+		},
+		map[string]string{
+			"driver":   "driver_id",
+			"customer": "customer_id",
+		},
+		sortKeyFilters,
+		true,
+		10,
+		true,
+	)
+
+	t.Logf("GroupSortedFeatureRefs returned %d groups", len(refGroups))
+	for i, group := range refGroups {
+		t.Logf("Group %d:", i)
+		t.Logf("  Features: %v", group.FeatureNames)
+		t.Logf("  AliasedNames: %v", group.AliasedFeatureNames)
+	}
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, refGroups, "Should return at least one group")
+
+	for _, group := range refGroups {
+		assert.Equal(t, 2, len(group.SortKeyFilters))
+		assert.Equal(t, sortKeyFilters[0].SortKeyName, group.SortKeyFilters[0].SortKeyName)
+		assert.Equal(t, sortKeyFilters[0].RangeStart, group.SortKeyFilters[0].RangeStart)
+		assert.Equal(t, sortKeyFilters[0].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+		assert.Equal(t, sortKeyFilters[0].StartInclusive, group.SortKeyFilters[0].StartInclusive)
+		assert.Equal(t, sortKeyFilters[0].EndInclusive, group.SortKeyFilters[0].EndInclusive)
+		assert.Equal(t, "ASC", group.SortKeyFilters[0].Order.Order.String())
+
+		// SortKeys missing from the filters should have a default filter with only Order assigned
+		assert.Equal(t, sortKey2.Name, group.SortKeyFilters[1].SortKeyName)
+		assert.Nil(t, group.SortKeyFilters[1].RangeStart)
+		assert.Nil(t, group.SortKeyFilters[1].RangeEnd)
+		assert.Equal(t, "DESC", group.SortKeyFilters[1].Order.Order.String())
+
+		assert.Equal(t, int32(10), group.Limit)
+	}
+
+	featureAFound := false
+
+	for _, group := range refGroups {
+		for _, feature := range group.FeatureNames {
+			if feature == "featureA" {
+				featureAFound = true
+			}
+		}
+	}
+
+	assert.True(t, featureAFound, "Feature A should be present in results")
 }
 
 func TestEntitiesToRangeFeatureVectors(t *testing.T) {

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -523,14 +523,14 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 		assert.Equal(t, 1, len(group.SortKeyFilters))
 		if group.SortKeyFilters[0].SortKeyName == "timestamp" {
 			assert.Equal(t, sortKeyFilters[0].SortKeyName, group.SortKeyFilters[0].SortKeyName)
-			assert.Equal(t, sortKeyFilters[0].RangeStart, group.SortKeyFilters[0].RangeStart)
-			assert.Equal(t, sortKeyFilters[0].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+			assert.Equal(t, sortKeyFilters[0].RangeStart.GetUnixTimestampVal(), group.SortKeyFilters[0].RangeStart)
+			assert.Equal(t, sortKeyFilters[0].RangeEnd.GetUnixTimestampVal(), group.SortKeyFilters[0].RangeEnd)
 			assert.Equal(t, sortKeyFilters[0].StartInclusive, group.SortKeyFilters[0].StartInclusive)
 			assert.Equal(t, sortKeyFilters[0].EndInclusive, group.SortKeyFilters[0].EndInclusive)
 			assert.Equal(t, "DESC", group.SortKeyFilters[0].Order.Order.String())
 		} else {
 			assert.Equal(t, sortKeyFilters[1].SortKeyName, group.SortKeyFilters[0].SortKeyName)
-			assert.Equal(t, sortKeyFilters[1].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+			assert.Equal(t, sortKeyFilters[1].RangeEnd.GetDoubleVal(), group.SortKeyFilters[0].RangeEnd)
 			assert.Equal(t, sortKeyFilters[1].EndInclusive, group.SortKeyFilters[0].EndInclusive)
 			assert.Equal(t, "ASC", group.SortKeyFilters[0].Order.Order.String())
 		}
@@ -621,8 +621,8 @@ func TestGroupSortedFeatureRefs_withReverseSortOrder(t *testing.T) {
 	for _, group := range refGroups {
 		assert.Equal(t, 2, len(group.SortKeyFilters))
 		assert.Equal(t, sortKeyFilters[0].SortKeyName, group.SortKeyFilters[0].SortKeyName)
-		assert.Equal(t, sortKeyFilters[0].RangeStart, group.SortKeyFilters[0].RangeStart)
-		assert.Equal(t, sortKeyFilters[0].RangeEnd, group.SortKeyFilters[0].RangeEnd)
+		assert.Equal(t, sortKeyFilters[0].RangeStart.GetUnixTimestampVal(), group.SortKeyFilters[0].RangeStart)
+		assert.Equal(t, sortKeyFilters[0].RangeEnd.GetUnixTimestampVal(), group.SortKeyFilters[0].RangeEnd)
 		assert.Equal(t, sortKeyFilters[0].StartInclusive, group.SortKeyFilters[0].StartInclusive)
 		assert.Equal(t, sortKeyFilters[0].EndInclusive, group.SortKeyFilters[0].EndInclusive)
 		assert.Equal(t, "ASC", group.SortKeyFilters[0].Order.Order.String())

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -395,7 +395,7 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
-		return nil, fmt.Errorf("error when serializing entity keys for Cassandra")
+		return nil, fmt.Errorf("error when serializing entity keys for Cassandra: %v", err)
 	}
 	results := make([][]FeatureData, len(entityKeys))
 	for i := range results {
@@ -540,7 +540,7 @@ func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entity
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
-		return nil, fmt.Errorf("error when serializing entity keys for Cassandra")
+		return nil, fmt.Errorf("error when serializing entity keys for Cassandra: %v", err)
 	}
 	results := make([][]FeatureData, len(entityKeys))
 	for i := range results {
@@ -773,7 +773,7 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys [
 
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 	if err != nil {
-		return nil, fmt.Errorf("error when serializing entity keys for Cassandra")
+		return nil, fmt.Errorf("error when serializing entity keys for Cassandra: %v", err)
 	}
 	results := make([][]RangeFeatureData, len(entityKeys))
 	for i := range results {

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/feast-dev/feast/go/internal/feast/model"
 	"math"
 	"math/big"
 	"os"
@@ -375,13 +376,20 @@ func (c *CassandraOnlineStore) buildCassandraEntityKeys(entityKeys []*types.Enti
 	return cassandraKeys, cassandraKeyToEntityIndex, nil
 }
 
-func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]FeatureData, error) {
+func (c *CassandraOnlineStore) validateUniqueFeatureNames(featureViewNames []string) error {
 	uniqueNames := make(map[string]int32)
 	for _, fvName := range featureViewNames {
 		uniqueNames[fvName] = 0
 	}
 	if len(uniqueNames) != 1 {
-		return nil, fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
+		return fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
+	}
+	return nil
+}
+
+func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]FeatureData, error) {
+	if err := c.validateUniqueFeatureNames(featureViewNames); err != nil {
+		return nil, err
 	}
 
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
@@ -525,13 +533,10 @@ func (c *CassandraOnlineStore) UnbatchedKeysOnlineRead(ctx context.Context, enti
 }
 
 func (c *CassandraOnlineStore) BatchedKeysOnlineRead(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]FeatureData, error) {
-	uniqueNames := make(map[string]int32)
-	for _, fvName := range featureViewNames {
-		uniqueNames[fvName] = 0
+	if err := c.validateUniqueFeatureNames(featureViewNames); err != nil {
+		return nil, err
 	}
-	if len(uniqueNames) != 1 {
-		return nil, fmt.Errorf("rejecting OnlineRead as more than 1 feature view was tried to be read at once")
-	}
+
 	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
 
 	if err != nil {
@@ -685,8 +690,195 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 	}
 }
 
-func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
-	return nil, errors.New("not implemented")
+func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (string, []interface{}) {
+	rangeParams := make([]interface{}, 0)
+
+	var rangeStart string
+	if filter.RangeStart != nil {
+		if filter.StartInclusive {
+			rangeStart = fmt.Sprintf(`"%s" >= ?`, filter.SortKeyName)
+		} else {
+			rangeStart = fmt.Sprintf(`"%s" > ?`, filter.SortKeyName)
+		}
+		rangeParams = append(rangeParams, filter.RangeStart)
+	}
+	var rangeEnd string
+	if filter.RangeEnd != nil {
+		if filter.EndInclusive {
+			rangeEnd = fmt.Sprintf(`"%s" <= ?`, filter.SortKeyName)
+		} else {
+			rangeEnd = fmt.Sprintf(`"%s" < ?`, filter.SortKeyName)
+		}
+		rangeParams = append(rangeParams, filter.RangeEnd)
+	}
+	if rangeStart != "" && rangeEnd != "" {
+		return fmt.Sprintf(`%s AND %s`, rangeStart, rangeEnd), rangeParams
+	} else if rangeStart != "" {
+		return rangeStart, rangeParams
+	} else if rangeEnd != "" {
+		return rangeEnd, rangeParams
+	} else {
+		return "", rangeParams
+	}
+}
+
+func (c *CassandraOnlineStore) getRangeQueryCQLStatement(tableName string, featureNames []string, sortKeyFilters []*model.SortKeyFilter, limit int32) (string, []interface{}) {
+	// this prevents fetching unnecessary features
+	quotedFeatureNames := make([]string, len(featureNames))
+	for i, featureName := range featureNames {
+		quotedFeatureNames[i] = fmt.Sprintf(`"%s"`, featureName)
+	}
+
+	rangeFilterString := ""
+	orderByString := ""
+	params := make([]interface{}, 0)
+	if len(sortKeyFilters) > 0 {
+		rangeFilters := make([]string, 0)
+		orderBy := make([]string, 0)
+		for _, filter := range sortKeyFilters {
+			filterString, filterParams := c.rangeFilterToCQL(filter)
+			if filterString != "" {
+				rangeFilters = append(rangeFilters, filterString)
+			}
+			orderBy = append(orderBy, fmt.Sprintf(`"%s" %s`, filter.SortKeyName, filter.Order.String()))
+			params = append(params, filterParams...)
+		}
+		if len(rangeFilters) > 0 {
+			rangeFilterString = fmt.Sprintf(" AND %s", strings.Join(rangeFilters, " AND "))
+		}
+		orderByString = fmt.Sprintf(" ORDER BY %s", strings.Join(orderBy, ", "))
+	}
+
+	limitString := ""
+	if limit > 0 {
+		limitString = " LIMIT ?"
+		params = append(params, limit)
+	}
+
+	return fmt.Sprintf(
+		`SELECT "entity_key", "event_ts", %s FROM %s WHERE "entity_key" = ?%s%s%s`,
+		strings.Join(quotedFeatureNames, ", "),
+		tableName,
+		rangeFilterString,
+		orderByString,
+		limitString,
+	), params
+}
+
+func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*model.SortKeyFilter, limit int32) ([][]RangeFeatureData, error) {
+	if err := c.validateUniqueFeatureNames(featureViewNames); err != nil {
+		return nil, err
+	}
+
+	serializedEntityKeys, serializedEntityKeyToIndex, err := c.buildCassandraEntityKeys(entityKeys)
+	if err != nil {
+		return nil, fmt.Errorf("error when serializing entity keys for Cassandra")
+	}
+	results := make([][]RangeFeatureData, len(entityKeys))
+	for i := range results {
+		results[i] = make([]RangeFeatureData, len(featureNames))
+	}
+
+	featureNamesToIdx := make(map[string]int)
+	for idx, name := range featureNames {
+		featureNamesToIdx[name] = idx
+	}
+
+	featureViewName := featureViewNames[0]
+
+	// Prepare the query
+	tableName, err := c.getFqTableName(c.clusterConfigs.Keyspace, c.project, featureViewName, c.tableNameFormatVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	cqlStatement, rangeParams := c.getRangeQueryCQLStatement(tableName, featureNames, sortKeyFilters, limit)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(len(serializedEntityKeys))
+
+	errorsChannel := make(chan error, len(serializedEntityKeys))
+	for _, serializedEntityKey := range serializedEntityKeys {
+		go func(serEntityKey any) {
+			defer waitGroup.Done()
+
+			queryParams := append([]interface{}{serEntityKey}, rangeParams...)
+			iter := c.session.Query(cqlStatement, queryParams...).WithContext(ctx).Iter()
+			rowIdx := serializedEntityKeyToIndex[serializedEntityKey.(string)]
+
+			// fill the row with nulls if not found
+			if iter.NumRows() == 0 {
+				for _, featName := range featureNames {
+					results[rowIdx][featureNamesToIdx[featName]] = RangeFeatureData{
+						FeatureView: featureViewName,
+						FeatureName: featName,
+						Values:      []interface{}{nil},
+						Statuses:    []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
+					}
+				}
+				return
+			}
+
+			for i := 0; i < iter.NumRows(); i++ {
+				readValues := make(map[string]interface{})
+				iter.MapScan(readValues)
+				eventTs := readValues["event_ts"].(time.Time)
+
+				rowFeatures := results[rowIdx]
+				for _, featName := range featureNames {
+					if val, ok := readValues[featName]; ok {
+						var status serving.FieldStatus
+						if val == nil {
+							status = serving.FieldStatus_NULL_VALUE
+						} else {
+							status = serving.FieldStatus_PRESENT
+						}
+
+						if featureData := &rowFeatures[featureNamesToIdx[featName]]; featureData != nil {
+							rowFeatures[featureNamesToIdx[featName]] = featureData.AppendValueStatusTime(val, status, eventTs)
+						} else {
+							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
+								FeatureView:     featureViewName,
+								FeatureName:     featName,
+								Values:          []interface{}{val},
+								Statuses:        []serving.FieldStatus{status},
+								EventTimestamps: []timestamppb.Timestamp{{Seconds: eventTs.Unix(), Nanos: int32(eventTs.Nanosecond())}},
+							}
+						}
+					} else {
+						if featureData := &rowFeatures[featureNamesToIdx[featName]]; featureData != nil {
+							rowFeatures[featureNamesToIdx[featName]] = featureData.AppendValueStatusTime(nil, serving.FieldStatus_NOT_FOUND, eventTs)
+						} else {
+							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
+								FeatureView:     featureViewName,
+								FeatureName:     featName,
+								Values:          []interface{}{nil},
+								Statuses:        []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
+								EventTimestamps: []timestamppb.Timestamp{{Seconds: eventTs.Unix(), Nanos: int32(eventTs.Nanosecond())}},
+							}
+						}
+					}
+				}
+				results[rowIdx] = rowFeatures
+			}
+		}(serializedEntityKey)
+	}
+
+	// wait until all concurrent single-key queries are done
+	waitGroup.Wait()
+	close(errorsChannel)
+
+	var collectedErrors []error
+	for err := range errorsChannel {
+		if err != nil {
+			collectedErrors = append(collectedErrors, err)
+		}
+	}
+	if len(collectedErrors) > 0 {
+		return nil, errors.Join(collectedErrors...)
+	}
+
+	return results, nil
 }
 
 func (c *CassandraOnlineStore) Destruct() {

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -835,7 +835,13 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys [
 						}
 
 						if featureData := &rowFeatures[featureNamesToIdx[featName]]; featureData != nil {
-							rowFeatures[featureNamesToIdx[featName]] = featureData.AppendValueStatusTime(val, status, eventTs)
+							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
+								FeatureView:     featureViewName,
+								FeatureName:     featName,
+								Values:          append(featureData.Values, val),
+								Statuses:        append(featureData.Statuses, status),
+								EventTimestamps: append(featureData.EventTimestamps, timestamppb.Timestamp{Seconds: eventTs.Unix(), Nanos: int32(eventTs.Nanosecond())}),
+							}
 						} else {
 							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
 								FeatureView:     featureViewName,
@@ -847,7 +853,13 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, entityKeys [
 						}
 					} else {
 						if featureData := &rowFeatures[featureNamesToIdx[featName]]; featureData != nil {
-							rowFeatures[featureNamesToIdx[featName]] = featureData.AppendValueStatusTime(nil, serving.FieldStatus_NOT_FOUND, eventTs)
+							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
+								FeatureView:     featureViewName,
+								FeatureName:     featName,
+								Values:          append(featureData.Values, nil),
+								Statuses:        append(featureData.Statuses, serving.FieldStatus_NOT_FOUND),
+								EventTimestamps: append(featureData.EventTimestamps, timestamppb.Timestamp{Seconds: eventTs.Unix(), Nanos: int32(eventTs.Nanosecond())}),
+							}
 						} else {
 							rowFeatures[featureNamesToIdx[featName]] = RangeFeatureData{
 								FeatureView:     featureViewName,

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -693,7 +693,7 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (string, []interface{}) {
 	rangeParams := make([]interface{}, 0)
 
-	var rangeStart string
+	rangeStart := ""
 	if filter.RangeStart != nil {
 		if filter.StartInclusive {
 			rangeStart = fmt.Sprintf(`"%s" >= ?`, filter.SortKeyName)
@@ -702,7 +702,7 @@ func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (st
 		}
 		rangeParams = append(rangeParams, filter.RangeStart)
 	}
-	var rangeEnd string
+	rangeEnd := ""
 	if filter.RangeEnd != nil {
 		if filter.EndInclusive {
 			rangeEnd = fmt.Sprintf(`"%s" <= ?`, filter.SortKeyName)
@@ -711,6 +711,7 @@ func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (st
 		}
 		rangeParams = append(rangeParams, filter.RangeEnd)
 	}
+
 	if rangeStart != "" && rangeEnd != "" {
 		return fmt.Sprintf(`%s AND %s`, rangeStart, rangeEnd), rangeParams
 	} else if rangeStart != "" {

--- a/go/internal/feast/onlinestore/onlinestore.go
+++ b/go/internal/feast/onlinestore/onlinestore.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/feast-dev/feast/go/internal/feast/model"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"time"
-
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
@@ -25,16 +22,6 @@ type RangeFeatureData struct {
 	Values          []interface{}
 	Statuses        []serving.FieldStatus
 	EventTimestamps []timestamp.Timestamp
-}
-
-func (r *RangeFeatureData) AppendValueStatusTime(value interface{}, status serving.FieldStatus, ts time.Time) RangeFeatureData {
-	return RangeFeatureData{
-		FeatureView:     r.FeatureView,
-		FeatureName:     r.FeatureName,
-		Values:          append(r.Values, value),
-		Statuses:        append(r.Statuses, status),
-		EventTimestamps: append(r.EventTimestamps, timestamppb.Timestamp{Seconds: ts.Unix(), Nanos: int32(ts.Nanosecond())}),
-	}
 }
 
 type OnlineStore interface {

--- a/go/internal/feast/onlinestore/redisonlinestore.go
+++ b/go/internal/feast/onlinestore/redisonlinestore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/internal/feast/utils"
 	"os"
 	"strconv"
@@ -332,8 +333,9 @@ func (r *RedisOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.E
 	return results, nil
 }
 
-func (r *RedisOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
-	return nil, errors.New("not implemented")
+func (r *RedisOnlineStore) OnlineReadRange(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*model.SortKeyFilter, limit int32) ([][]RangeFeatureData, error) {
+	// TODO: Implement OnlineReadRange
+	return nil, errors.New("OnlineReadRange is not supported by RedisOnlineStore")
 }
 
 // Dummy destruct function to conform with plugin OnlineStore interface

--- a/go/internal/feast/onlinestore/sqliteonlinestore.go
+++ b/go/internal/feast/onlinestore/sqliteonlinestore.go
@@ -3,6 +3,7 @@ package onlinestore
 import (
 	"database/sql"
 	"errors"
+	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/internal/feast/utils"
 	"strings"
 	"sync"
@@ -121,8 +122,8 @@ func (s *SqliteOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 	return results, nil
 }
 
-func (s *SqliteOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*serving.SortKeyFilter, reverseSortOrder bool, limit int32) ([][]RangeFeatureData, error) {
-	return nil, errors.New("not implemented")
+func (s *SqliteOnlineStore) OnlineReadRange(ctx context.Context, entityRows []*types.EntityKey, featureViewNames []string, featureNames []string, sortKeyFilters []*model.SortKeyFilter, limit int32) ([][]RangeFeatureData, error) {
+	return nil, errors.New("OnlineReadRange is not supported by SqliteOnlineStore")
 }
 
 // Gets a sqlite connection and sets it to the online store and also returns a pointer to the connection.

--- a/go/main.go
+++ b/go/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"google.golang.org/grpc/reflection"
 	"net"
 	"net/http"
 	"os"
@@ -139,6 +140,7 @@ func StartGrpcServer(fs *feast.FeatureStore, host string, port int, writeLoggedF
 	serving.RegisterServingServiceServer(grpcServer, ser)
 	healthService := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
+	reflection.Register(grpcServer)
 
 	// Running Prometheus metrics endpoint on a separate goroutine
 	go func() {

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -696,3 +696,46 @@ func appendNullByType(builder array.Builder) {
 		builder.AppendNull()
 	}
 }
+
+func ValueTypeToGoType(value *types.Value) interface{} {
+	if value == nil || value.Val == nil {
+		return nil
+	}
+
+	switch x := value.Val.(type) {
+	case *types.Value_StringVal:
+		return x.StringVal
+	case *types.Value_BytesVal:
+		return x.BytesVal
+	case *types.Value_Int32Val:
+		return x.Int32Val
+	case *types.Value_Int64Val:
+		return x.Int64Val
+	case *types.Value_FloatVal:
+		return x.FloatVal
+	case *types.Value_DoubleVal:
+		return x.DoubleVal
+	case *types.Value_BoolVal:
+		return x.BoolVal
+	case *types.Value_BoolListVal:
+		return x.BoolListVal.Val
+	case *types.Value_StringListVal:
+		return x.StringListVal.Val
+	case *types.Value_BytesListVal:
+		return x.BytesListVal.Val
+	case *types.Value_Int32ListVal:
+		return x.Int32ListVal.Val
+	case *types.Value_Int64ListVal:
+		return x.Int64ListVal.Val
+	case *types.Value_FloatListVal:
+		return x.FloatListVal.Val
+	case *types.Value_DoubleListVal:
+		return x.DoubleListVal.Val
+	case *types.Value_UnixTimestampVal:
+		return x.UnixTimestampVal
+	case *types.Value_UnixTimestampListVal:
+		return x.UnixTimestampListVal.Val
+	default:
+		return nil
+	}
+}

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -388,3 +388,37 @@ func TestProtoValuesToRepeatedConversion(t *testing.T) {
 		}
 	}
 }
+
+func TestValueTypeToGoType(t *testing.T) {
+	timestamp := time.Now().Unix()
+	testCases := []*types.Value{
+		{Val: &types.Value_StringVal{StringVal: "test"}},
+		{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}},
+		{Val: &types.Value_Int32Val{Int32Val: 10}},
+		{Val: &types.Value_Int64Val{Int64Val: 10}},
+		{Val: &types.Value_FloatVal{FloatVal: 10.0}},
+		{Val: &types.Value_DoubleVal{DoubleVal: 10.0}},
+		{Val: &types.Value_BoolVal{BoolVal: true}},
+		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: timestamp}},
+		{Val: &types.Value_NullVal{NullVal: types.Null_NULL}},
+		nil,
+	}
+
+	expectedTypes := []interface{}{
+		"test",
+		[]byte{1, 2, 3},
+		int32(10),
+		int64(10),
+		float32(10.0),
+		float64(10.0),
+		true,
+		timestamp,
+		nil,
+		nil,
+	}
+
+	for i, testCase := range testCases {
+		actual := ValueTypeToGoType(testCase)
+		assert.Equal(t, expectedTypes[i], actual)
+	}
+}


### PR DESCRIPTION
Draft based on https://github.com/ExpediaGroup/feast/pull/192 with some minor modifications for per-reversing the order of the sort key filters.

# What this PR does / why we need it:
Generates a CQL statement based on the requested features and sort key filters

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
