### PR TITLE
feat: Support for replica addresses for valkey

### DIFF
--- a/go/internal/feast/onlinestore/egvalkeyonlinestore.go
+++ b/go/internal/feast/onlinestore/egvalkeyonlinestore.go
@@ -27,6 +27,8 @@ import (
 	// valkeytrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/valkey-go"
 )
 
+const defaultConnectionString = "localhost:6379"
+
 type valkeyType int
 
 const (
@@ -56,14 +58,13 @@ func parseConnectionString(onlineStoreConfig map[string]interface{}, valkeyStore
 	}
 
 	if valkeyStoreType == valkeyNode {
-
-		replicaAddressJson, ok := onlineStoreConfig["replica_address"]
+		replicaAddressJsonValue, ok := onlineStoreConfig["replica_address"]
 		if !ok {
 			log.Warn().Msg("define replica_address or reader endpoint to read from cluster replicas")
 		} else {
-			replicaAddress, ok := replicaAddressJson.(string)
+			replicaAddress, ok := replicaAddressJsonValue.(string)
 			if !ok {
-				return clientOption, fmt.Errorf("failed to convert replica_address to string: %+v", replicaAddressJson)
+				return clientOption, fmt.Errorf("failed to convert replica_address to string: %+v", replicaAddressJsonValue)
 			}
 
 			parts := strings.Split(replicaAddress, ",")
@@ -77,14 +78,14 @@ func parseConnectionString(onlineStoreConfig map[string]interface{}, valkeyStore
 		}
 	}
 
-	valkeyConnJson, ok := onlineStoreConfig["connection_string"]
+	valkeyConnJsonValue, ok := onlineStoreConfig["connection_string"]
 	if !ok {
-		valkeyConnJson = "localhost:6379" // Default connection string
+		valkeyConnJsonValue = defaultConnectionString
 	}
 
-	valkeyConnStr, ok := valkeyConnJson.(string)
+	valkeyConnStr, ok := valkeyConnJsonValue.(string)
 	if !ok {
-		return clientOption, fmt.Errorf("failed to convert connection_string to string: %+v", valkeyConnJson)
+		return clientOption, fmt.Errorf("failed to convert connection_string to string: %+v", valkeyConnJsonValue)
 	}
 
 	parts := strings.Split(valkeyConnStr, ",")
@@ -176,12 +177,12 @@ func NewValkeyOnlineStore(project string, config *registry.RepoConfig, onlineSto
 func getValkeyType(onlineStoreConfig map[string]interface{}) (valkeyType, error) {
 	var t valkeyType
 
-	valkeyTypeJson, ok := onlineStoreConfig["valkey_type"]
+	valkeyTypeJsonValue, ok := onlineStoreConfig["valkey_type"]
 	if !ok {
 		// Default to "valkey"
-		valkeyTypeJson = "valkey"
-	} else if valkeyTypeStr, ok := valkeyTypeJson.(string); !ok {
-		return -1, fmt.Errorf("failed to convert valkey_type to string: %+v", valkeyTypeJson)
+		valkeyTypeJsonValue = "valkey"
+	} else if valkeyTypeStr, ok := valkeyTypeJsonValue.(string); !ok {
+		return -1, fmt.Errorf("failed to convert valkey_type to string: %+v", valkeyTypeJsonValue)
 	} else {
 		if valkeyTypeStr == "valkey" {
 			t = valkeyNode

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -73,7 +73,7 @@ class EGValkeyOnlineStoreConfig(FeastConfigBaseModel):
     """Connection string containing the host, port, and configuration parameters for Valkey
      format: host:port,parameter1,parameter2 eg. valkey:6379,db=0 """
 
-    replica_address: StrictStr = None
+    replica_address: Optional[StrictStr] = None
     """
     (Optional) Address of the replica node used for read operations.
     If not provided, the master node will be used for both read and write operations.

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -73,6 +73,14 @@ class EGValkeyOnlineStoreConfig(FeastConfigBaseModel):
     """Connection string containing the host, port, and configuration parameters for Valkey
      format: host:port,parameter1,parameter2 eg. valkey:6379,db=0 """
 
+    replica_address: StrictStr = None
+    """
+    (Optional) Address of the replica node used for read operations.
+    If not provided, the master node will be used for both read and write operations.
+    Used by GO Feature server. An example use case is the reader endpoint provided by cloud vendors.
+    Example: "host1:port1,host2:port2"
+    """
+
     key_ttl_seconds: Optional[int] = None
     """(Optional) valkey key bin ttl (in seconds) for expiring entities. Value None means No TTL. Value 0 means expire in 0 seconds."""
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Address of the replica node used for read operations in GO Feature Server for Valkey Standalone clusters. 

# Which issue(s) this PR fixes:
Supports reading from read replicas in Valkey Standalone clusters. 


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
