### PR TITLE
feat: Use feature view ttl in Scylladb

### DIFF
--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -324,9 +324,6 @@ class TestCassandraOnlineStore:
         self,
         online_store: CassandraOnlineStore,
     ):
-        """
-        Test the _create_table method of CassandraOnlineStore for sorted feature view
-        """
 
         ttl = online_store._get_ttl(
             True,
@@ -340,9 +337,6 @@ class TestCassandraOnlineStore:
         self,
         online_store: CassandraOnlineStore,
     ):
-        """
-        Test the _create_table method of CassandraOnlineStore for sorted feature view
-        """
 
         ttl = online_store._get_ttl(
             False,

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -1,5 +1,6 @@
 import textwrap
-from datetime import datetime
+import time
+from datetime import datetime, timedelta
 
 import pytest
 from cassandra.cluster import Cluster
@@ -281,6 +282,76 @@ class TestCassandraOnlineStore:
         count = [row.count for row in result]
         assert count[0] == 10
 
+    def test_cassandra_online_write_batch_ttl(
+        self,
+        cassandra_session,
+        repo_config: RepoConfig,
+        online_store: CassandraOnlineStore,
+    ):
+        session, keyspace = cassandra_session
+        (
+            feature_view,
+            data,
+        ) = self._create_n_test_sample_features()
+        constructed_table_name_in_cassandra = online_store._fq_table_name(
+            keyspace,
+            repo_config.project,
+            feature_view,
+            repo_config.online_store.table_name_format_version,
+        )
+
+        constructed_table_name = constructed_table_name_in_cassandra.split(".")[
+            1
+        ].strip('"')
+
+        online_store._create_table(repo_config, repo_config.project, feature_view)
+        online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+        # Wait until the records expire before querying
+        time.sleep(15)
+        result = session.execute(
+            f"SELECT COUNT(*) from {keyspace}.{constructed_table_name};"
+        )
+        count = [row.count for row in result]
+        # Number of records should be 0 as they were expired
+        assert count[0] == 0
+
+    def test_ttl_when_apply_ttl_on_write_true(
+        self,
+        online_store: CassandraOnlineStore,
+    ):
+        """
+        Test the _create_table method of CassandraOnlineStore for sorted feature view
+        """
+
+        ttl = online_store._get_ttl(
+            True,
+            timedelta(seconds=10),
+            timedelta(seconds=15),
+            datetime.utcnow() - timedelta(seconds=300),
+        )
+        assert ttl == 10
+
+    def test_only_ttl_online_store_config_is_configured(
+        self,
+        online_store: CassandraOnlineStore,
+    ):
+        """
+        Test the _create_table method of CassandraOnlineStore for sorted feature view
+        """
+
+        ttl = online_store._get_ttl(
+            False,
+            timedelta(0),
+            timedelta(seconds=30),
+            datetime.utcnow() - timedelta(seconds=15),
+        )
+        assert ttl == 15
+
     def test_cassandra_online_write_batch_all_datatypes(
         self,
         cassandra_session,
@@ -379,6 +450,7 @@ class TestCassandraOnlineStore:
                 timestamp_field="event_timestamp",
             ),
             entities=[Entity(name="id")],
+            ttl=timedelta(seconds=10),
             sort_keys=[
                 SortKey(
                     name="int",

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -324,7 +324,6 @@ class TestCassandraOnlineStore:
         self,
         online_store: CassandraOnlineStore,
     ):
-
         ttl = online_store._get_ttl(
             True,
             timedelta(seconds=10),
@@ -337,7 +336,6 @@ class TestCassandraOnlineStore:
         self,
         online_store: CassandraOnlineStore,
     ):
-
         ttl = online_store._get_ttl(
             False,
             timedelta(0),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Currently, `key_ttl_seconds` in `online_store` config is being used to set TTL in Online store. Also theTTL is activated based on the time when data is written in to Scylla DB as mentioned [here](https://opensource.docs.scylladb.com/stable/cql/time-to-live.html#expiring-data-with-time-to-live-ttl)

In this PR, the idea is to set TTL using the `ttl` field in the Feature View definition and also TTL is calculated based on the event timestamp but not the time at which data is written into Scylla DB.

For example, lets say right now we are materializing data that is an hour old (meaning event timestamps are an hour old) and the TTL that user configured is 3hrs. Then the final/effective TTL that will be set in Scylla DB will be 2hrs. This is because an hour is already elapsed between the event timestamp and by the time data is materialized. 

`apply_ttl_on_write` field is added so users can pick between TTL based on event time stamp or time during writing in to ScyllaDB. By default, this is `False` which means TTL is calculated on event time stamp by default.

Also`key_ttl_seconds` in `online_store` config is still supported, but this will be deprecated or will be used for backward compatibility in the future.
If ttl is configured both in feature view and online store config, then ttl from feature view definition takes priority.

Docs for reference:
https://expediagroup.atlassian.net/wiki/spaces/DSA/pages/438071753/Feature+Store+Delete+Functionality+Spike
https://github.com/feast-dev/feast/issues/4133

https://github.com/feast-dev/feast/issues/4133
# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
