### PR TITLE
feat: Completely rewrite the sql fallback caching system to only use lazy caching with a map structure

### DIFF
--- a/sdk/python/feast/infra/registry/sql_fallback.py
+++ b/sdk/python/feast/infra/registry/sql_fallback.py
@@ -1,9 +1,10 @@
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from threading import Lock
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from pydantic import StrictStr
 from sqlalchemy import Table
@@ -54,6 +55,76 @@ from feast.utils import _utc_now
 logger = logging.getLogger(__name__)
 
 
+class SqlFallbackCacheMap:
+    def __init__(
+        self,
+        name: str,
+        get_fn: Callable,
+    ):
+        self.lock = Lock()
+        self.name = name
+        self.get_fn = get_fn
+        self.cache_map: Dict[str, Dict[str, Tuple[Any, datetime]]] = {}
+
+    def get(self, project: str, name: str) -> Optional[Any]:
+        with self.lock:
+            if project in self.cache_map and name in self.cache_map[project]:
+                return self.cache_map[project][name][0]
+            else:
+                return None
+
+    def get_and_cache_object(
+        self,
+        project: str,
+        name: str,
+        ttl_offset: timedelta,
+        not_found_exception: Optional[Callable],
+    ) -> Optional[Any]:
+        obj = self.get_fn(name, project)
+        if obj is None:
+            if not_found_exception:
+                self.delete(project, name)
+                raise not_found_exception(name, project)
+            return None
+
+        self.set(project, name, obj, _utc_now() + ttl_offset)
+        return obj
+
+    def set(self, project: str, name: str, obj: Any, ttl: datetime):
+        with self.lock:
+            if project not in self.cache_map:
+                self.cache_map[project] = {}
+            self.cache_map[project][name] = (obj, ttl)
+
+    def delete(self, project: str, name: str):
+        with self.lock:
+            if project in self.cache_map and name in self.cache_map[project]:
+                del self.cache_map[project][name]
+
+    def expire(self, ttl_offset: timedelta):
+        obj_refreshed = 0
+        for project, items in self.cache_map.items():
+            for name, (obj, ttl) in items.items():
+                if ttl <= _utc_now():
+                    try:
+                        obj = self.get_fn(name, project)
+                        self.set(project, name, obj, _utc_now() + ttl_offset)
+                    except FeastObjectNotFoundException:
+                        self.delete(project, name)
+                    finally:
+                        obj_refreshed += 1
+        logger.info(f"Refreshed {obj_refreshed} objects in {self.name} cache")
+
+    def clear_project(self, project: str):
+        with self.lock:
+            if project in self.cache_map:
+                del self.cache_map[project]
+
+    def clear(self):
+        with self.lock:
+            self.cache_map.clear()
+
+
 class SqlFallbackRegistryConfig(SqlRegistryConfig):
     registry_type: StrictStr = "sql-fallback"
     """ str: Provider name or a class name that implements Registry."""
@@ -70,71 +141,49 @@ class SqlFallbackRegistry(SqlRegistry):
             registry_config, SqlFallbackRegistryConfig
         ), "SqlFallbackRegistry needs a valid registry_config"
 
-        self.cached_project_map: Dict[str, Tuple[Project, datetime]] = {}
-        self.cached_data_source_map: Dict[
-            str, Dict[str, Tuple[DataSource, datetime]]
-        ] = {}
-        self.cached_entity_map: Dict[str, Dict[str, Tuple[Entity, datetime]]] = {}
-        self.cached_feature_service_map: Dict[
-            str, Dict[str, Tuple[FeatureService, datetime]]
-        ] = {}
-        self.cached_feature_view_map: Dict[
-            str, Dict[str, Tuple[FeatureView, datetime]]
-        ] = {}
-        self.cached_on_demand_feature_view_map: Dict[
-            str, Dict[str, Tuple[OnDemandFeatureView, datetime]]
-        ] = {}
-        self.cached_permission_map: Dict[
-            str, Dict[str, Tuple[Permission, datetime]]
-        ] = {}
-        self.cached_saved_dataset_map: Dict[
-            str, Dict[str, Tuple[SavedDataset, datetime]]
-        ] = {}
-        self.cached_sorted_feature_view_map: Dict[
-            str, Dict[str, Tuple[SortedFeatureView, datetime]]
-        ] = {}
-        self.cached_stream_feature_view_map: Dict[
-            str, Dict[str, Tuple[StreamFeatureView, datetime]]
-        ] = {}
-        self.cached_validation_reference_map: Dict[
-            str, Dict[str, Tuple[ValidationReference, datetime]]
-        ] = {}
+        self.cached_projects: Dict[str, Tuple[Project, datetime]] = {}
+        self.cached_project_lock = Lock()
+
+        self.cached_data_sources = SqlFallbackCacheMap(
+            data_sources.name, self._get_data_source
+        )
+        self.cached_entities = SqlFallbackCacheMap(entities.name, self._get_entity)
+        self.cached_feature_services = SqlFallbackCacheMap(
+            feature_services.name, self._get_feature_service
+        )
+        self.cached_feature_views = SqlFallbackCacheMap(
+            feature_views.name, self._get_feature_view
+        )
+        self.cached_on_demand_feature_views = SqlFallbackCacheMap(
+            on_demand_feature_views.name, self._get_on_demand_feature_view
+        )
+        self.cached_permissions = SqlFallbackCacheMap(
+            permissions.name, self._get_permission
+        )
+        self.cached_saved_datasets = SqlFallbackCacheMap(
+            saved_datasets.name, self._get_saved_dataset
+        )
+        self.cached_sorted_feature_views = SqlFallbackCacheMap(
+            sorted_feature_views.name, self._get_sorted_feature_view
+        )
+        self.cached_stream_feature_views = SqlFallbackCacheMap(
+            stream_feature_views.name, self._get_stream_feature_view
+        )
+        self.cached_validation_references = SqlFallbackCacheMap(
+            validation_references.name, self._get_validation_reference
+        )
 
         self.cache_process_list = [
-            (self.cached_data_source_map, self._get_data_source, data_sources.name),
-            (self.cached_entity_map, self._get_entity, entities.name),
-            (
-                self.cached_feature_service_map,
-                self._get_feature_service,
-                feature_services.name,
-            ),
-            (self.cached_feature_view_map, self._get_feature_view, feature_views.name),
-            (
-                self.cached_on_demand_feature_view_map,
-                self._get_on_demand_feature_view,
-                on_demand_feature_views.name,
-            ),
-            (
-                self.cached_sorted_feature_view_map,
-                self._get_sorted_feature_view,
-                sorted_feature_views.name,
-            ),
-            (
-                self.cached_stream_feature_view_map,
-                self._get_stream_feature_view,
-                stream_feature_views.name,
-            ),
-            (
-                self.cached_saved_dataset_map,
-                self._get_saved_dataset,
-                saved_datasets.name,
-            ),
-            (
-                self.cached_validation_reference_map,
-                self._get_validation_reference,
-                validation_references.name,
-            ),
-            (self.cached_permission_map, self._get_permission, permissions.name),
+            self.cached_data_sources,
+            self.cached_entities,
+            self.cached_feature_services,
+            self.cached_feature_views,
+            self.cached_on_demand_feature_views,
+            self.cached_sorted_feature_views,
+            self.cached_stream_feature_views,
+            self.cached_saved_datasets,
+            self.cached_validation_references,
+            self.cached_permissions,
         ]
 
         super().__init__(registry_config, project, repo_path)
