### PR TITLE
feat: Add equals option to SortKeyFilter and validate

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -142,18 +142,22 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	sortKeyFilters := []*serving.SortKeyFilter{
 		{
 			SortKeyName: "event_timestamp",
-			RangeStart: &types.Value{
-				Val: &types.Value_UnixTimestampVal{
-					UnixTimestampVal: oneWeekAgo.Unix(),
+			Query: &serving.SortKeyFilter_Range{
+				Range: &serving.SortKeyFilter_RangeQuery{
+					RangeStart: &types.Value{
+						Val: &types.Value_UnixTimestampVal{
+							UnixTimestampVal: oneWeekAgo.Unix(),
+						},
+					},
+					RangeEnd: &types.Value{
+						Val: &types.Value_UnixTimestampVal{
+							UnixTimestampVal: now.Unix(),
+						},
+					},
+					StartInclusive: true,
+					EndInclusive:   true,
 				},
 			},
-			RangeEnd: &types.Value{
-				Val: &types.Value_UnixTimestampVal{
-					UnixTimestampVal: now.Unix(),
-				},
-			},
-			StartInclusive: true,
-			EndInclusive:   true,
 		},
 	}
 	sortKeyFilterModels := []*model.SortKeyFilter{

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -2,6 +2,7 @@ package feast
 
 import (
 	"context"
+	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
@@ -10,6 +11,7 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/core"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
+	types2 "github.com/feast-dev/feast/go/types"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -252,9 +254,34 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	assert.Equal(t, "driver_id", result[0].Name)
 	assert.Equal(t, "driver_stats__acc_rate", result[1].Name)
 	assert.Equal(t, "driver_stats__conv_rate", result[2].Name)
-	assert.Equal(t, 2, len(result[1].RangeStatuses))
-	assert.Equal(t, 3, len(result[1].RangeStatuses[0]))
-	assert.Equal(t, 2, len(result[1].RangeStatuses[1]))
+	assert.Equal(t, 2, result[0].RangeValues.Len())
+	assert.Equal(t, 2, len(result[0].RangeStatuses))
+	assert.Equal(t, 2, len(result[0].RangeTimestamps))
+
+	for i := 0; i < result[0].RangeValues.Len(); i++ {
+		key := result[0].RangeValues.(*array.List).ListValues().(*array.Int64).Value(i)
+		var expectedLength int
+
+		accRateValues, err := types2.ArrowValuesToProtoValues(result[1].RangeValues)
+		assert.NoError(t, err)
+		convRateValues, err := types2.ArrowValuesToProtoValues(result[2].RangeValues)
+		assert.NoError(t, err)
+
+		if key == 1001 {
+			assert.Equal(t, []float64{0.91, 0.92, 0.94}, accRateValues[i].GetDoubleListVal().Val)
+			assert.Equal(t, []float64{0.85, 0.87, 0.89}, convRateValues[i].GetDoubleListVal().Val)
+			expectedLength = 3
+		} else {
+			assert.Equal(t, []float64{0.85, 0.88}, accRateValues[i].GetDoubleListVal().Val)
+			assert.Equal(t, []float64{0.78, 0.80}, convRateValues[i].GetDoubleListVal().Val)
+			expectedLength = 2
+		}
+
+		assert.Equal(t, expectedLength, len(result[1].RangeStatuses[i]))
+		assert.Equal(t, expectedLength, len(result[2].RangeStatuses[i]))
+		assert.Equal(t, expectedLength, len(result[1].RangeTimestamps[i]))
+		assert.Equal(t, expectedLength, len(result[2].RangeTimestamps[i]))
+	}
 	mockStore.AssertExpectations(t)
 }
 

--- a/go/internal/feast/model/sortedfeatureview.go
+++ b/go/internal/feast/model/sortedfeatureview.go
@@ -93,16 +93,25 @@ type SortKeyFilter struct {
 	RangeEnd       interface{}
 	StartInclusive bool
 	EndInclusive   bool
+	Equals         interface{}
 	Order          *SortOrder
 }
 
 func NewSortKeyFilterFromProto(proto *serving.SortKeyFilter, sortOrder core.SortOrder_Enum) *SortKeyFilter {
+	if proto.GetRange() != nil {
+		return &SortKeyFilter{
+			SortKeyName:    proto.GetSortKeyName(),
+			RangeStart:     types2.ValueTypeToGoType(proto.GetRange().GetRangeStart()),
+			RangeEnd:       types2.ValueTypeToGoType(proto.GetRange().GetRangeEnd()),
+			StartInclusive: proto.GetRange().GetStartInclusive(),
+			EndInclusive:   proto.GetRange().GetEndInclusive(),
+			Order:          NewSortOrderFromProto(sortOrder),
+		}
+	}
+
 	return &SortKeyFilter{
-		SortKeyName:    proto.GetSortKeyName(),
-		RangeStart:     types2.ValueTypeToGoType(proto.GetRangeStart()),
-		RangeEnd:       types2.ValueTypeToGoType(proto.GetRangeEnd()),
-		StartInclusive: proto.GetStartInclusive(),
-		EndInclusive:   proto.GetEndInclusive(),
-		Order:          NewSortOrderFromProto(sortOrder),
+		SortKeyName: proto.GetSortKeyName(),
+		Equals:      types2.ValueTypeToGoType(proto.GetEquals()),
+		Order:       NewSortOrderFromProto(sortOrder),
 	}
 }

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -568,7 +568,11 @@ func ValidateSortKeyFilterOrder(filters []*serving.SortKeyFilter, sortedViews []
 				orderedFilters = append(orderedFilters, filtersByName[sortKey.FieldName])
 			}
 
-			for _, filter := range orderedFilters[:len(orderedFilters)-1] {
+			for i, filter := range orderedFilters[:len(orderedFilters)-1] {
+				if filter == nil {
+					return fmt.Errorf("sort key '%s' not found in sort key filters", sortedView.View.SortKeys[i].FieldName)
+				}
+
 				if filter.GetEquals() == nil {
 					return fmt.Errorf("sort key filter for sort key '%s' must have an equality relation",
 						filter.SortKeyName)

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -570,11 +570,11 @@ func ValidateSortKeyFilterOrder(filters []*serving.SortKeyFilter, sortedViews []
 
 			for i, filter := range orderedFilters[:len(orderedFilters)-1] {
 				if filter == nil {
-					return fmt.Errorf("sort key '%s' not found in sort key filters", sortedView.View.SortKeys[i].FieldName)
+					return fmt.Errorf("specify sort key filter in request for sort key: '%s' with query type equals", sortedView.View.SortKeys[i].FieldName)
 				}
 
 				if filter.GetEquals() == nil {
-					return fmt.Errorf("sort key filter for sort key '%s' must have an equality relation",
+					return fmt.Errorf("sort key filter for sort key '%s' must have query type equals instead of range",
 						filter.SortKeyName)
 				}
 			}

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -589,6 +589,11 @@ func isValueTypeCompatible(value *prototypes.Value, expectedType prototypes.Valu
 		return false
 	}
 
+	switch value.Val.(type) {
+	case *prototypes.Value_NullVal:
+		return true
+	}
+
 	switch expectedType {
 	case prototypes.ValueType_INT32:
 		_, ok := value.Val.(*prototypes.Value_Int32Val)

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -396,7 +396,7 @@ func TestValidateSortKeyFilters_ValidFilters(t *testing.T) {
 			SortKeyName: "price",
 			Query: &serving.SortKeyFilter_Range{
 				Range: &serving.SortKeyFilter_RangeQuery{
-					RangeStart:     &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 10.5}},
+					RangeStart:     &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}},
 					RangeEnd:       &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 50.0}},
 					StartInclusive: true,
 					EndInclusive:   true,

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -693,6 +693,13 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (string, []interface{}) {
 	rangeParams := make([]interface{}, 0)
 
+	equality := ""
+	if filter.Equals != nil {
+		equality = fmt.Sprintf(`"%s" = ?`, filter.SortKeyName)
+		rangeParams = append(rangeParams, filter.Equals)
+		return equality, rangeParams
+	}
+
 	rangeStart := ""
 	if filter.RangeStart != nil {
 		if filter.StartInclusive {

--- a/go/internal/feast/onlinestore/cassandraonlinestore_test.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore_test.go
@@ -250,12 +250,9 @@ func TestCassandraOnlineStore_getRangeQueryCQLStatement_multipleFilters(t *testi
 	store := CassandraOnlineStore{}
 	fqTableName := `"scylladb"."dummy_project_dummy_fv"`
 	sortFilter1 := model.SortKeyFilter{
-		SortKeyName:    "sort1",
-		RangeStart:     4,
-		RangeEnd:       12,
-		StartInclusive: false,
-		EndInclusive:   false,
-		Order:          &model.SortOrder{Order: core.SortOrder_ASC},
+		SortKeyName: "sort1",
+		Equals:      4,
+		Order:       &model.SortOrder{Order: core.SortOrder_ASC},
 	}
 	sortFilter2 := model.SortKeyFilter{
 		SortKeyName:    "sort2",
@@ -266,10 +263,10 @@ func TestCassandraOnlineStore_getRangeQueryCQLStatement_multipleFilters(t *testi
 
 	cqlStatement, params := store.getRangeQueryCQLStatement(fqTableName, []string{"feat1", "feat2"}, []*model.SortKeyFilter{&sortFilter1, &sortFilter2}, 5)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" > ? AND "sort1" < ? AND "sort2" >= ? ORDER BY "sort1" ASC, "sort2" DESC LIMIT ?`,
+		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" = ? AND "sort2" >= ? ORDER BY "sort1" ASC, "sort2" DESC LIMIT ?`,
 		cqlStatement,
 	)
-	assert.ElementsMatch(t, []interface{}{4, 12, 10, int32(5)}, params)
+	assert.ElementsMatch(t, []interface{}{4, 10, int32(5)}, params)
 }
 
 func TestCassandraOnlineStore_getRangeQueryCQLStatement_multipleFiltersWithMixOfRanges(t *testing.T) {

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/feast-dev/feast/go/internal/feast"
 	"github.com/feast-dev/feast/go/internal/feast/server/logging"
@@ -221,6 +222,7 @@ func (s *grpcServingServiceServer) RegisterServices() (*grpc.Server, *health.Ser
 	serving.RegisterServingServiceServer(grpcServer, s)
 	healthService := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
+	reflection.Register(grpcServer)
 
 	return grpcServer, healthService
 }

--- a/java/serving-client/src/main/java/dev/feast/RangeQueryModel.java
+++ b/java/serving-client/src/main/java/dev/feast/RangeQueryModel.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2025 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.feast;
+
+import feast.proto.serving.ServingAPIProto;
+import feast.proto.types.ValueProto;
+
+public class RangeQueryModel {
+  private ValueProto.Value rangeStart;
+  private ValueProto.Value rangeEnd;
+  private boolean startInclusive;
+  private boolean endInclusive;
+
+  public RangeQueryModel(
+      Object rangeStart, Object rangeEnd, boolean inclusiveStart, boolean inclusiveEnd) {
+    this.rangeStart = RequestUtil.objectToValue(rangeStart);
+    this.rangeEnd = RequestUtil.objectToValue(rangeEnd);
+    this.startInclusive = inclusiveStart;
+    this.endInclusive = inclusiveEnd;
+  }
+
+  public ServingAPIProto.SortKeyFilter.RangeQuery toProto() {
+    return ServingAPIProto.SortKeyFilter.RangeQuery.newBuilder()
+        .setRangeStart(rangeStart)
+        .setRangeEnd(rangeEnd)
+        .setStartInclusive(startInclusive)
+        .setEndInclusive(endInclusive)
+        .build();
+  }
+}

--- a/java/serving-client/src/main/java/dev/feast/RequestUtil.java
+++ b/java/serving-client/src/main/java/dev/feast/RequestUtil.java
@@ -20,6 +20,7 @@ import com.google.protobuf.ByteString;
 import feast.proto.serving.ServingAPIProto.FeatureReferenceV2;
 import feast.proto.types.ValueProto;
 import feast.proto.types.ValueProto.Value;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -100,6 +101,18 @@ public class RequestUtil {
         return Value.newBuilder().setBoolVal((boolean) value).build();
       case "feast.proto.types.ValueProto.Value":
         return (Value) value;
+      case "java.time.LocalDateTime":
+        return Value.newBuilder()
+            .setUnixTimestampVal(((java.time.LocalDateTime) value).toEpochSecond(ZoneOffset.UTC))
+            .build();
+      case "java.time.Instant":
+        return Value.newBuilder()
+            .setUnixTimestampVal(((java.time.Instant) value).getEpochSecond())
+            .build();
+      case "java.time.OffsetDateTime":
+        return Value.newBuilder()
+            .setUnixTimestampVal(((java.time.OffsetDateTime) value).toEpochSecond())
+            .build();
       case "java.util.Arrays.ArrayList":
         if (((List<?>) value).isEmpty()) {
           throw new IllegalArgumentException("Unsupported empty list type");

--- a/java/serving-client/src/main/java/dev/feast/RequestUtil.java
+++ b/java/serving-client/src/main/java/dev/feast/RequestUtil.java
@@ -103,15 +103,16 @@ public class RequestUtil {
         return (Value) value;
       case "java.time.LocalDateTime":
         return Value.newBuilder()
-            .setUnixTimestampVal(((java.time.LocalDateTime) value).toEpochSecond(ZoneOffset.UTC))
+            .setUnixTimestampVal(
+                ((java.time.LocalDateTime) value).toInstant(ZoneOffset.UTC).toEpochMilli())
             .build();
       case "java.time.Instant":
         return Value.newBuilder()
-            .setUnixTimestampVal(((java.time.Instant) value).getEpochSecond())
+            .setUnixTimestampVal(((java.time.Instant) value).toEpochMilli())
             .build();
       case "java.time.OffsetDateTime":
         return Value.newBuilder()
-            .setUnixTimestampVal(((java.time.OffsetDateTime) value).toEpochSecond())
+            .setUnixTimestampVal(((java.time.OffsetDateTime) value).toInstant().toEpochMilli())
             .build();
       case "java.util.Arrays.ArrayList":
         if (((List<?>) value).isEmpty()) {

--- a/java/serving-client/src/main/java/dev/feast/SortKeyFilterModel.java
+++ b/java/serving-client/src/main/java/dev/feast/SortKeyFilterModel.java
@@ -22,22 +22,11 @@ import feast.proto.types.ValueProto.Value;
 public class SortKeyFilterModel {
   private String sortKeyName;
   private Value equals;
-  private Value rangeStart;
-  private Value rangeEnd;
-  private boolean startInclusive;
-  private boolean endInclusive;
+  private RangeQueryModel rangeQueryModel;
 
-  public SortKeyFilterModel(
-      String sortKeyName,
-      Object rangeStart,
-      Object rangeEnd,
-      boolean inclusiveStart,
-      boolean inclusiveEnd) {
+  public SortKeyFilterModel(String sortKeyName, RangeQueryModel rangeQueryModel) {
     this.sortKeyName = sortKeyName;
-    this.rangeStart = RequestUtil.objectToValue(rangeStart);
-    this.rangeEnd = RequestUtil.objectToValue(rangeEnd);
-    this.startInclusive = inclusiveStart;
-    this.endInclusive = inclusiveEnd;
+    this.rangeQueryModel = rangeQueryModel;
   }
 
   public SortKeyFilterModel(String sortKeyName, Object equals) {
@@ -52,33 +41,7 @@ public class SortKeyFilterModel {
 
     return SortKeyFilter.newBuilder()
         .setSortKeyName(sortKeyName)
-        .setRange(
-            SortKeyFilter.RangeQuery.newBuilder()
-                .setRangeStart(rangeStart)
-                .setRangeEnd(rangeEnd)
-                .setStartInclusive(startInclusive)
-                .setEndInclusive(endInclusive)
-                .build())
+        .setRange(this.rangeQueryModel.toProto())
         .build();
-  }
-
-  public String getSortKeyName() {
-    return sortKeyName;
-  }
-
-  public Value getRangeStart() {
-    return rangeStart;
-  }
-
-  public Value getRangeEnd() {
-    return rangeEnd;
-  }
-
-  public boolean isStartInclusive() {
-    return startInclusive;
-  }
-
-  public boolean isEndInclusive() {
-    return endInclusive;
   }
 }

--- a/java/serving-client/src/main/java/dev/feast/SortKeyFilterModel.java
+++ b/java/serving-client/src/main/java/dev/feast/SortKeyFilterModel.java
@@ -21,6 +21,7 @@ import feast.proto.types.ValueProto.Value;
 
 public class SortKeyFilterModel {
   private String sortKeyName;
+  private Value equals;
   private Value rangeStart;
   private Value rangeEnd;
   private boolean startInclusive;
@@ -39,13 +40,25 @@ public class SortKeyFilterModel {
     this.endInclusive = inclusiveEnd;
   }
 
+  public SortKeyFilterModel(String sortKeyName, Object equals) {
+    this.sortKeyName = sortKeyName;
+    this.equals = RequestUtil.objectToValue(equals);
+  }
+
   public SortKeyFilter toProto() {
+    if (equals != null) {
+      return SortKeyFilter.newBuilder().setSortKeyName(sortKeyName).setEquals(equals).build();
+    }
+
     return SortKeyFilter.newBuilder()
         .setSortKeyName(sortKeyName)
-        .setRangeStart(rangeStart)
-        .setRangeEnd(rangeEnd)
-        .setStartInclusive(startInclusive)
-        .setEndInclusive(endInclusive)
+        .setRange(
+            SortKeyFilter.RangeQuery.newBuilder()
+                .setRangeStart(rangeStart)
+                .setRangeEnd(rangeEnd)
+                .setStartInclusive(startInclusive)
+                .setEndInclusive(endInclusive)
+                .build())
         .build();
   }
 

--- a/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
+++ b/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
@@ -37,7 +37,6 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -152,9 +151,8 @@ public class FeastClientTest {
             Arrays.asList("driver:name", "driver:rating", "driver:null_value"),
             Arrays.asList(Row.create().set("driver_id", 1)),
             Arrays.asList(
-                new SortKeyFilterModel(
-                    "event_timestamp", LocalDateTime.ofEpochSecond(1743542014, 0, ZoneOffset.UTC)),
-                new SortKeyFilterModel("sort_key", 2.5f, 5.0f, true, false)),
+                new SortKeyFilterModel("event_timestamp", LocalDateTime.of(2025, 5, 1, 0, 0)),
+                new SortKeyFilterModel("sort_key", new RangeQueryModel(2.5f, 5.0f, true, false))),
             10,
             false,
             "driver_project");
@@ -243,7 +241,7 @@ public class FeastClientTest {
             Arrays.asList(
                 ServingAPIProto.SortKeyFilter.newBuilder()
                     .setSortKeyName("event_timestamp")
-                    .setEquals(Value.newBuilder().setUnixTimestampVal(1743542014).build())
+                    .setEquals(Value.newBuilder().setUnixTimestampVal(1746057600000L).build())
                     .build(),
                 ServingAPIProto.SortKeyFilter.newBuilder()
                     .setSortKeyName("sort_key")

--- a/java/serving-client/src/test/java/dev/feast/RequestUtilTest.java
+++ b/java/serving-client/src/test/java/dev/feast/RequestUtilTest.java
@@ -25,6 +25,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.TextFormat;
 import feast.proto.serving.ServingAPIProto.FeatureReferenceV2;
 import feast.proto.types.ValueProto;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -117,6 +121,18 @@ public class RequestUtilTest {
     byte[] bytes = "test".getBytes();
     assertArrayEquals(RequestUtil.objectToValue(bytes).getBytesVal().toByteArray(), bytes);
     assertTrue(RequestUtil.objectToValue(true).getBoolVal());
+    Instant instant = Instant.now();
+    assertEquals(
+        RequestUtil.objectToValue(LocalDateTime.ofInstant(instant, ZoneId.of("UTC")))
+            .getUnixTimestampVal(),
+        instant.getEpochSecond());
+    assertEquals(
+        RequestUtil.objectToValue(
+                OffsetDateTime.ofInstant(instant, ZoneId.of("America/Los_Angeles")))
+            .getUnixTimestampVal(),
+        instant.getEpochSecond());
+    assertEquals(
+        RequestUtil.objectToValue(instant).getUnixTimestampVal(), instant.getEpochSecond());
     assertEquals(RequestUtil.objectToValue(null).getNullVal(), ValueProto.Null.NULL);
     assertEquals(
         RequestUtil.objectToValue(Arrays.asList(1, 2, 3)).getInt32ListVal().getValList(),

--- a/java/serving-client/src/test/java/dev/feast/RequestUtilTest.java
+++ b/java/serving-client/src/test/java/dev/feast/RequestUtilTest.java
@@ -125,14 +125,13 @@ public class RequestUtilTest {
     assertEquals(
         RequestUtil.objectToValue(LocalDateTime.ofInstant(instant, ZoneId.of("UTC")))
             .getUnixTimestampVal(),
-        instant.getEpochSecond());
+        instant.toEpochMilli());
     assertEquals(
         RequestUtil.objectToValue(
                 OffsetDateTime.ofInstant(instant, ZoneId.of("America/Los_Angeles")))
             .getUnixTimestampVal(),
-        instant.getEpochSecond());
-    assertEquals(
-        RequestUtil.objectToValue(instant).getUnixTimestampVal(), instant.getEpochSecond());
+        instant.toEpochMilli());
+    assertEquals(RequestUtil.objectToValue(instant).getUnixTimestampVal(), instant.toEpochMilli());
     assertEquals(RequestUtil.objectToValue(null).getNullVal(), ValueProto.Null.NULL);
     assertEquals(
         RequestUtil.objectToValue(Arrays.asList(1, 2, 3)).getInt32ListVal().getValList(),

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -144,17 +144,24 @@ message SortKeyFilter {
     // Name of the sort key to filter on
     string sort_key_name = 1;
 
-    // Start of the range that the sort key will be bounded by for the query
-    feast.types.Value range_start = 2;
+    message RangeQuery {
+        // Start of the range that the sort key will be bounded by for the query
+        feast.types.Value range_start = 2;
 
-    // End of the range that the sort key will be bounded by for the query
-    feast.types.Value range_end = 3;
+        // End of the range that the sort key will be bounded by for the query
+        feast.types.Value range_end = 3;
 
-    // Whether the start of the range is inclusive
-    bool start_inclusive = 4;
+        // Whether the start of the range is inclusive
+        bool start_inclusive = 4;
 
-    // Whether the end of the range is inclusive
-    bool end_inclusive = 5;
+        // Whether the end of the range is inclusive
+        bool end_inclusive = 5;
+    }
+
+    oneof query {
+        RangeQuery range = 2;
+        feast.types.Value equals = 3;
+    }
 }
 
 message GetOnlineFeaturesRangeRequest {


### PR DESCRIPTION
# What this PR does / why we need it:
Add equals option to SortKeyFilter and validate that only the last sort key filter uses a range query

# Which issue(s) this PR fixes:
Support for multiple sort keys


# Misc
The main change is the SortKeyFilter proto, changing to a oneof:
`    oneof query {
        RangeQuery range = 2;
        feast.types.Value equals = 3;
    }`
    
Please review validation test cases for any missed variations.
