### PR TITLE
feat: Go http server range query support

### DIFF
--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -206,12 +206,27 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 	}
 
 	fvs, sortedFvs, odFvs, entities, err := fs.fetchViewsAndEntities()
+	fvsNames, sortedFvNames, odFvNames, entityNames := make([]string, 0), make([]string, 0), make([]string, 0), make([]string, 0)
+	for _, fv := range fvs {
+		fvsNames = append(fvsNames, fv.Base.Name)
+	}
+	for _, sfv := range sortedFvs {
+		sortedFvNames = append(sortedFvNames, sfv.Base.Name)
+	}
+	for _, odfv := range odFvs {
+		odFvNames = append(odFvNames, odfv.Base.Name)
+	}
+	for _, entity := range entities {
+		entityNames = append(entityNames, entity.Name)
+	}
+
+	fmt.Printf("fvs: %v, sortedFvs: %v, odFvs: %v, entities: %v\n", fvsNames, sortedFvNames, odFvNames, entityNames)
 	if err != nil {
 		return nil, err
 	}
 
 	var requestedSortedFeatureViews []*onlineserving.SortedFeatureViewAndRefs
-
+	fmt.Printf("featureRefs: %v\n", featureRefs)
 	if featureService != nil {
 		_, requestedSortedFeatureViews, _, err =
 			onlineserving.GetFeatureViewsToUseByService(featureService, fvs, sortedFvs, odFvs)
@@ -390,6 +405,7 @@ func (fs *FeatureStore) listAllViews() (map[string]*model.FeatureView, map[strin
 
 func (fs *FeatureStore) fetchViewsAndEntities() (map[string]*model.FeatureView, map[string]*model.SortedFeatureView, map[string]*model.OnDemandFeatureView, []*model.Entity, error) {
 	fvs, sortedFvs, odFvs, err := fs.listAllViews()
+
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -226,11 +226,12 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 	}
 
 	var requestedSortedFeatureViews []*onlineserving.SortedFeatureViewAndRefs
-	fmt.Printf("featureRefs: %v\n", featureRefs)
 	if featureService != nil {
+		fmt.Printf("featureService: %v\n", featureService.Name)
 		_, requestedSortedFeatureViews, _, err =
 			onlineserving.GetFeatureViewsToUseByService(featureService, fvs, sortedFvs, odFvs)
 	} else {
+		fmt.Printf("featureRefs: %v\n", featureRefs)
 		_, requestedSortedFeatureViews, _, err =
 			onlineserving.GetFeatureViewsToUseByFeatureRefs(featureRefs, fvs, sortedFvs, odFvs)
 	}

--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -206,32 +206,15 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 	}
 
 	fvs, sortedFvs, odFvs, entities, err := fs.fetchViewsAndEntities()
-	fvsNames, sortedFvNames, odFvNames, entityNames := make([]string, 0), make([]string, 0), make([]string, 0), make([]string, 0)
-	for _, fv := range fvs {
-		fvsNames = append(fvsNames, fv.Base.Name)
-	}
-	for _, sfv := range sortedFvs {
-		sortedFvNames = append(sortedFvNames, sfv.Base.Name)
-	}
-	for _, odfv := range odFvs {
-		odFvNames = append(odFvNames, odfv.Base.Name)
-	}
-	for _, entity := range entities {
-		entityNames = append(entityNames, entity.Name)
-	}
-
-	fmt.Printf("fvs: %v, sortedFvs: %v, odFvs: %v, entities: %v\n", fvsNames, sortedFvNames, odFvNames, entityNames)
 	if err != nil {
 		return nil, err
 	}
 
 	var requestedSortedFeatureViews []*onlineserving.SortedFeatureViewAndRefs
 	if featureService != nil {
-		fmt.Printf("featureService: %v\n", featureService.Name)
 		_, requestedSortedFeatureViews, _, err =
 			onlineserving.GetFeatureViewsToUseByService(featureService, fvs, sortedFvs, odFvs)
 	} else {
-		fmt.Printf("featureRefs: %v\n", featureRefs)
 		_, requestedSortedFeatureViews, _, err =
 			onlineserving.GetFeatureViewsToUseByFeatureRefs(featureRefs, fvs, sortedFvs, odFvs)
 	}
@@ -406,7 +389,6 @@ func (fs *FeatureStore) listAllViews() (map[string]*model.FeatureView, map[strin
 
 func (fs *FeatureStore) fetchViewsAndEntities() (map[string]*model.FeatureView, map[string]*model.SortedFeatureView, map[string]*model.OnDemandFeatureView, []*model.Entity, error) {
 	fvs, sortedFvs, odFvs, err := fs.listAllViews()
-
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -209,10 +209,12 @@ func GetFeatureViewsToUseByFeatureRefs(
 
 	for _, featureRef := range features {
 		featureViewName, featureName, err := ParseFeatureReference(featureRef)
+		fmt.Printf("featureViewName: %s, featureName: %s\n", featureViewName, featureName)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		if fv, ok := featureViews[featureViewName]; ok {
+			fmt.Printf("fv: %s\n", fv)
 			if viewAndRef, ok := viewNameToViewAndRefs[fv.Base.Name]; ok {
 				viewAndRef.FeatureRefs = addStringIfNotContains(viewAndRef.FeatureRefs, featureName)
 			} else {
@@ -222,6 +224,7 @@ func GetFeatureViewsToUseByFeatureRefs(
 				}
 			}
 		} else if sortedFv, ok := sortedFeatureViews[featureViewName]; ok {
+			fmt.Printf("sortedFv: %s\n", sortedFv)
 			if viewAndRef, ok := viewNameToSortedViewAndRefs[sortedFv.Base.Name]; ok {
 				viewAndRef.FeatureRefs = addStringIfNotContains(viewAndRef.FeatureRefs, featureName)
 			} else {

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -207,16 +207,12 @@ func GetFeatureViewsToUseByFeatureRefs(
 	viewNameToSortedViewAndRefs := make(map[string]*SortedFeatureViewAndRefs)
 	odFvToFeatures := make(map[string][]string)
 
-	fmt.Printf("features: %v\n", features)
-
 	for _, featureRef := range features {
 		featureViewName, featureName, err := ParseFeatureReference(featureRef)
-		fmt.Printf("featureViewName: %s, featureName: %s\n", featureViewName, featureName)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		if fv, ok := featureViews[featureViewName]; ok {
-			fmt.Printf("fv: %s\n", fv)
 			if viewAndRef, ok := viewNameToViewAndRefs[fv.Base.Name]; ok {
 				viewAndRef.FeatureRefs = addStringIfNotContains(viewAndRef.FeatureRefs, featureName)
 			} else {
@@ -226,7 +222,6 @@ func GetFeatureViewsToUseByFeatureRefs(
 				}
 			}
 		} else if sortedFv, ok := sortedFeatureViews[featureViewName]; ok {
-			fmt.Printf("sortedFv: %s\n", sortedFv)
 			if viewAndRef, ok := viewNameToSortedViewAndRefs[sortedFv.Base.Name]; ok {
 				viewAndRef.FeatureRefs = addStringIfNotContains(viewAndRef.FeatureRefs, featureName)
 			} else {

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -207,6 +207,8 @@ func GetFeatureViewsToUseByFeatureRefs(
 	viewNameToSortedViewAndRefs := make(map[string]*SortedFeatureViewAndRefs)
 	odFvToFeatures := make(map[string][]string)
 
+	fmt.Printf("features: %v\n", features)
+
 	for _, featureRef := range features {
 		featureViewName, featureName, err := ParseFeatureReference(featureRef)
 		fmt.Printf("featureViewName: %s, featureName: %s\n", featureViewName, featureName)

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -185,14 +185,17 @@ func (u *repeatedValue) ToProto() *prototypes.RepeatedValue {
 
 func (filter sortKeyFilter) ToProto() (*serving.SortKeyFilter, error) {
 	proto := &serving.SortKeyFilter{
-		SortKeyName:    filter.SortKeyName,
+		SortKeyName: filter.SortKeyName,
+	}
+
+	rangeQuery := &serving.SortKeyFilter_RangeQuery{
 		StartInclusive: filter.StartInclusive,
 		EndInclusive:   filter.EndInclusive,
 	}
 
 	if filter.RangeStart != nil {
 		var err error
-		proto.RangeStart, err = parseValueFromJSON(filter.RangeStart)
+		rangeQuery.RangeStart, err = parseValueFromJSON(filter.RangeStart)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing range_start: %w", err)
 		}
@@ -200,10 +203,14 @@ func (filter sortKeyFilter) ToProto() (*serving.SortKeyFilter, error) {
 
 	if filter.RangeEnd != nil {
 		var err error
-		proto.RangeEnd, err = parseValueFromJSON(filter.RangeEnd)
+		rangeQuery.RangeEnd, err = parseValueFromJSON(filter.RangeEnd)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing range_end: %w", err)
 		}
+	}
+
+	proto.Query = &serving.SortKeyFilter_Range{
+		Range: rangeQuery,
 	}
 
 	return proto, nil

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -425,7 +425,7 @@ func (s *httpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 	}
 
 	// TODO: Implement support for feature services with range queries
-	featureService := &model.FeatureService{}
+	var featureService *model.FeatureService
 	if request.FeatureService != nil {
 		writeJSONError(w, fmt.Errorf("feature services are not supported for range queries"), http.StatusBadRequest)
 		return

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -98,6 +98,46 @@ func (u *repeatedValue) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+func parseValueFromJSON(data json.RawMessage) (*prototypes.Value, error) {
+	var result prototypes.Value
+
+	var stringVal string
+	if err := json.Unmarshal(data, &stringVal); err == nil {
+		result.Val = &prototypes.Value_StringVal{StringVal: stringVal}
+		return &result, nil
+	}
+
+	var intVal int64
+	if err := json.Unmarshal(data, &intVal); err == nil {
+		result.Val = &prototypes.Value_Int64Val{Int64Val: intVal}
+		return &result, nil
+	}
+
+	var floatVal float64
+	if err := json.Unmarshal(data, &floatVal); err == nil {
+		result.Val = &prototypes.Value_DoubleVal{DoubleVal: floatVal}
+		return &result, nil
+	}
+
+	var boolVal bool
+	if err := json.Unmarshal(data, &boolVal); err == nil {
+		result.Val = &prototypes.Value_BoolVal{BoolVal: boolVal}
+		return &result, nil
+	}
+
+	var valueObj map[string]interface{}
+	if err := json.Unmarshal(data, &valueObj); err == nil {
+		if timestampVal, ok := valueObj["unix_timestamp_val"]; ok {
+			if ts, ok := timestampVal.(float64); ok {
+				result.Val = &prototypes.Value_UnixTimestampVal{UnixTimestampVal: int64(ts)}
+				return &result, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not parse JSON value: %s", string(data))
+}
+
 func (u *repeatedValue) ToProto() *prototypes.RepeatedValue {
 	proto := new(prototypes.RepeatedValue)
 	if u.stringVal != nil {
@@ -141,6 +181,32 @@ func (u *repeatedValue) ToProto() *prototypes.RepeatedValue {
 		}
 	}
 	return proto
+}
+
+func (filter sortKeyFilter) ToProto() (*serving.SortKeyFilter, error) {
+	proto := &serving.SortKeyFilter{
+		SortKeyName:    filter.SortKeyName,
+		StartInclusive: filter.StartInclusive,
+		EndInclusive:   filter.EndInclusive,
+	}
+
+	if filter.RangeStart != nil {
+		var err error
+		proto.RangeStart, err = parseValueFromJSON(filter.RangeStart)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing range_start: %w", err)
+		}
+	}
+
+	if filter.RangeEnd != nil {
+		var err error
+		proto.RangeEnd, err = parseValueFromJSON(filter.RangeEnd)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing range_end: %w", err)
+		}
+	}
+
+	return proto, nil
 }
 
 type getOnlineFeaturesRequest struct {
@@ -299,9 +365,169 @@ func (s *httpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 	go releaseCGOMemory(featureVectors)
 }
 
+type getOnlineFeaturesRangeRequest struct {
+	FeatureService   *string                  `json:"feature_service"`
+	Features         []string                 `json:"features"`
+	Entities         map[string]repeatedValue `json:"entities"`
+	SortKeyFilters   []sortKeyFilter          `json:"sort_key_filters"`
+	ReverseSortOrder bool                     `json:"reverse_sort_order"`
+	Limit            int32                    `json:"limit"`
+	FullFeatureNames bool                     `json:"full_feature_names"`
+	RequestContext   map[string]repeatedValue `json:"request_context"`
+}
+
+type sortKeyFilter struct {
+	SortKeyName    string          `json:"sort_key_name"`
+	RangeStart     json.RawMessage `json:"range_start"`
+	RangeEnd       json.RawMessage `json:"range_end"`
+	StartInclusive bool            `json:"start_inclusive"`
+	EndInclusive   bool            `json:"end_inclusive"`
+}
+
+func (s *httpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "getOnlineFeaturesRange", tracer.ResourceName("/get-online-features-range"))
+	defer span.Finish(tracer.WithError(err))
+
+	logSpanContext := LogWithSpanContext(span)
+
+	if r.Method != "POST" {
+		http.NotFound(w, r)
+		return
+	}
+
+	statusQuery := r.URL.Query().Get("status")
+	status := false
+	if statusQuery != "" {
+		status, err = strconv.ParseBool(statusQuery)
+		if err != nil {
+			logSpanContext.Error().Err(err).Msg("Error parsing status query parameter")
+			writeJSONError(w, fmt.Errorf("error parsing status query parameter: %w", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	var request getOnlineFeaturesRangeRequest
+	err = decoder.Decode(&request)
+	if err != nil {
+		logSpanContext.Error().Err(err).Msg("Error decoding JSON request data")
+		writeJSONError(w, fmt.Errorf("error decoding JSON request data: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	// TODO: Implement support for feature services with range queries
+	featureService := &model.FeatureService{}
+	if request.FeatureService != nil {
+		writeJSONError(w, fmt.Errorf("feature services are not supported for range queries"), http.StatusBadRequest)
+		return
+	}
+
+	entitiesProto := make(map[string]*prototypes.RepeatedValue)
+	for key, value := range request.Entities {
+		entitiesProto[key] = value.ToProto()
+	}
+
+	requestContextProto := make(map[string]*prototypes.RepeatedValue)
+	if request.RequestContext != nil {
+		for key, value := range request.RequestContext {
+			requestContextProto[key] = value.ToProto()
+		}
+	}
+
+	sortKeyFiltersProto := make([]*serving.SortKeyFilter, len(request.SortKeyFilters))
+	for i, filter := range request.SortKeyFilters {
+		protoFilter, err := filter.ToProto()
+		if err != nil {
+			logSpanContext.Error().Err(err).Msg("Error converting sort key filter to protobuf")
+			writeJSONError(w, fmt.Errorf("error converting sort key filter to protobuf: %w", err), http.StatusInternalServerError)
+			return
+		}
+		sortKeyFiltersProto[i] = protoFilter
+	}
+
+	rangeFeatureVectors, err := s.fs.GetOnlineFeaturesRange(
+		ctx,
+		request.Features,
+		featureService,
+		entitiesProto,
+		sortKeyFiltersProto,
+		request.ReverseSortOrder,
+		request.Limit,
+		requestContextProto,
+		request.FullFeatureNames)
+
+	if err != nil {
+		logSpanContext.Error().Err(err).Msg("Error getting range feature vectors")
+		writeJSONError(w, fmt.Errorf("error getting range feature vectors: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	featureNames := make([]string, 0, len(rangeFeatureVectors))
+	results := make([]map[string]interface{}, 0, len(rangeFeatureVectors))
+
+	for _, vector := range rangeFeatureVectors {
+		featureNames = append(featureNames, vector.Name)
+		result := make(map[string]interface{})
+		rangeValues, err := types.ArrowValuesToRepeatedProtoValues(vector.RangeValues)
+		if err != nil {
+			logSpanContext.Error().Err(err).Msg("Error converting Arrow range values to proto values")
+			writeJSONError(w, fmt.Errorf("error converting Arrow range values to proto values: %w", err), http.StatusInternalServerError)
+			return
+		}
+
+		result["values"] = rangeValues
+		if status {
+			statuses := make([][]string, len(vector.RangeStatuses))
+			for i, entityStatuses := range vector.RangeStatuses {
+				statuses[i] = make([]string, len(entityStatuses))
+				for j, stat := range entityStatuses {
+					statuses[i][j] = stat.String()
+				}
+			}
+			result["statuses"] = statuses
+			timestamps := make([][]string, len(vector.RangeTimestamps))
+			for i, entityTimestamps := range vector.RangeTimestamps {
+				timestamps[i] = make([]string, len(entityTimestamps))
+				for j, ts := range entityTimestamps {
+					timestamps[i][j] = ts.AsTime().Format(time.RFC3339)
+				}
+			}
+			result["event_timestamps"] = timestamps
+		}
+
+		results = append(results, result)
+	}
+
+	response := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"feature_names": featureNames,
+		},
+		"results": results,
+		"status":  true,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		logSpanContext.Error().Err(err).Msg("Error encoding response")
+		writeJSONError(w, fmt.Errorf("error encoding response: %w", err), http.StatusInternalServerError)
+		return
+	}
+
+	go releaseCGORangeMemory(rangeFeatureVectors)
+}
+
 func releaseCGOMemory(featureVectors []*onlineserving.FeatureVector) {
 	for _, vector := range featureVectors {
 		vector.Values.Release()
+	}
+}
+
+func releaseCGORangeMemory(featureVectors []*onlineserving.RangeFeatureVector) {
+	for _, vector := range featureVectors {
+		vector.RangeValues.Release()
 	}
 }
 
@@ -373,6 +599,10 @@ func DefaultHttpHandlers(s *httpServer) []Handler {
 		{
 			path:        "/get-online-features",
 			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeatures)),
+		},
+		{
+			path:        "/get-online-features-range",
+			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeaturesRange)),
 		},
 		{
 			path:        "/metrics",

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -625,3 +625,5 @@ func (s *httpServer) Stop() error {
 	}
 	return nil
 }
+
+// new line


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR adds the implementation of range query to the http go server. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
Example request:
```
curl -X POST \
  "https://{test-url}/get-online-features-range?status=true" \
-d '{      
  "features": [            
    "batch_mat_sorted_fv:feature_1",
    "batch_mat_sorted_fv:feature_2",
    "batch_mat_sorted_fv:feature_3"
  ],      
  "entities": {    
    "entity_key": [  
      "entity_key_4"
    ]
  },          
  "sort_key_filters": [
    {                    
      "sort_key_name": "event_timestamp",
      "range_start": 1740000000,
      "start_inclusive": false,
      "end_inclusive": false
    }
  ],
  "reverse_sort_order": false,
  "limit": 10,
  "full_feature_names": true
}'
```
Response:
```
'{
    "metadata": {
        "feature_names": [
            "entity_key",
            "batch_mat_sorted_fv__feature_1",
            "batch_mat_sorted_fv__feature_2",
            "batch_mat_sorted_fv__feature_3"
        ]
    },
    "results": [
        {
            "event_timestamps": [
                [
                    "2025-05-07T15:30:51Z"
                ]
            ],
            "statuses": [
                [
                    "PRESENT"
                ]
            ],
            "values": [
                "entity_key_4"
            ]
        },
        {
            "event_timestamps": [
                [
                    "2025-04-11T20:14:03Z",
                    "2025-04-06T01:28:23Z",
                    "2025-04-05T20:30:21Z"
                ]
            ],
            "statuses": [
                [
                    "PRESENT",
                    "PRESENT",
                    "PRESENT"
                ]
            ],
            "values": [
                [
                    "YD2EV",
                    "ZGF3D",
                    "UNW5N"
                ]
            ]
        },
        {
            "event_timestamps": [
                [
                    "2025-04-11T20:14:03Z",
                    "2025-04-06T01:28:23Z",
                    "2025-04-05T20:30:21Z"
                ]
            ],
            "statuses": [
                [
                    "PRESENT",
                    "PRESENT",
                    "PRESENT"
                ]
            ],
            "values": [
                [
                    892,
                    800,
                    967
                ]
            ]
        },
        {
            "event_timestamps": [
                [
                    "2025-04-11T20:14:03Z",
                    "2025-04-06T01:28:23Z",
                    "2025-04-05T20:30:21Z"
                ]
            ],
            "statuses": [
                [
                    "PRESENT",
                    "PRESENT",
                    "PRESENT"
                ]
            ],
            "values": [
                [
                    97.080505,
                    94.33013,
                    99.56895
                ]
            ]
        }
    ],
    "status": true
}
<img width="571" alt="Screenshot 2025-05-07 at 10 35 26 AM" src="https://github.com/user-attachments/assets/aabe688a-7efc-40db-85e6-d4795cfffb62" />
'
```