@@ -142,48 +191,31 @@ class SqlFallbackRegistry(SqlRegistry):
     def proto(self) -> RegistryProto:
         # proto() is called during the refresh cycle, this implementation only refreshes cached items
         projects_refreshed = 0
-        for project_name, project_ttl in self.cached_project_map.items():
+        for project_name, project_ttl in self.cached_projects.items():
             if (
-                project_name in self.cached_project_map
-                and self.cached_project_map[project_name][1] <= _utc_now()  # type: ignore
+                project_name in self.cached_projects
+                and self.cached_projects[project_name][1] <= _utc_now()  # type: ignore
             ):
                 try:
                     project_obj = self._get_project(project_name)
                     if project_obj:
-                        self.cached_project_map[project_name] = (
+                        self.cached_projects[project_name] = (
                             project_obj,
                             _utc_now() + self.cached_registry_proto_ttl,
                         )
                     else:
-                        del self.cached_project_map[project_name]
+                        del self.cached_projects[project_name]
                 except ProjectObjectNotFoundException:
-                    del self.cached_project_map[project_name]
+                    del self.cached_projects[project_name]
                 finally:
                     projects_refreshed += 1
         logger.info(f"Refreshed {projects_refreshed} projects in cache")
 
-        def process_expiration(cache_map, get_fn, cache_name):
-            obj_refreshed = 0
-            for project, items in cache_map.items():
-                for name, (obj, ttl) in items.items():
-                    if ttl <= _utc_now():
-                        try:
-                            obj = get_fn(name, project)
-                            cache_map[project][name] = (
-                                obj,
-                                _utc_now() + self.cached_registry_proto_ttl,
-                            )
-                        except FeastObjectNotFoundException:
-                            del cache_map[project][name]
-                        finally:
-                            obj_refreshed += 1
-            logger.info(f"Refreshed {obj_refreshed} objects in {cache_name} cache")
-
         if self.thread_pool_executor_worker_count == 0:
             logger.info("Starting timer for single threaded self.proto()")
             start = time.time()
-            for cache_map, get_fn, cache_name in self.cache_process_list:
-                process_expiration(cache_map, get_fn, cache_name)
+            for cache_map in self.cache_process_list:
+                cache_map.expire(self.cached_registry_proto_ttl)
             logger.info(
                 f"Finished processing cache expiration and refresh in {time.time() - start} seconds"
             )
@@ -198,8 +230,9 @@ class SqlFallbackRegistry(SqlRegistry):
                         len(self.cache_process_list),
                     )
                 ) as executor:
