### PR TITLE
fix: Fix/delete sfv

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1016,6 +1016,7 @@ class FeatureStore:
                 if (
                     (isinstance(ob, FeatureView) or isinstance(ob, BatchFeatureView))
                     and not isinstance(ob, StreamFeatureView)
+                    and not isinstance(ob, SortedFeatureView)
                 )
             ]
             odfvs_to_delete = [

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -483,11 +483,20 @@ class HttpRegistry(BaseRegistry):
             self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted FeatureView {name} from project {project}")
         except FeatureViewNotFoundException as exception:
-            logger.error(
-                f"Requested FeatureView {name} does not exist for deletion: %s",
-                str(exception),
-            )
-            raise httpx.HTTPError(message=f"FeatureView: {name} not found")
+            try:
+                logger.info(
+                    f"Requested FeatureView {name} does not exist for deletion: %s. Checking if a SortedFeatureView "
+                    f"with that name exists..")
+                url = f"{self.base_url}/projects/{project}/sorted_feature_views/{name}"
+                params = {"commit": commit}
+                self._send_request("DELETE", url, params=params)
+                logger.info(f"Deleted SortedFeatureView {name} from project {project}")
+            except FeatureViewNotFoundException as exception:
+                logger.error(
+                    f"Requested FeatureView or SortedFeatureView with name {name} does not exist for deletion: %s",
+                    str(exception),
+                )
+                raise httpx.HTTPError(message=f"Neither FeatureView nor SortedFeatureView with name {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
 

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -483,20 +483,11 @@ class HttpRegistry(BaseRegistry):
             self._send_request("DELETE", url, params=params)
             logger.info(f"Deleted FeatureView {name} from project {project}")
         except FeatureViewNotFoundException as exception:
-            try:
-                logger.info(
-                    f"Requested FeatureView {name} does not exist for deletion: %s. Checking if a SortedFeatureView "
-                    f"with that name exists..")
-                url = f"{self.base_url}/projects/{project}/sorted_feature_views/{name}"
-                params = {"commit": commit}
-                self._send_request("DELETE", url, params=params)
-                logger.info(f"Deleted SortedFeatureView {name} from project {project}")
-            except FeatureViewNotFoundException as exception:
-                logger.error(
-                    f"Requested FeatureView or SortedFeatureView with name {name} does not exist for deletion: %s",
-                    str(exception),
-                )
-                raise httpx.HTTPError(message=f"Neither FeatureView nor SortedFeatureView with name {name} not found")
+            logger.error(
+                f"Requested FeatureView {name} does not exist for deletion: %s",
+                str(exception),
+            )
+            raise httpx.HTTPError(message=f"FeatureView: {name} not found")
         except Exception as exception:
             self._handle_exception(exception)
 


### PR DESCRIPTION
Exclude SortedFeatureViews from list of FeatureViews to be deleted, otherwise Delete operation is attempted twice on SortedFeatureViews


**Test**:
Renaming/deleting feature view was successful after the above change-

https://github.expedia.biz/eg-ai-platform/mlpfs-scylladb-perf-test/actions/runs/35665934
