### PR TITLE
feat: Fallback to registry calls when not found in internal server cache

### DIFF
--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -107,8 +107,8 @@ func (r *HttpRegistryStore) loadProtobufMessages(url string, messageProcessor fu
 	return nil
 }
 
-func (r *HttpRegistryStore) loadEntities(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/entities?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadEntities(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/entities?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		entity_list := &core.EntityList{}
 		if err := proto.Unmarshal(data, entity_list); err != nil {
@@ -123,14 +123,14 @@ func (r *HttpRegistryStore) loadEntities(registry *core.Registry) error {
 }
 
 func (r *HttpRegistryStore) loadAndListEntities(registry *core.Registry) []*core.Entity {
-	if err := r.loadEntities(registry); err != nil {
+	if err := r.loadEntities(registry, false); err != nil {
 		log.Warn().Msgf("Error loading entities: %v", err)
 	}
 	return registry.Entities
 }
 
-func (r *HttpRegistryStore) loadDatasources(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/data_sources?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadDatasources(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/data_sources?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		data_source_list := &core.DataSourceList{}
 		if err := proto.Unmarshal(data, data_source_list); err != nil {
@@ -144,8 +144,8 @@ func (r *HttpRegistryStore) loadDatasources(registry *core.Registry) error {
 	})
 }
 
-func (r *HttpRegistryStore) loadFeatureViews(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/feature_views?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadFeatureViews(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/feature_views?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		feature_view_list := &core.FeatureViewList{}
 		if err := proto.Unmarshal(data, feature_view_list); err != nil {
@@ -159,15 +159,15 @@ func (r *HttpRegistryStore) loadFeatureViews(registry *core.Registry) error {
 	})
 }
 
-func (r *HttpRegistryStore) loadAndListFeatureViews(registry *core.Registry) []*core.FeatureView {
-	if err := r.loadFeatureViews(registry); err != nil {
+func (r *HttpRegistryStore) loadAndListFeatureViews(registry *core.Registry, allowCache bool) []*core.FeatureView {
+	if err := r.loadFeatureViews(registry, false); err != nil {
 		log.Warn().Msgf("Error loading feature views: %v", err)
 	}
 	return registry.FeatureViews
 }
 
-func (r *HttpRegistryStore) loadSortedFeatureViews(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadSortedFeatureViews(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		sorted_feature_view_list := &core.SortedFeatureViewList{}
 		if err := proto.Unmarshal(data, sorted_feature_view_list); err != nil {
@@ -182,14 +182,14 @@ func (r *HttpRegistryStore) loadSortedFeatureViews(registry *core.Registry) erro
 }
 
 func (r *HttpRegistryStore) loadAndListSortedFeatureViews(registry *core.Registry) []*core.SortedFeatureView {
-	if err := r.loadSortedFeatureViews(registry); err != nil {
+	if err := r.loadSortedFeatureViews(registry, false); err != nil {
 		log.Warn().Msgf("Error loading sorted feature views: %v", err)
 	}
 	return registry.SortedFeatureViews
 }
 
-func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/on_demand_feature_views?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/on_demand_feature_views?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		od_feature_view_list := &core.OnDemandFeatureViewList{}
 		if err := proto.Unmarshal(data, od_feature_view_list); err != nil {
@@ -201,14 +201,14 @@ func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry) er
 }
 
 func (r *HttpRegistryStore) loadAndListOnDemandFeatureViews(registry *core.Registry) []*core.OnDemandFeatureView {
-	if err := r.loadOnDemandFeatureViews(registry); err != nil {
+	if err := r.loadOnDemandFeatureViews(registry, false); err != nil {
 		log.Warn().Msgf("Error loading on-demand feature views: %v", err)
 	}
 	return registry.OnDemandFeatureViews
 }
 
-func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry) error {
-	url := fmt.Sprintf("%s/projects/%s/feature_services?allow_cache=true", r.endpoint, r.project)
+func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry, allowCache bool) error {
+	url := fmt.Sprintf("%s/projects/%s/feature_services?allow_cache=%t", r.endpoint, r.project, allowCache)
 	return r.loadProtobufMessages(url, func(data []byte) error {
 		feature_service_list := &core.FeatureServiceList{}
 		if err := proto.Unmarshal(data, feature_service_list); err != nil {
@@ -219,8 +219,8 @@ func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry) error {
 	})
 }
 
-func (r *HttpRegistryStore) getFeatureView(registry *core.Registry, name string) (*core.FeatureView, error) {
-	url := fmt.Sprintf("%s/projects/%s/feature_views/%s?allow_cache=true", r.endpoint, r.project, name)
+func (r *HttpRegistryStore) getFeatureView(registry *core.Registry, name string, allowCache bool) (*core.FeatureView, error) {
+	url := fmt.Sprintf("%s/projects/%s/feature_views/%s?allow_cache=%t", r.endpoint, r.project, name, allowCache)
 	featureView := &core.FeatureView{}
 	err := r.loadProtobufMessages(url, func(data []byte) error {
 		if err := proto.Unmarshal(data, featureView); err != nil {
@@ -236,8 +236,8 @@ func (r *HttpRegistryStore) getFeatureView(registry *core.Registry, name string)
 	return featureView, nil
 }
 
-func (r *HttpRegistryStore) getSortedFeatureView(registry *core.Registry, name string) (*core.SortedFeatureView, error) {
-	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views/%s?allow_cache=true", r.endpoint, r.project, name)
+func (r *HttpRegistryStore) getSortedFeatureView(registry *core.Registry, name string, allowCache bool) (*core.SortedFeatureView, error) {
+	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views/%s?allow_cache=%t", r.endpoint, r.project, name, allowCache)
 	sortedFeatureView := &core.SortedFeatureView{}
 	err := r.loadProtobufMessages(url, func(data []byte) error {
 		if err := proto.Unmarshal(data, sortedFeatureView); err != nil {
@@ -257,27 +257,27 @@ func (r *HttpRegistryStore) GetRegistryProto() (*core.Registry, error) {
 
 	registry := core.Registry{}
 
-	if err := r.loadEntities(&registry); err != nil {
+	if err := r.loadEntities(&registry, true); err != nil {
 		return nil, err
 	}
 
-	if err := r.loadDatasources(&registry); err != nil {
+	if err := r.loadDatasources(&registry, true); err != nil {
 		return nil, err
 	}
 
-	if err := r.loadFeatureViews(&registry); err != nil {
+	if err := r.loadFeatureViews(&registry, true); err != nil {
 		return nil, err
 	}
 
-	if err := r.loadSortedFeatureViews(&registry); err != nil {
+	if err := r.loadSortedFeatureViews(&registry, true); err != nil {
 		return nil, err
 	}
 
-	if err := r.loadOnDemandFeatureViews(&registry); err != nil {
+	if err := r.loadOnDemandFeatureViews(&registry, true); err != nil {
 		return nil, err
 	}
 
-	if err := r.loadFeatureServices(&registry); err != nil {
+	if err := r.loadFeatureServices(&registry, true); err != nil {
 		return nil, err
 	}
 

--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -122,6 +122,13 @@ func (r *HttpRegistryStore) loadEntities(registry *core.Registry) error {
 	})
 }
 
+func (r *HttpRegistryStore) loadAndListEntities(registry *core.Registry) []*core.Entity {
+	if err := r.loadEntities(registry); err != nil {
+		log.Warn().Msgf("Error loading entities: %v", err)
+	}
+	return registry.Entities
+}
+
 func (r *HttpRegistryStore) loadDatasources(registry *core.Registry) error {
 	url := fmt.Sprintf("%s/projects/%s/data_sources?allow_cache=true", r.endpoint, r.project)
 	return r.loadProtobufMessages(url, func(data []byte) error {
@@ -152,6 +159,13 @@ func (r *HttpRegistryStore) loadFeatureViews(registry *core.Registry) error {
 	})
 }
 
+func (r *HttpRegistryStore) loadAndListFeatureViews(registry *core.Registry) []*core.FeatureView {
+	if err := r.loadFeatureViews(registry); err != nil {
+		log.Warn().Msgf("Error loading feature views: %v", err)
+	}
+	return registry.FeatureViews
+}
+
 func (r *HttpRegistryStore) loadSortedFeatureViews(registry *core.Registry) error {
 	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views?allow_cache=true", r.endpoint, r.project)
 	return r.loadProtobufMessages(url, func(data []byte) error {
@@ -167,6 +181,13 @@ func (r *HttpRegistryStore) loadSortedFeatureViews(registry *core.Registry) erro
 	})
 }
 
+func (r *HttpRegistryStore) loadAndListSortedFeatureViews(registry *core.Registry) []*core.SortedFeatureView {
+	if err := r.loadSortedFeatureViews(registry); err != nil {
+		log.Warn().Msgf("Error loading sorted feature views: %v", err)
+	}
+	return registry.SortedFeatureViews
+}
+
 func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry) error {
 	url := fmt.Sprintf("%s/projects/%s/on_demand_feature_views?allow_cache=true", r.endpoint, r.project)
 	return r.loadProtobufMessages(url, func(data []byte) error {
@@ -179,6 +200,13 @@ func (r *HttpRegistryStore) loadOnDemandFeatureViews(registry *core.Registry) er
 	})
 }
 
+func (r *HttpRegistryStore) loadAndListOnDemandFeatureViews(registry *core.Registry) []*core.OnDemandFeatureView {
+	if err := r.loadOnDemandFeatureViews(registry); err != nil {
+		log.Warn().Msgf("Error loading on-demand feature views: %v", err)
+	}
+	return registry.OnDemandFeatureViews
+}
+
 func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry) error {
 	url := fmt.Sprintf("%s/projects/%s/feature_services?allow_cache=true", r.endpoint, r.project)
 	return r.loadProtobufMessages(url, func(data []byte) error {
@@ -189,6 +217,40 @@ func (r *HttpRegistryStore) loadFeatureServices(registry *core.Registry) error {
 		registry.FeatureServices = append(registry.FeatureServices, feature_service_list.GetFeatureservices()...)
 		return nil
 	})
+}
+
+func (r *HttpRegistryStore) getFeatureView(registry *core.Registry, name string) (*core.FeatureView, error) {
+	url := fmt.Sprintf("%s/projects/%s/feature_views/%s?allow_cache=true", r.endpoint, r.project, name)
+	featureView := &core.FeatureView{}
+	err := r.loadProtobufMessages(url, func(data []byte) error {
+		if err := proto.Unmarshal(data, featureView); err != nil {
+			return err
+		}
+		registry.FeatureViews = append(registry.FeatureViews, featureView)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return featureView, nil
+}
+
+func (r *HttpRegistryStore) getSortedFeatureView(registry *core.Registry, name string) (*core.SortedFeatureView, error) {
+	url := fmt.Sprintf("%s/projects/%s/sorted_feature_views/%s?allow_cache=true", r.endpoint, r.project, name)
+	sortedFeatureView := &core.SortedFeatureView{}
+	err := r.loadProtobufMessages(url, func(data []byte) error {
+		if err := proto.Unmarshal(data, sortedFeatureView); err != nil {
+			return err
+		}
+		registry.SortedFeatureViews = append(registry.SortedFeatureViews, sortedFeatureView)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return sortedFeatureView, nil
 }
 
 func (r *HttpRegistryStore) GetRegistryProto() (*core.Registry, error) {

--- a/go/internal/feast/registry/http.go
+++ b/go/internal/feast/registry/http.go
@@ -291,3 +291,7 @@ func (r *HttpRegistryStore) UpdateRegistryProto(rp *core.Registry) error {
 func (r *HttpRegistryStore) Teardown() error {
 	return &NotImplementedError{FunctionName: "Teardown"}
 }
+
+func (r *HttpRegistryStore) HasFallback() bool {
+	return true
+}

--- a/go/internal/feast/registry/http_test.go
+++ b/go/internal/feast/registry/http_test.go
@@ -181,7 +181,7 @@ func TestLoadEntities(t *testing.T) {
 	registry := &core.Registry{}
 
 	// Call the method under test
-	err := store.loadEntities(registry)
+	err := store.loadEntities(registry, true)
 
 	// Assert that there was no error and that the registry now contains the entity
 	assert.Nil(t, err)
@@ -219,7 +219,7 @@ func TestLoadDatasources(t *testing.T) {
 	registry := &core.Registry{}
 
 	// Call the method under test
-	err := store.loadDatasources(registry)
+	err := store.loadDatasources(registry, true)
 
 	// Assert that there was no error and that the registry now contains the datasource
 	assert.Nil(t, err)
@@ -257,7 +257,7 @@ func TestLoadFeatureViews(t *testing.T) {
 	registry := &core.Registry{}
 
 	// Call the method under test
-	err := store.loadFeatureViews(registry)
+	err := store.loadFeatureViews(registry, true)
 
 	// Assert that there was no error and that the registry now contains the feature view
 	assert.Nil(t, err)
@@ -295,7 +295,7 @@ func TestLoadOnDemandFeatureViews(t *testing.T) {
 	registry := &core.Registry{}
 
 	// Call the method under test
-	err := store.loadOnDemandFeatureViews(registry)
+	err := store.loadOnDemandFeatureViews(registry, true)
 
 	// Assert that there was no error and that the registry now contains the on-demand feature view
 	assert.Nil(t, err)
@@ -333,7 +333,7 @@ func TestLoadFeatureServices(t *testing.T) {
 	registry := &core.Registry{}
 
 	// Call the method under test
-	err := store.loadFeatureServices(registry)
+	err := store.loadFeatureServices(registry, true)
 
 	// Assert that there was no error and that the registry now contains the feature service
 	assert.Nil(t, err)

--- a/go/internal/feast/registry/local.go
+++ b/go/internal/feast/registry/local.go
@@ -64,3 +64,7 @@ func (r *FileRegistryStore) writeRegistry(rp *core.Registry) error {
 	}
 	return nil
 }
+
+func (r *FileRegistryStore) HasFallback() bool {
+	return false
+}

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -196,18 +196,22 @@ func (r *Registry) loadOnDemandFeatureViews(registry *core.Registry) {
 
 func (r *Registry) ListEntities(project string) ([]*model.Entity, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedEntities, ok := r.cachedEntities[project]; !ok {
-		return []*model.Entity{}, nil
-	} else {
-		entities := make([]*model.Entity, len(cachedEntities))
-		index := 0
-		for _, entityProto := range cachedEntities {
-			entities[index] = model.NewEntityFromProto(entityProto)
-			index += 1
+	cachedEntities, ok := r.cachedEntities[project]
+	r.mu.RUnlock()
+	if !ok {
+		entities := r.registryStore.(*HttpRegistryStore).loadAndListEntities(r.cachedRegistry)
+		for _, entityProto := range entities {
+			cachedEntities[entityProto.Spec.Name] = entityProto
 		}
-		return entities, nil
+		r.cachedEntities[project] = cachedEntities
 	}
+	entities := make([]*model.Entity, len(cachedEntities))
+	index := 0
+	for _, entityProto := range cachedEntities {
+		entities[index] = model.NewEntityFromProto(entityProto)
+		index += 1
+	}
+	return entities, nil
 }
 
 /*
@@ -217,18 +221,22 @@ func (r *Registry) ListEntities(project string) ([]*model.Entity, error) {
 
 func (r *Registry) ListFeatureViews(project string) ([]*model.FeatureView, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedFeatureViews, ok := r.cachedFeatureViews[project]; !ok {
-		return []*model.FeatureView{}, nil
-	} else {
-		featureViews := make([]*model.FeatureView, len(cachedFeatureViews))
-		index := 0
-		for _, featureViewProto := range cachedFeatureViews {
-			featureViews[index] = model.NewFeatureViewFromProto(featureViewProto)
-			index += 1
+	cachedFeatureViews, ok := r.cachedFeatureViews[project]
+	r.mu.RUnlock()
+	if !ok {
+		featureViews := r.registryStore.(*HttpRegistryStore).loadAndListFeatureViews(r.cachedRegistry)
+		for _, featureViewProto := range featureViews {
+			cachedFeatureViews[featureViewProto.Spec.Name] = featureViewProto
 		}
-		return featureViews, nil
+		r.cachedFeatureViews[project] = cachedFeatureViews
 	}
+	featureViews := make([]*model.FeatureView, len(cachedFeatureViews))
+	index := 0
+	for _, featureViewProto := range cachedFeatureViews {
+		featureViews[index] = model.NewFeatureViewFromProto(featureViewProto)
+		index += 1
+	}
+	return featureViews, nil
 }
 
 /*
@@ -238,18 +246,22 @@ func (r *Registry) ListFeatureViews(project string) ([]*model.FeatureView, error
 
 func (r *Registry) ListSortedFeatureViews(project string) ([]*model.SortedFeatureView, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedSortedFeatureViews, ok := r.cachedSortedFeatureViews[project]; !ok {
-		return []*model.SortedFeatureView{}, nil
-	} else {
-		sortedFeatureViews := make([]*model.SortedFeatureView, len(cachedSortedFeatureViews))
-		index := 0
-		for _, sortedFeatureViewProto := range cachedSortedFeatureViews {
-			sortedFeatureViews[index] = model.NewSortedFeatureViewFromProto(sortedFeatureViewProto)
-			index += 1
+	cachedSortedFeatureViews, ok := r.cachedSortedFeatureViews[project]
+	r.mu.RUnlock()
+	if !ok {
+		sortedFeatureViews := r.registryStore.(*HttpRegistryStore).loadAndListSortedFeatureViews(r.cachedRegistry)
+		for _, sortedFeatureViewProto := range sortedFeatureViews {
+			cachedSortedFeatureViews[sortedFeatureViewProto.Spec.Name] = sortedFeatureViewProto
 		}
-		return sortedFeatureViews, nil
+		r.cachedSortedFeatureViews[project] = cachedSortedFeatureViews
 	}
+	sortedFeatureViews := make([]*model.SortedFeatureView, len(cachedSortedFeatureViews))
+	index := 0
+	for _, sortedFeatureViewProto := range cachedSortedFeatureViews {
+		sortedFeatureViews[index] = model.NewSortedFeatureViewFromProto(sortedFeatureViewProto)
+		index += 1
+	}
+	return sortedFeatureViews, nil
 }
 
 /*
@@ -301,18 +313,22 @@ func (r *Registry) ListFeatureServices(project string) ([]*model.FeatureService,
 
 func (r *Registry) ListOnDemandFeatureViews(project string) ([]*model.OnDemandFeatureView, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedOnDemandFeatureViews, ok := r.cachedOnDemandFeatureViews[project]; !ok {
-		return []*model.OnDemandFeatureView{}, nil
-	} else {
-		onDemandFeatureViews := make([]*model.OnDemandFeatureView, len(cachedOnDemandFeatureViews))
-		index := 0
-		for _, onDemandFeatureViewProto := range cachedOnDemandFeatureViews {
-			onDemandFeatureViews[index] = model.NewOnDemandFeatureViewFromProto(onDemandFeatureViewProto)
-			index += 1
+	cachedOnDemandFeatureViews, ok := r.cachedOnDemandFeatureViews[project]
+	r.mu.RUnlock()
+	if !ok {
+		onDemandFeatureViews := r.registryStore.(*HttpRegistryStore).loadAndListOnDemandFeatureViews(r.cachedRegistry)
+		for _, onDemandFeatureViewProto := range onDemandFeatureViews {
+			cachedOnDemandFeatureViews[onDemandFeatureViewProto.Spec.Name] = onDemandFeatureViewProto
 		}
-		return onDemandFeatureViews, nil
+		r.cachedOnDemandFeatureViews[project] = cachedOnDemandFeatureViews
 	}
+	onDemandFeatureViews := make([]*model.OnDemandFeatureView, len(cachedOnDemandFeatureViews))
+	index := 0
+	for _, onDemandFeatureViewProto := range cachedOnDemandFeatureViews {
+		onDemandFeatureViews[index] = model.NewOnDemandFeatureViewFromProto(onDemandFeatureViewProto)
+		index += 1
+	}
+	return onDemandFeatureViews, nil
 }
 
 func (r *Registry) GetEntity(project, entityName string) (*model.Entity, error) {
@@ -331,30 +347,50 @@ func (r *Registry) GetEntity(project, entityName string) (*model.Entity, error) 
 
 func (r *Registry) GetFeatureView(project, featureViewName string) (*model.FeatureView, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedFeatureViews, ok := r.cachedFeatureViews[project]; !ok {
-		return nil, fmt.Errorf("no cached feature views found for project %s", project)
-	} else {
-		if featureViewProto, ok := cachedFeatureViews[featureViewName]; !ok {
-			return nil, fmt.Errorf("no cached feature view %s found for project %s", featureViewName, project)
-		} else {
-			return model.NewFeatureViewFromProto(featureViewProto), nil
-		}
+	cachedFeatureViews, ok := r.cachedFeatureViews[project]
+	r.mu.RUnlock()
+	if !ok {
+		return r.GetFeatureViewFromRegistry(featureViewName, project)
 	}
+
+	featureViewProto, ok := cachedFeatureViews[featureViewName]
+	if !ok {
+		return r.GetFeatureViewFromRegistry(featureViewName, project)
+	}
+	return model.NewFeatureViewFromProto(featureViewProto), nil
+}
+
+func (r *Registry) GetFeatureViewFromRegistry(featureViewName string, project string) (*model.FeatureView, error) {
+	featureViewProto, err := r.registryStore.(*HttpRegistryStore).getFeatureView(r.cachedRegistry, featureViewName)
+	if err != nil {
+		return nil, fmt.Errorf("no feature view %s found in project %s", featureViewName, project)
+	}
+	r.cachedFeatureViews[project][featureViewName] = featureViewProto
+	return model.NewFeatureViewFromProto(featureViewProto), nil
 }
 
 func (r *Registry) GetSortedFeatureView(project, sortedFeatureViewName string) (*model.SortedFeatureView, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if cachedSortedFeatureViews, ok := r.cachedSortedFeatureViews[project]; !ok {
-		return nil, fmt.Errorf("no cached sorted feature views found for project %s", project)
-	} else {
-		if sortedFeatureViewProto, ok := cachedSortedFeatureViews[sortedFeatureViewName]; !ok {
-			return nil, fmt.Errorf("no cached sorted feature view %s found for project %s", sortedFeatureViewName, project)
-		} else {
-			return model.NewSortedFeatureViewFromProto(sortedFeatureViewProto), nil
-		}
+	cachedSortedFeatureViews, ok := r.cachedSortedFeatureViews[project]
+	r.mu.RUnlock()
+	if !ok {
+		return r.GetSortedFeatureViewFromRegistry(sortedFeatureViewName, project)
 	}
+
+	sortedFeatureViewProto, protoOk := cachedSortedFeatureViews[sortedFeatureViewName]
+	if !protoOk {
+		return r.GetSortedFeatureViewFromRegistry(sortedFeatureViewName, project)
+	}
+	return model.NewSortedFeatureViewFromProto(sortedFeatureViewProto), nil
+}
+
+func (r *Registry) GetSortedFeatureViewFromRegistry(sortedFeatureViewName string, project string) (*model.SortedFeatureView, error) {
+	sortedFeatureViewProto, err := r.registryStore.(*HttpRegistryStore).getSortedFeatureView(r.cachedRegistry, sortedFeatureViewName)
+	if err != nil {
+		return nil, fmt.Errorf("no sorted feature view %s found in project %s", sortedFeatureViewName, project)
+	}
+	r.cachedSortedFeatureViews[project][sortedFeatureViewName] = sortedFeatureViewProto
+	return model.NewSortedFeatureViewFromProto(sortedFeatureViewProto), nil
 }
 
 func (r *Registry) GetStreamFeatureView(project, streamFeatureViewName string) (*model.FeatureView, error) {

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -224,7 +224,7 @@ func (r *Registry) ListFeatureViews(project string) ([]*model.FeatureView, error
 	cachedFeatureViews, ok := r.cachedFeatureViews[project]
 	r.mu.RUnlock()
 	if !ok && r.registryStore.HasFallback() {
-		featureViews := r.registryStore.(*HttpRegistryStore).loadAndListFeatureViews(r.cachedRegistry)
+		featureViews := r.registryStore.(*HttpRegistryStore).loadAndListFeatureViews(r.cachedRegistry, true)
 		for _, featureViewProto := range featureViews {
 			cachedFeatureViews[featureViewProto.Spec.Name] = featureViewProto
 		}
@@ -365,7 +365,7 @@ func (r *Registry) GetFeatureView(project, featureViewName string) (*model.Featu
 }
 
 func (r *Registry) GetFeatureViewFromRegistry(featureViewName string, project string) (*model.FeatureView, error) {
-	featureViewProto, err := r.registryStore.(*HttpRegistryStore).getFeatureView(r.cachedRegistry, featureViewName)
+	featureViewProto, err := r.registryStore.(*HttpRegistryStore).getFeatureView(r.cachedRegistry, featureViewName, true)
 	if err != nil {
 		return nil, fmt.Errorf("no feature view %s found in project %s", featureViewName, project)
 	}
@@ -393,7 +393,7 @@ func (r *Registry) GetSortedFeatureView(project, sortedFeatureViewName string) (
 }
 
 func (r *Registry) GetSortedFeatureViewFromRegistry(sortedFeatureViewName string, project string) (*model.SortedFeatureView, error) {
-	sortedFeatureViewProto, err := r.registryStore.(*HttpRegistryStore).getSortedFeatureView(r.cachedRegistry, sortedFeatureViewName)
+	sortedFeatureViewProto, err := r.registryStore.(*HttpRegistryStore).getSortedFeatureView(r.cachedRegistry, sortedFeatureViewName, true)
 	if err != nil {
 		return nil, fmt.Errorf("no sorted feature view %s found in project %s", sortedFeatureViewName, project)
 	}

--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -351,6 +351,8 @@ func (r *Registry) GetFeatureView(project, featureViewName string) (*model.Featu
 	r.mu.RUnlock()
 	if !ok && r.registryStore.HasFallback() {
 		return r.GetFeatureViewFromRegistry(featureViewName, project)
+	} else if !ok {
+		return nil, fmt.Errorf("no cached feature views found for project %s", project)
 	}
 
 	featureViewProto, ok := cachedFeatureViews[featureViewName]
@@ -377,6 +379,8 @@ func (r *Registry) GetSortedFeatureView(project, sortedFeatureViewName string) (
 	r.mu.RUnlock()
 	if !ok && r.registryStore.HasFallback() {
 		return r.GetSortedFeatureViewFromRegistry(sortedFeatureViewName, project)
+	} else if !ok {
+		return nil, fmt.Errorf("no cached sorted feature views found for project %s", project)
 	}
 
 	sortedFeatureViewProto, protoOk := cachedSortedFeatureViews[sortedFeatureViewName]

--- a/go/internal/feast/registry/registrystore.go
+++ b/go/internal/feast/registry/registrystore.go
@@ -9,4 +9,5 @@ type RegistryStore interface {
 	GetRegistryProto() (*core.Registry, error)
 	UpdateRegistryProto(*core.Registry) error
 	Teardown() error
+	HasFallback() bool
 }


### PR DESCRIPTION
# What this PR does / why we need it:
When cache is missing, fallback to making a registry call and update the cache.

# Which issue(s) this PR fixes:
This also includes Get... functions with fallback logic which is currently not used, but will be in the future.

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