+                    ttl_offset = self.cached_registry_proto_ttl
                     executor.map(
-                        lambda args: process_expiration(*args), self.cache_process_list
+                        lambda cache: cache.expire(ttl_offset), self.cache_process_list
                     )
 
                 logger.info(
@@ -209,44 +242,9 @@ class SqlFallbackRegistry(SqlRegistry):
                 logger.error(
                     f"Resetting cache due to error during multi-threaded cache processing: {e}"
                 )
-                for cache_map, _, _ in self.cache_process_list:
+                for cache_map in self.cache_process_list:
                     cache_map.clear()  # type: ignore
         return self.cached_registry_proto
-
-    def _cache_obj_with_ttl(
-        self,
-        cache_map: Dict[str, Dict[str, Tuple[Any, datetime]]],
-        name: str,
-        project: str,
-        obj: Any,
-    ):
-        if project not in cache_map:
-            cache_map[project] = {}
-
-        ttl = _utc_now() + self.cached_registry_proto_ttl
-        cache_map[project][name] = (obj, ttl)
-
-    def _get_and_cache_object(
-        self,
-        cache_map: Dict[str, Dict[str, Tuple[Any, datetime]]],
-        get_fn: Callable,
-        name: str,
-        project: str,
-        not_found_exception: Optional[Callable],
-    ) -> Any:
-        obj = get_fn(name, project)
-        if obj is None:
-            if not_found_exception:
-                if project in cache_map and name in cache_map[project]:
-                    del cache_map[project][name]
-                raise not_found_exception(name, project)
-            return None
-
-        if project in self.cache_exempt_projects:
-            return obj
-
-        self._cache_obj_with_ttl(cache_map, name, project, obj)
-        return obj
 
     def _delete_object(
         self,
@@ -259,17 +257,13 @@ class SqlFallbackRegistry(SqlRegistry):
         deleted_rows = super()._delete_object(
             table, name, project, id_field_name, not_found_exception
         )
-        cache_map: Union[Dict[str, Dict[str, Tuple[Any, datetime]]] | None] = None
-        for cm, _, cache_name in self.cache_process_list:
-            if cache_name == table.name:
-                cache_map = cm  # type: ignore
+        cache_map: Optional[SqlFallbackCacheMap] = None
+        for cache in self.cache_process_list:
+            if cache.name == table.name:
+                cache_map = cache  # type: ignore
                 break
-        if (
-            cache_map is not None
-            and project in cache_map
-            and name in cache_map[project]
-        ):
-            del cache_map[project][name]
+        if cache_map is not None:
+            cache_map.delete(project, name)
         return deleted_rows
 
     def get_project(
@@ -278,8 +272,9 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
     ) -> Project:
         if allow_cache:
-            if name in self.cached_project_map:
-                return self.cached_project_map[name][0]
+            with self.cached_project_lock:
+                if name in self.cached_projects:
+                    return self.cached_projects[name][0]
 
         project = self._get_project(name)
         if project is None:
@@ -290,46 +285,37 @@ class SqlFallbackRegistry(SqlRegistry):
 
         ttl = _utc_now() + self.cached_registry_proto_ttl
 
-        self.cached_project_map[name] = (project, ttl)
-        for cache_map, _, _ in self.cache_process_list:
-            if name not in cache_map:  # type: ignore
-                cache_map[name] = {}  # type: ignore
+        with self.cached_project_lock:
+            self.cached_projects[name] = (project, ttl)
         return project
 
     def delete_project(self, name: str, commit: bool = True):
         super().delete_project(name, commit)
         if commit:
             # Clear the cache for the deleted project
-            if name in self.cached_project_map:
-                del self.cached_project_map[name]
-            for cache_map, _, _ in self.cache_process_list:
-                if name in cache_map:  # type: ignore
-                    del cache_map[name]  # type: ignore
+            with self.cached_project_lock:
+                if name in self.cached_projects:
+                    del self.cached_projects[name]
+                for cache_map, _, _ in self.cache_process_list:
+                    if name in cache_map:  # type: ignore
+                        del cache_map[name]  # type: ignore
 
     def get_any_feature_view(
         self, name: str, project: str, allow_cache: bool = False
     ) -> BaseFeatureView:
         if allow_cache:
-            if (
-                project in self.cached_feature_view_map
-                and name in self.cached_feature_view_map[project]
-            ):
-                return self.cached_feature_view_map[project][name][0]
-            if (
-                project in self.cached_on_demand_feature_view_map
-                and name in self.cached_on_demand_feature_view_map[project]
-            ):
-                return self.cached_on_demand_feature_view_map[project][name][0]
-            if (
-                project in self.cached_sorted_feature_view_map
-                and name in self.cached_sorted_feature_view_map[project]
-            ):
-                return self.cached_sorted_feature_view_map[project][name][0]
-            if (
-                project in self.cached_stream_feature_view_map
-                and name in self.cached_stream_feature_view_map[project]
-            ):
-                return self.cached_stream_feature_view_map[project][name][0]
+            fv = self.cached_feature_views.get(name, project)
+            if fv:
+                return fv
+            odfv = self.cached_on_demand_feature_views[project][name][0]
+            if odfv:
+                return odfv
+            sorted_fv = self.cached_sorted_feature_views[project][name][0]
+            if sorted_fv:
+                return sorted_fv
+            stream_fv = self.cached_stream_feature_views[project][name][0]
+            if stream_fv:
+                return stream_fv
 
         # if allow_cache=False or failed to find any feature view in the cache, fetch from the registry
         feature_view = self._get_any_feature_view(name, project)
@@ -342,20 +328,20 @@ class SqlFallbackRegistry(SqlRegistry):
             return feature_view
 
         if isinstance(feature_view, SortedFeatureView):
-            self._cache_obj_with_ttl(
-                self.cached_feature_view_map, name, project, feature_view
+            self.cached_feature_views.set(
+                project, name, feature_view, _utc_now() + self.cached_registry_proto_ttl
             )
         elif isinstance(feature_view, StreamFeatureView):
-            self._cache_obj_with_ttl(
-                self.cached_stream_feature_view_map, name, project, feature_view
+            self.cached_stream_feature_views.set(
+                project, name, feature_view, _utc_now() + self.cached_registry_proto_ttl
             )
         elif isinstance(feature_view, OnDemandFeatureView):
-            self._cache_obj_with_ttl(
-                self.cached_on_demand_feature_view_map, name, project, feature_view
+            self.cached_on_demand_feature_views.set(
+                project, name, feature_view, _utc_now() + self.cached_registry_proto_ttl
             )
         else:
-            self._cache_obj_with_ttl(
-                self.cached_feature_view_map, name, project, feature_view
+            self.cached_feature_views.set(
+                project, name, feature_view, _utc_now() + self.cached_registry_proto_ttl
             )
         return feature_view
 
@@ -363,33 +349,33 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> DataSource:
         if allow_cache:
-            if (
-                project in self.cached_data_source_map
-                and name in self.cached_data_source_map[project]
-            ):
-                return self.cached_data_source_map[project][name][0]
+            data_source = self.cached_data_sources.get(name, project)
+            if data_source:
+                return data_source
 
-        return self._get_and_cache_object(
-            self.cached_data_source_map,
-            self._get_data_source,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_data_source(name, project)
+
+        return self.cached_data_sources.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             DataSourceObjectNotFoundException,
         )
 
     def get_entity(self, name: str, project: str, allow_cache: bool = False) -> Entity:
         if allow_cache:
-            if (
-                project in self.cached_entity_map
-                and name in self.cached_entity_map[project]
-            ):
-                return self.cached_entity_map[project][name][0]
+            entity = self.cached_entities.get(project, name)
+            if entity:
+                return entity
 
-        return self._get_and_cache_object(
-            self.cached_entity_map,
-            self._get_entity,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_entity(name, project)
+
+        return self.cached_entities.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             EntityNotFoundException,
         )
 
@@ -397,17 +383,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureService:
         if allow_cache:
-            if (
-                project in self.cached_feature_service_map
-                and name in self.cached_feature_service_map[project]
-            ):
-                return self.cached_feature_service_map[project][name][0]
+            feature_service = self.cached_feature_services.get(name, project)
+            if feature_service:
+                return feature_service
 
-        return self._get_and_cache_object(
-            self.cached_feature_service_map,
-            self._get_feature_service,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_feature_service(name, project)
+
+        return self.cached_feature_services.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             FeatureServiceNotFoundException,
         )
 
@@ -415,17 +401,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureView:
         if allow_cache:
-            if (
-                project in self.cached_feature_view_map
-                and name in self.cached_feature_view_map[project]
-            ):
-                return self.cached_feature_view_map[project][name][0]
+            feature_view = self.cached_feature_views.get(name, project)
+            if feature_view:
+                return feature_view
 
-        return self._get_and_cache_object(
-            self.cached_feature_view_map,
-            self._get_feature_view,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_feature_view(name, project)
+
+        return self.cached_feature_views.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             FeatureViewNotFoundException,
         )
 
@@ -433,17 +419,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> OnDemandFeatureView:
         if allow_cache:
-            if (
-                project in self.cached_on_demand_feature_view_map
-                and name in self.cached_on_demand_feature_view_map[project]
-            ):
-                return self.cached_on_demand_feature_view_map[project][name][0]
+            od_feature_view = self.cached_on_demand_feature_views.get(name, project)
+            if od_feature_view:
+                return od_feature_view
 
-        return self._get_and_cache_object(
-            self.cached_on_demand_feature_view_map,
-            self._get_on_demand_feature_view,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_on_demand_feature_view(name, project)
+
+        return self.cached_on_demand_feature_views.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             OnDemandFeatureViewNotFoundException,
         )
 
@@ -451,17 +437,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> SortedFeatureView:
         if allow_cache:
-            if (
-                project in self.cached_sorted_feature_view_map
-                and name in self.cached_sorted_feature_view_map[project]
-            ):
-                return self.cached_sorted_feature_view_map[project][name][0]
+            sorted_feature_view = self.cached_sorted_feature_views.get(name, project)
+            if sorted_feature_view:
+                return sorted_feature_view
 
-        return self._get_and_cache_object(
-            self.cached_sorted_feature_view_map,
-            self._get_sorted_feature_view,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_sorted_feature_view(name, project)
+
+        return self.cached_sorted_feature_views.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             SortedFeatureViewNotFoundException,
         )
 
@@ -469,17 +455,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> StreamFeatureView:
         if allow_cache:
-            if (
-                project in self.cached_stream_feature_view_map
-                and name in self.cached_stream_feature_view_map[project]
-            ):
-                return self.cached_stream_feature_view_map[project][name][0]
+            stream_feature_view = self.cached_stream_feature_views.get(name, project)
+            if stream_feature_view:
+                return stream_feature_view
 
-        return self._get_and_cache_object(
-            self.cached_stream_feature_view_map,
-            self._get_stream_feature_view,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_stream_feature_view(name, project)
+
+        return self.cached_stream_feature_views.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             FeatureViewNotFoundException,
         )
 
@@ -487,17 +473,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> SavedDataset:
         if allow_cache:
-            if (
-                project in self.cached_saved_dataset_map
-                and name in self.cached_saved_dataset_map[project]
-            ):
-                return self.cached_saved_dataset_map[project][name][0]
+            saved_dataset = self.cached_saved_datasets.get(name, project)
+            if saved_dataset:
+                return saved_dataset
 
-        return self._get_and_cache_object(
-            self.cached_saved_dataset_map,
-            self._get_saved_dataset,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_saved_dataset(name, project)
+
+        return self.cached_saved_datasets.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             SavedDatasetNotFound,
         )
 
@@ -505,17 +491,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> ValidationReference:
         if allow_cache:
-            if (
-                project in self.cached_validation_reference_map
-                and name in self.cached_validation_reference_map[project]
-            ):
-                return self.cached_validation_reference_map[project][name][0]
+            validation_reference = self.cached_validation_references.get(name, project)
+            if validation_reference:
+                return validation_reference
 
-        return self._get_and_cache_object(
-            self.cached_validation_reference_map,
-            self._get_validation_reference,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_validation_reference(name, project)
+
+        return self.cached_validation_references.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             ValidationReferenceNotFound,
         )
 
@@ -523,17 +509,17 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> Permission:
         if allow_cache:
-            if (
-                project in self.cached_permission_map
-                and name in self.cached_permission_map[project]
-            ):
-                return self.cached_permission_map[project][name][0]
+            permission = self.cached_permissions.get(name, project)
+            if permission:
+                return permission
 
-        return self._get_and_cache_object(
-            self.cached_permission_map,
-            self._get_permission,
-            name,
+        if project in self.cache_exempt_projects:
+            return self._get_permission(name, project)
+
+        return self.cached_permissions.get_and_cache_object(
             project,
+            name,
+            self.cached_registry_proto_ttl,
             PermissionObjectNotFoundException,
         )
 

--- a/sdk/python/feast/infra/registry/sql_fallback.py
+++ b/sdk/python/feast/infra/registry/sql_fallback.py
@@ -1,22 +1,53 @@
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from pathlib import Path
-from typing import Callable, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from pydantic import StrictStr
+from sqlalchemy import Table
 
 from feast import (
     Entity,
     FeatureService,
     FeatureView,
     OnDemandFeatureView,
+    Project,
     SortedFeatureView,
     StreamFeatureView,
 )
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
-from feast.infra.registry import proto_registry_utils
-from feast.infra.registry.sql import SqlRegistry, SqlRegistryConfig
+from feast.errors import (
+    DataSourceObjectNotFoundException,
+    EntityNotFoundException,
+    FeastObjectNotFoundException,
+    FeatureServiceNotFoundException,
+    FeatureViewNotFoundException,
+    OnDemandFeatureViewNotFoundException,
+    PermissionObjectNotFoundException,
+    ProjectObjectNotFoundException,
+    SavedDatasetNotFound,
+    SortedFeatureViewNotFoundException,
+    ValidationReferenceNotFound,
+)
+from feast.infra.registry.sql import (
+    SqlRegistry,
+    SqlRegistryConfig,
+    data_sources,
+    entities,
+    feature_services,
+    feature_views,
+    on_demand_feature_views,
+    permissions,
+    saved_datasets,
+    sorted_feature_views,
+    stream_feature_views,
+    validation_references,
+)
 from feast.permissions.permission import Permission
+from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.saved_dataset import SavedDataset, ValidationReference
 
 logger = logging.getLogger(__name__)
@@ -25,15 +56,6 @@ logger = logging.getLogger(__name__)
 class SqlFallbackRegistryConfig(SqlRegistryConfig):
     registry_type: StrictStr = "sql-fallback"
     """ str: Provider name or a class name that implements Registry."""
-
-
-def _obj_to_proto_with_project_name(obj, project: str):
-    proto = obj.to_proto()
-    if "spec" in proto.DESCRIPTOR.fields_by_name:
-        proto.spec.project = project
-    else:
-        proto.project = project
-    return proto
 
 
 class SqlFallbackRegistry(SqlRegistry):
@@ -47,29 +69,472 @@ class SqlFallbackRegistry(SqlRegistry):
             registry_config, SqlFallbackRegistryConfig
         ), "SqlFallbackRegistry needs a valid registry_config"
 
+        self.cached_project_map: Dict[str, Tuple[Project, datetime]] = {}
+        self.cached_data_source_map: Dict[
+            str, Dict[str, Tuple[DataSource, datetime]]
+        ] = {}
+        self.cached_entity_map: Dict[str, Dict[str, Tuple[Entity, datetime]]] = {}
+        self.cached_feature_service_map: Dict[
+            str, Dict[str, Tuple[FeatureService, datetime]]
+        ] = {}
+        self.cached_feature_view_map: Dict[
+            str, Dict[str, Tuple[FeatureView, datetime]]
+        ] = {}
+        self.cached_on_demand_feature_view_map: Dict[
+            str, Dict[str, Tuple[OnDemandFeatureView, datetime]]
+        ] = {}
+        self.cached_permission_map: Dict[
+            str, Dict[str, Tuple[Permission, datetime]]
+        ] = {}
+        self.cached_saved_dataset_map: Dict[
+            str, Dict[str, Tuple[SavedDataset, datetime]]
+        ] = {}
+        self.cached_sorted_feature_view_map: Dict[
+            str, Dict[str, Tuple[SortedFeatureView, datetime]]
+        ] = {}
+        self.cached_stream_feature_view_map: Dict[
+            str, Dict[str, Tuple[StreamFeatureView, datetime]]
+        ] = {}
+        self.cached_validation_reference_map: Dict[
+            str, Dict[str, Tuple[ValidationReference, datetime]]
+        ] = {}
+
+        self.cache_process_list = [
+            (self.cached_data_source_map, self._get_data_source, data_sources.name),
+            (self.cached_entity_map, self._get_entity, entities.name),
+            (
+                self.cached_feature_service_map,
+                self._get_feature_service,
+                feature_services.name,
+            ),
+            (self.cached_feature_view_map, self._get_feature_view, feature_views.name),
+            (
+                self.cached_on_demand_feature_view_map,
+                self._get_on_demand_feature_view,
+                on_demand_feature_views.name,
+            ),
+            (
+                self.cached_sorted_feature_view_map,
+                self._get_sorted_feature_view,
+                sorted_feature_views.name,
+            ),
+            (
+                self.cached_stream_feature_view_map,
+                self._get_stream_feature_view,
+                stream_feature_views.name,
+            ),
+            (
+                self.cached_saved_dataset_map,
+                self._get_saved_dataset,
+                saved_datasets.name,
+            ),
+            (
+                self.cached_validation_reference_map,
+                self._get_validation_reference,
+                validation_references.name,
+            ),
+            (self.cached_permission_map, self._get_permission, permissions.name),
+        ]
+
         super().__init__(registry_config, project, repo_path)
 
-    def _get_and_cache_objects(
+    def proto(self) -> RegistryProto:
+        # proto() is called during the refresh cycle, this implementation only refreshes cached items
+        projects_refreshed = 0
+        for project_name, project_ttl in self.cached_project_map.items():
+            if (
+                project_name in self.cached_project_map
+                and self.cached_project_map[project_name][1] <= datetime.now()  # type: ignore
+            ):
+                try:
+                    project_obj = self._get_project(project_name)
+                    if project_obj:
+                        self.cached_project_map[project_name] = (
+                            project_obj,
+                            datetime.now() + self.cached_registry_proto_ttl,
+                        )
+                    else:
+                        del self.cached_project_map[project_name]
+                except ProjectObjectNotFoundException:
+                    del self.cached_project_map[project_name]
+                finally:
+                    projects_refreshed += 1
+        logger.info(f"Refreshed {projects_refreshed} projects in cache")
+
+        def process_expiration(cache_map, get_fn, cache_name):
+            obj_refreshed = 0
+            for project, items in cache_map.items():
+                for name, (obj, ttl) in items.items():
+                    if ttl <= datetime.now():
+                        try:
+                            obj = get_fn(name, project)
+                            cache_map[project][name] = (
+                                obj,
+                                datetime.now() + self.cached_registry_proto_ttl,
+                            )
+                        except FeastObjectNotFoundException:
+                            del cache_map[project][name]
+                        finally:
+                            obj_refreshed += 1
+            logger.info(f"Refreshed {obj_refreshed} objects in {cache_name} cache")
+
+        if self.thread_pool_executor_worker_count == 0:
+            logger.info("Starting timer for single threaded self.proto()")
+            start = time.time()
+            for cache_map, get_fn, cache_name in self.cache_process_list:
+                process_expiration(cache_map, get_fn, cache_name)
+            logger.info(
+                f"Finished processing cache expiration and refresh in {time.time() - start} seconds"
+            )
+        else:
+            try:
+                logger.info("Starting timer for multi threaded self.proto()")
+                start = time.time()
+
+                with ThreadPoolExecutor(
+                    max_workers=min(
+                        self.thread_pool_executor_worker_count,
+                        len(self.cache_process_list),
+                    )
+                ) as executor:
+                    executor.map(
+                        lambda args: process_expiration(*args), self.cache_process_list
+                    )
+
+                logger.info(
+                    f"Multi threaded self.proto() took {time.time() - start} seconds to process cache expiration and refresh"
+                )
+            except RuntimeError as e:
+                logger.error(
+                    f"Resetting cache due to error during multi-threaded cache processing: {e}"
+                )
+                for cache_map, _, _ in self.cache_process_list:
+                    cache_map.clear()  # type: ignore
+        return self.cached_registry_proto
+
+    def _cache_obj_with_ttl(
         self,
-        registry_proto_field_name: str,
-        get_fn: Callable,
+        cache_map: Dict[str, Dict[str, Tuple[Any, datetime]]],
+        name: str,
         project: str,
-        tags: Optional[dict[str, str]],
+        obj: Any,
     ):
-        objects = get_fn(project, tags)
-        if len(objects) == 0:
-            return []
-        # Do not add to cache if the list was filtered by tags or the project is exempt from caching
-        elif tags is not None or project in self.cache_exempt_projects:
-            return objects
-        # Clear and reset the cache with the new list of objects
-        protos = [_obj_to_proto_with_project_name(obj, project) for obj in objects]
-        with self._refresh_lock:
-            self.cached_registry_proto.ClearField(registry_proto_field_name)  # type: ignore[arg-type]
-            self.cached_registry_proto.__getattribute__(
-                registry_proto_field_name
-            ).extend(protos)
-        return objects
+        if project not in cache_map:
+            cache_map[project] = {}
+
+        ttl = datetime.now() + self.cached_registry_proto_ttl
+        cache_map[project][name] = (obj, ttl)
+
+    def _get_and_cache_object(
+        self,
+        cache_map: Dict[str, Dict[str, Tuple[Any, datetime]]],
+        get_fn: Callable,
+        name: str,
+        project: str,
+        not_found_exception: Optional[Callable],
+    ) -> Any:
+        obj = get_fn(name, project)
+        if obj is None:
+            if not_found_exception:
+                if project in cache_map and name in cache_map[project]:
+                    del cache_map[project][name]
+                raise not_found_exception(name, project)
+            return None
+
+        if project in self.cache_exempt_projects:
+            return obj
+
+        self._cache_obj_with_ttl(cache_map, name, project, obj)
+        return obj
+
+    def _delete_object(
+        self,
+        table: Table,
+        name: str,
+        project: str,
+        id_field_name: str,
+        not_found_exception: Optional[Callable],
+    ):
+        deleted_rows = super()._delete_object(
+            table, name, project, id_field_name, not_found_exception
+        )
+        cache_map: Union[Dict[str, Dict[str, Tuple[Any, datetime]]] | None] = None
+        for cm, _, cache_name in self.cache_process_list:
+            if cache_name == table.name:
+                cache_map = cm  # type: ignore
+                break
+        if (
+            cache_map is not None
+            and project in cache_map
+            and name in cache_map[project]
+        ):
+            del cache_map[project][name]
+        return deleted_rows
+
+    def get_project(
+        self,
+        name: str,
+        allow_cache: bool = False,
+    ) -> Project:
+        if allow_cache:
+            if name in self.cached_project_map:
+                return self.cached_project_map[name][0]
+
+        project = self._get_project(name)
+        if project is None:
+            raise ProjectObjectNotFoundException(name)
+
+        if name in self.cache_exempt_projects:
+            return project
+
+        ttl = datetime.now() + self.cached_registry_proto_ttl
+
+        self.cached_project_map[name] = (project, ttl)
+        for cache_map, _, _ in self.cache_process_list:
+            if name not in cache_map:  # type: ignore
+                cache_map[name] = {}  # type: ignore
+        return project
+
+    def delete_project(self, name: str, commit: bool = True):
+        super().delete_project(name, commit)
+        if commit:
+            # Clear the cache for the deleted project
+            if name in self.cached_project_map:
+                del self.cached_project_map[name]
+            for cache_map, _, _ in self.cache_process_list:
+                if name in cache_map:  # type: ignore
+                    del cache_map[name]  # type: ignore
+
+    def get_any_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> BaseFeatureView:
+        if allow_cache:
+            if (
+                project in self.cached_feature_view_map
+                and name in self.cached_feature_view_map[project]
+            ):
+                return self.cached_feature_view_map[project][name][0]
+            if (
+                project in self.cached_on_demand_feature_view_map
+                and name in self.cached_on_demand_feature_view_map[project]
+            ):
+                return self.cached_on_demand_feature_view_map[project][name][0]
+            if (
+                project in self.cached_sorted_feature_view_map
+                and name in self.cached_sorted_feature_view_map[project]
+            ):
+                return self.cached_sorted_feature_view_map[project][name][0]
+            if (
+                project in self.cached_stream_feature_view_map
+                and name in self.cached_stream_feature_view_map[project]
+            ):
+                return self.cached_stream_feature_view_map[project][name][0]
+
+        # if allow_cache=False or failed to find any feature view in the cache, fetch from the registry
+        feature_view = self._get_any_feature_view(name, project)
+        if feature_view is None:
+            raise FeatureViewNotFoundException(
+                f"Feature view {name} not found in project {project}"
+            )
+
+        if project in self.cache_exempt_projects:
+            return feature_view
+
+        if isinstance(feature_view, SortedFeatureView):
+            self._cache_obj_with_ttl(
+                self.cached_feature_view_map, name, project, feature_view
+            )
+        elif isinstance(feature_view, StreamFeatureView):
+            self._cache_obj_with_ttl(
+                self.cached_stream_feature_view_map, name, project, feature_view
+            )
+        elif isinstance(feature_view, OnDemandFeatureView):
+            self._cache_obj_with_ttl(
+                self.cached_on_demand_feature_view_map, name, project, feature_view
+            )
+        else:
+            self._cache_obj_with_ttl(
+                self.cached_feature_view_map, name, project, feature_view
+            )
+        return feature_view
+
+    def get_data_source(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> DataSource:
+        if allow_cache:
+            if (
+                project in self.cached_data_source_map
+                and name in self.cached_data_source_map[project]
+            ):
+                return self.cached_data_source_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_data_source_map,
+            self._get_data_source,
+            name,
+            project,
+            DataSourceObjectNotFoundException,
+        )
+
+    def get_entity(self, name: str, project: str, allow_cache: bool = False) -> Entity:
+        if allow_cache:
+            if (
+                project in self.cached_entity_map
+                and name in self.cached_entity_map[project]
+            ):
+                return self.cached_entity_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_entity_map,
+            self._get_entity,
+            name,
+            project,
+            EntityNotFoundException,
+        )
+
+    def get_feature_service(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> FeatureService:
+        if allow_cache:
+            if (
+                project in self.cached_feature_service_map
+                and name in self.cached_feature_service_map[project]
+            ):
+                return self.cached_feature_service_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_feature_service_map,
+            self._get_feature_service,
+            name,
+            project,
+            FeatureServiceNotFoundException,
+        )
+
+    def get_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> FeatureView:
+        if allow_cache:
+            if (
+                project in self.cached_feature_view_map
+                and name in self.cached_feature_view_map[project]
+            ):
+                return self.cached_feature_view_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_feature_view_map,
+            self._get_feature_view,
+            name,
+            project,
+            FeatureViewNotFoundException,
+        )
+
+    def get_on_demand_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> OnDemandFeatureView:
+        if allow_cache:
+            if (
+                project in self.cached_on_demand_feature_view_map
+                and name in self.cached_on_demand_feature_view_map[project]
+            ):
+                return self.cached_on_demand_feature_view_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_on_demand_feature_view_map,
+            self._get_on_demand_feature_view,
+            name,
+            project,
+            OnDemandFeatureViewNotFoundException,
+        )
+
+    def get_sorted_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> SortedFeatureView:
+        if allow_cache:
+            if (
+                project in self.cached_sorted_feature_view_map
+                and name in self.cached_sorted_feature_view_map[project]
+            ):
+                return self.cached_sorted_feature_view_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_sorted_feature_view_map,
+            self._get_sorted_feature_view,
+            name,
+            project,
+            SortedFeatureViewNotFoundException,
+        )
+
+    def get_stream_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> StreamFeatureView:
+        if allow_cache:
+            if (
+                project in self.cached_stream_feature_view_map
+                and name in self.cached_stream_feature_view_map[project]
+            ):
+                return self.cached_stream_feature_view_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_stream_feature_view_map,
+            self._get_stream_feature_view,
+            name,
+            project,
+            FeatureViewNotFoundException,
+        )
+
+    def get_saved_dataset(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> SavedDataset:
+        if allow_cache:
+            if (
+                project in self.cached_saved_dataset_map
+                and name in self.cached_saved_dataset_map[project]
+            ):
+                return self.cached_saved_dataset_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_saved_dataset_map,
+            self._get_saved_dataset,
+            name,
+            project,
+            SavedDatasetNotFound,
+        )
+
+    def get_validation_reference(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> ValidationReference:
+        if allow_cache:
+            if (
+                project in self.cached_validation_reference_map
+                and name in self.cached_validation_reference_map[project]
+            ):
+                return self.cached_validation_reference_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_validation_reference_map,
+            self._get_validation_reference,
+            name,
+            project,
+            ValidationReferenceNotFound,
+        )
+
+    def get_permission(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> Permission:
+        if allow_cache:
+            if (
+                project in self.cached_permission_map
+                and name in self.cached_permission_map[project]
+            ):
+                return self.cached_permission_map[project][name][0]
+
+        return self._get_and_cache_object(
+            self.cached_permission_map,
+            self._get_permission,
+            name,
+            project,
+            PermissionObjectNotFoundException,
+        )
 
     def list_data_sources(
         self,
@@ -77,15 +542,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[DataSource]:
-        if allow_cache:
-            result = proto_registry_utils.list_data_sources(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "data_sources", self._list_data_sources, project, tags
-        )
+        return self._list_data_sources(project, tags)
 
     def list_entities(
         self,
@@ -93,15 +550,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[Entity]:
-        if allow_cache:
-            result = proto_registry_utils.list_entities(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "entities", self._list_entities, project, tags
-        )
+        return self._list_entities(project, tags)
 
     def list_all_feature_views(
         self,
@@ -109,30 +558,15 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[BaseFeatureView]:
-        if allow_cache:
-            result = proto_registry_utils.list_all_feature_views(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        # If allow_cache=False or failed to find any feature views in the cache, fetch from the registry
-        feature_views = self._get_and_cache_objects(
-            "feature_views", self._list_feature_views, project, tags
-        )
-        on_demand_feature_views = self._get_and_cache_objects(
-            "on_demand_feature_views", self._list_on_demand_feature_views, project, tags
-        )
-        stream_feature_views = self._get_and_cache_objects(
-            "stream_feature_views", self._list_stream_feature_views, project, tags
-        )
-        sorted_feature_views = self._get_and_cache_objects(
-            "sorted_feature_views", self._list_sorted_feature_views, project, tags
-        )
+        fvs = self._list_feature_views(project, tags)
+        od_fvs = self._list_on_demand_feature_views(project, tags)
+        stream_fvs = self._list_stream_feature_views(project, tags)
+        sorted_fvs = self._list_sorted_feature_views(project, tags)
         return (
-            cast(list[BaseFeatureView], feature_views)
-            + cast(list[BaseFeatureView], on_demand_feature_views)
-            + cast(list[BaseFeatureView], stream_feature_views)
-            + cast(list[BaseFeatureView], sorted_feature_views)
+            cast(list[BaseFeatureView], fvs)
+            + cast(list[BaseFeatureView], od_fvs)
+            + cast(list[BaseFeatureView], stream_fvs)
+            + cast(list[BaseFeatureView], sorted_fvs)
         )
 
     def list_feature_views(
@@ -141,15 +575,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[FeatureView]:
-        if allow_cache:
-            result = proto_registry_utils.list_feature_views(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "feature_views", self._list_feature_views, project, tags
-        )
+        return self._list_feature_views(project, tags)
 
     def list_on_demand_feature_views(
         self,
@@ -157,15 +583,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[OnDemandFeatureView]:
-        if allow_cache:
-            result = proto_registry_utils.list_on_demand_feature_views(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "on_demand_feature_views", self._list_on_demand_feature_views, project, tags
-        )
+        return self._list_on_demand_feature_views(project, tags)
 
     def list_stream_feature_views(
         self,
@@ -173,15 +591,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[StreamFeatureView]:
-        if allow_cache:
-            result = proto_registry_utils.list_stream_feature_views(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "stream_feature_views", self._list_stream_feature_views, project, tags
-        )
+        return self._list_stream_feature_views(project, tags)
 
     def list_sorted_feature_views(
         self,
@@ -189,15 +599,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[SortedFeatureView]:
-        if allow_cache:
-            result = proto_registry_utils.list_sorted_feature_views(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "sorted_feature_views", self._list_sorted_feature_views, project, tags
-        )
+        return self._list_sorted_feature_views(project, tags)
 
     def list_feature_services(
         self,
@@ -205,15 +607,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[FeatureService]:
-        if allow_cache:
-            result = proto_registry_utils.list_feature_services(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "feature_services", self._list_feature_services, project, tags
-        )
+        return self._list_feature_services(project, tags)
 
     def list_saved_datasets(
         self,
@@ -221,15 +615,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[SavedDataset]:
-        if allow_cache:
-            result = proto_registry_utils.list_saved_datasets(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "saved_datasets", self._list_saved_datasets, project, tags
-        )
+        return self._list_saved_datasets(project, tags)
 
     def list_validation_references(
         self,
@@ -237,15 +623,7 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[ValidationReference]:
-        if allow_cache:
-            result = proto_registry_utils.list_validation_references(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "validation_references", self._list_validation_references, project, tags
-        )
+        return self._list_validation_references(project, tags)
 
     def list_permissions(
         self,
@@ -253,12 +631,4 @@ class SqlFallbackRegistry(SqlRegistry):
         allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[Permission]:
-        if allow_cache:
-            result = proto_registry_utils.list_permissions(
-                self.cached_registry_proto, project, tags
-            )
-            if len(result) > 0:
-                return result
-        return self._get_and_cache_objects(
-            "permissions", self._list_permissions, project, tags
-        )
+        return self._list_permissions(project, tags)

--- a/sdk/python/feast/infra/registry/sql_fallback.py
+++ b/sdk/python/feast/infra/registry/sql_fallback.py
@@ -79,7 +79,7 @@ class SqlFallbackCacheMap:
         name: str,
         ttl_offset: timedelta,
         not_found_exception: Optional[Callable],
-    ) -> Optional[Any]:
+    ) -> Any:
         obj = self.get_fn(name, project)
         if obj is None:
             if not_found_exception:
@@ -296,9 +296,9 @@ class SqlFallbackRegistry(SqlRegistry):
             with self.cached_project_lock:
                 if name in self.cached_projects:
                     del self.cached_projects[name]
-                for cache_map, _, _ in self.cache_process_list:
-                    if name in cache_map:  # type: ignore
-                        del cache_map[name]  # type: ignore
+
+            for cache_map in self.cache_process_list:
+                cache_map.clear_project(name)
 
     def get_any_feature_view(
         self, name: str, project: str, allow_cache: bool = False
@@ -307,13 +307,13 @@ class SqlFallbackRegistry(SqlRegistry):
             fv = self.cached_feature_views.get(name, project)
             if fv:
                 return fv
-            odfv = self.cached_on_demand_feature_views[project][name][0]
+            odfv = self.cached_on_demand_feature_views.get(project, name)
             if odfv:
                 return odfv
-            sorted_fv = self.cached_sorted_feature_views[project][name][0]
+            sorted_fv = self.cached_sorted_feature_views.get(project, name)
             if sorted_fv:
                 return sorted_fv
-            stream_fv = self.cached_stream_feature_views[project][name][0]
+            stream_fv = self.cached_stream_feature_views.get(project, name)
             if stream_fv:
                 return stream_fv
 

--- a/sdk/python/feast/infra/registry/sql_fallback.py
+++ b/sdk/python/feast/infra/registry/sql_fallback.py
@@ -304,7 +304,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> BaseFeatureView:
         if allow_cache:
-            fv = self.cached_feature_views.get(name, project)
+            fv = self.cached_feature_views.get(project, name)
             if fv:
                 return fv
             odfv = self.cached_on_demand_feature_views.get(project, name)
@@ -349,7 +349,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> DataSource:
         if allow_cache:
-            data_source = self.cached_data_sources.get(name, project)
+            data_source = self.cached_data_sources.get(project, name)
             if data_source:
                 return data_source
 
@@ -383,7 +383,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureService:
         if allow_cache:
-            feature_service = self.cached_feature_services.get(name, project)
+            feature_service = self.cached_feature_services.get(project, name)
             if feature_service:
                 return feature_service
 
@@ -401,7 +401,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> FeatureView:
         if allow_cache:
-            feature_view = self.cached_feature_views.get(name, project)
+            feature_view = self.cached_feature_views.get(project, name)
             if feature_view:
                 return feature_view
 
@@ -419,7 +419,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> OnDemandFeatureView:
         if allow_cache:
-            od_feature_view = self.cached_on_demand_feature_views.get(name, project)
+            od_feature_view = self.cached_on_demand_feature_views.get(project, name)
             if od_feature_view:
                 return od_feature_view
 
@@ -437,7 +437,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> SortedFeatureView:
         if allow_cache:
-            sorted_feature_view = self.cached_sorted_feature_views.get(name, project)
+            sorted_feature_view = self.cached_sorted_feature_views.get(project, name)
             if sorted_feature_view:
                 return sorted_feature_view
 
@@ -455,7 +455,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> StreamFeatureView:
         if allow_cache:
-            stream_feature_view = self.cached_stream_feature_views.get(name, project)
+            stream_feature_view = self.cached_stream_feature_views.get(project, name)
             if stream_feature_view:
                 return stream_feature_view
 
@@ -473,7 +473,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> SavedDataset:
         if allow_cache:
-            saved_dataset = self.cached_saved_datasets.get(name, project)
+            saved_dataset = self.cached_saved_datasets.get(project, name)
             if saved_dataset:
                 return saved_dataset
 
@@ -491,7 +491,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> ValidationReference:
         if allow_cache:
-            validation_reference = self.cached_validation_references.get(name, project)
+            validation_reference = self.cached_validation_references.get(project, name)
             if validation_reference:
                 return validation_reference
 
@@ -509,7 +509,7 @@ class SqlFallbackRegistry(SqlRegistry):
         self, name: str, project: str, allow_cache: bool = False
     ) -> Permission:
         if allow_cache:
-            permission = self.cached_permissions.get(name, project)
+            permission = self.cached_permissions.get(project, name)
             if permission:
                 return permission
 


### PR DESCRIPTION
# What this PR does / why we need it:
The current caching system periodically queries the db for the complete list of objects per type and stores them in a list format. This cache loading is also done via a thread pool executor that makes a thread per project. This has caused many issues with threads being maxed out which cascades into errors in the cache.

# Which issue(s) this PR fixes:
This PR moves to a new lazy-cache system where objects not found in the cache are queried from the db, then stored in a map structure with a ttl. The refresh process now executes with a thread per cache map wherein each object's ttl is checked for expiration and if expired the object is queried from the db and restored. If the object is no longer found, it is removed from the cache. This should drastically reduce the number of threads created during refresh as well as reduce cache-lookup time.

# Misc

