### PR TITLE
fix: Hybrid server kubernetes health endpoint invalid if server isn't started

### DIFF
--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+
 	"google.golang.org/grpc/reflection"
 
 	"github.com/feast-dev/feast/go/internal/feast"
@@ -212,7 +213,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 }
 
 // Register services used by the grpcServingServiceServer.
-func (s *grpcServingServiceServer) RegisterServices() (*grpc.Server, *health.Server) {
+func (s *grpcServingServiceServer) RegisterServices() *grpc.Server {
 	grpcPromMetrics := grpcPrometheus.NewServerMetrics()
 	prometheus.MustRegister(grpcPromMetrics)
 	grpcServer := grpc.NewServer(
@@ -224,7 +225,7 @@ func (s *grpcServingServiceServer) RegisterServices() (*grpc.Server, *health.Ser
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthService)
 	reflection.Register(grpcServer)
 
-	return grpcServer, healthService
+	return grpcServer
 }
 
 func GenerateRequestId() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
1/ We need to add changes to the health-check s.t. it actually calls the health server from a client. The health.server check endpoint just checks the internal servingStatus enum, this would be initialized as 'SERVING', therefore if the server itself doesn't spawn then the enum value 'SERVING' would remain.
2/ Move httpServer listen to goroutine as it's a blocking call.


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
