### PR TITLE
feat: Add option to exempt projects from caching in sql registry

### DIFF
--- a/sdk/python/feast/infra/registry/caching_registry.py
+++ b/sdk/python/feast/infra/registry/caching_registry.py
@@ -30,7 +30,13 @@ logger = logging.getLogger(__name__)
 
 
 class CachingRegistry(BaseRegistry):
-    def __init__(self, project: str, cache_ttl_seconds: int, cache_mode: str, exempt_projects: Optional[List[str]] = None):
+    def __init__(
+        self,
+        project: str,
+        cache_ttl_seconds: int,
+        cache_mode: str,
+        exempt_projects: Optional[List[str]] = None,
+    ):
         self.cache_mode = cache_mode
         self.cached_registry_proto = RegistryProto()
         self._refresh_lock = Lock()

--- a/sdk/python/feast/infra/registry/caching_registry.py
+++ b/sdk/python/feast/infra/registry/caching_registry.py
@@ -30,13 +30,14 @@ logger = logging.getLogger(__name__)
 
 
 class CachingRegistry(BaseRegistry):
-    def __init__(self, project: str, cache_ttl_seconds: int, cache_mode: str):
+    def __init__(self, project: str, cache_ttl_seconds: int, cache_mode: str, exempt_projects: Optional[List[str]] = None):
         self.cache_mode = cache_mode
         self.cached_registry_proto = RegistryProto()
         self._refresh_lock = Lock()
         self.cached_registry_proto_ttl = timedelta(
             seconds=cache_ttl_seconds if cache_ttl_seconds is not None else 0
         )
+        self.cache_exempt_projects = exempt_projects if exempt_projects else []
         self.cached_registry_proto = self.proto()
         self.cached_registry_proto_created = _utc_now()
         self._stop_event = threading.Event()

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -994,7 +994,9 @@ class SqlRegistry(CachingRegistry):
             r.infra.CopyFrom(self.get_infra(project_name).to_proto())
 
         projects_list = self.list_projects(allow_cache=False)
-        filtered_project_list = [p for p in projects_list if p.name not in self.cache_exempt_projects]
+        filtered_project_list = [
+            p for p in projects_list if p.name not in self.cache_exempt_projects
+        ]
 
         if self._executor:
             logger.info(

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -257,6 +257,9 @@ class SqlRegistryConfig(RegistryConfig):
     thread_pool_executor_worker_count: StrictInt = 0
     """ int: Number of worker threads to use for asynchronous caching in SQL Registry. If set to 0, it doesn't use ThreadPoolExecutor. """
 
+    exempt_projects: Optional[List[str]] = None
+    """ List[str]: List of projects to exempt from caching. All associated objects under the project will only be accessible with allow_cache=False. """
+
 
 class SqlRegistry(CachingRegistry):
     def __init__(
@@ -296,6 +299,7 @@ class SqlRegistry(CachingRegistry):
             project=project,
             cache_ttl_seconds=registry_config.cache_ttl_seconds,
             cache_mode=registry_config.cache_mode,
+            exempt_projects=registry_config.exempt_projects,
         )
 
     def _sync_feast_metadata_to_projects_table(self):
@@ -983,14 +987,16 @@ class SqlRegistry(CachingRegistry):
             r.infra.CopyFrom(self.get_infra(project_name).to_proto())
 
         projects_list = self.list_projects(allow_cache=False)
+        filtered_project_list = [p for p in projects_list if p.name not in self.cache_exempt_projects]
+
         if self.thread_pool_executor_worker_count == 0:
-            for project in projects_list:
+            for project in filtered_project_list:
                 process_project(project)
         else:
             with ThreadPoolExecutor(
                 max_workers=self.thread_pool_executor_worker_count
             ) as executor:
-                executor.map(process_project, projects_list)
+                executor.map(process_project, filtered_project_list)
 
         if last_updated_timestamps:
             r.last_updated.FromDatetime(max(last_updated_timestamps))


### PR DESCRIPTION
# What this PR does / why we need it:
Some projects have a large number of feature views that can overload the registry cache. This adds the option to exempt projects from caching.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
