### PR TITLE
fix: loosen range query type validations

### DIFF
--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -591,21 +591,27 @@ func isValueTypeCompatible(value *prototypes.Value, expectedType prototypes.Valu
 
 	switch value.Val.(type) {
 	case *prototypes.Value_Int32Val:
-		return expectedType == prototypes.ValueType_INT32
+		return expectedType == prototypes.ValueType_INT32 ||
+			expectedType == prototypes.ValueType_INT64 ||
+			expectedType == prototypes.ValueType_UNIX_TIMESTAMP
 	case *prototypes.Value_Int64Val:
-		return expectedType == prototypes.ValueType_INT64
+		return expectedType == prototypes.ValueType_INT64 ||
+			expectedType == prototypes.ValueType_INT32 ||
+			expectedType == prototypes.ValueType_UNIX_TIMESTAMP
 	case *prototypes.Value_FloatVal:
-		return expectedType == prototypes.ValueType_FLOAT
+		return expectedType == prototypes.ValueType_FLOAT ||
+			expectedType == prototypes.ValueType_DOUBLE
 	case *prototypes.Value_DoubleVal:
-		return expectedType == prototypes.ValueType_DOUBLE
+		return expectedType == prototypes.ValueType_DOUBLE ||
+			expectedType == prototypes.ValueType_FLOAT
+	case *prototypes.Value_UnixTimestampVal:
+		return expectedType == prototypes.ValueType_UNIX_TIMESTAMP
 	case *prototypes.Value_StringVal:
 		return expectedType == prototypes.ValueType_STRING
 	case *prototypes.Value_BoolVal:
 		return expectedType == prototypes.ValueType_BOOL
 	case *prototypes.Value_BytesVal:
 		return expectedType == prototypes.ValueType_BYTES
-	case *prototypes.Value_UnixTimestampVal:
-		return expectedType == prototypes.ValueType_UNIX_TIMESTAMP
 	case *prototypes.Value_NullVal:
 		return canBeNull
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR loosens the type validations applied on range queries. This is needed because types provided by the client is inferred and because we want ints to be able to be compared to timestamps. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
