### PR TITLE
feat: Adding in sortOrder check for OnlineReadRange Functionality

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -2,6 +2,7 @@ package feast
 
 import (
 	"context"
+	"fmt"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/feast-dev/feast/go/internal/feast/model"
@@ -141,31 +142,41 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	now := time.Now()
 	oneWeekAgo := now.AddDate(0, 0, -7)
 
-	sortKeyFilters := []*serving.SortKeyFilter{
-		{
-			SortKeyName: "event_timestamp",
-			Query: &serving.SortKeyFilter_Range{
-				Range: &serving.SortKeyFilter_RangeQuery{
-					RangeStart: &types.Value{
-						Val: &types.Value_UnixTimestampVal{
-							UnixTimestampVal: oneWeekAgo.Unix(),
-						},
-					},
-					RangeEnd: &types.Value{
-						Val: &types.Value_UnixTimestampVal{
-							UnixTimestampVal: now.Unix(),
-						},
-					},
-					StartInclusive: true,
-					EndInclusive:   true,
+	sortKeyProto := &serving.SortKeyFilter{
+		SortKeyName: "event_timestamp",
+		Query: &serving.SortKeyFilter_Range{
+			Range: &serving.SortKeyFilter_RangeQuery{
+				RangeStart: &types.Value{
+					Val: &types.Value_UnixTimestampVal{UnixTimestampVal: oneWeekAgo.Unix()},
 				},
+				RangeEnd: &types.Value{
+					Val: &types.Value_UnixTimestampVal{UnixTimestampVal: now.Unix()},
+				},
+				StartInclusive: true,
+				EndInclusive:   true,
 			},
 		},
 	}
-	asc := core.SortOrder_ASC
-	sortKeyFilterModels := []*model.SortKeyFilter{
-		model.NewSortKeyFilterFromProto(sortKeyFilters[0], &asc),
-	}
+
+	expectedFilter := model.NewSortKeyFilterFromProto(sortKeyProto, nil)
+	filterMatcher := mock.MatchedBy(func(fs []*model.SortKeyFilter) bool {
+		if len(fs) != 1 {
+			return false
+		}
+		f := fs[0]
+		sameBase :=
+			f.SortKeyName == expectedFilter.SortKeyName &&
+				f.StartInclusive == expectedFilter.StartInclusive &&
+				f.EndInclusive == expectedFilter.EndInclusive &&
+				fmt.Sprint(f.RangeStart) == fmt.Sprint(expectedFilter.RangeStart) &&
+				fmt.Sprint(f.RangeEnd) == fmt.Sprint(expectedFilter.RangeEnd)
+
+		if f.Order == nil && expectedFilter.Order == nil {
+			return sameBase
+		}
+		return sameBase && f.Order != nil && expectedFilter.Order != nil &&
+			f.Order.Order == expectedFilter.Order.Order
+	})
 
 	mockRangeFeatureData := [][]onlinestore.RangeFeatureData{
 		{
@@ -226,7 +237,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		mock.AnythingOfType("[]*types.EntityKey"),
 		featureViewNamesMatcher,
 		[]string{"conv_rate", "acc_rate"},
-		sortKeyFilterModels,
+		filterMatcher,
 		int32(0),
 	).Return(mockRangeFeatureData, nil)
 
@@ -237,7 +248,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		[]*model.Entity{testEntity},
 		[]*model.SortedFeatureView{sortedFV},
 		entityValues,
-		sortKeyFilters,
+		[]*serving.SortKeyFilter{sortKeyProto},
 		false,
 		0,
 		nil,

--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -162,8 +162,9 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 			},
 		},
 	}
+	asc := core.SortOrder_ASC
 	sortKeyFilterModels := []*model.SortKeyFilter{
-		model.NewSortKeyFilterFromProto(sortKeyFilters[0], core.SortOrder_ASC),
+		model.NewSortKeyFilterFromProto(sortKeyFilters[0], &asc),
 	}
 
 	mockRangeFeatureData := [][]onlinestore.RangeFeatureData{

--- a/go/internal/feast/model/sortedfeatureview.go
+++ b/go/internal/feast/model/sortedfeatureview.go
@@ -97,7 +97,13 @@ type SortKeyFilter struct {
 	Order          *SortOrder
 }
 
-func NewSortKeyFilterFromProto(proto *serving.SortKeyFilter, sortOrder core.SortOrder_Enum) *SortKeyFilter {
+func NewSortKeyFilterFromProto(
+	proto *serving.SortKeyFilter,
+	sortOrderPtr *core.SortOrder_Enum,
+) *SortKeyFilter {
+
+	order := NewSortOrderFromProtoPtr(sortOrderPtr)
+
 	if proto.GetRange() != nil {
 		return &SortKeyFilter{
 			SortKeyName:    proto.GetSortKeyName(),
@@ -105,13 +111,20 @@ func NewSortKeyFilterFromProto(proto *serving.SortKeyFilter, sortOrder core.Sort
 			RangeEnd:       types2.ValueTypeToGoType(proto.GetRange().GetRangeEnd()),
 			StartInclusive: proto.GetRange().GetStartInclusive(),
 			EndInclusive:   proto.GetRange().GetEndInclusive(),
-			Order:          NewSortOrderFromProto(sortOrder),
+			Order:          order,
 		}
 	}
 
 	return &SortKeyFilter{
 		SortKeyName: proto.GetSortKeyName(),
 		Equals:      types2.ValueTypeToGoType(proto.GetEquals()),
-		Order:       NewSortOrderFromProto(sortOrder),
+		Order:       order,
 	}
+}
+
+func NewSortOrderFromProtoPtr(ptr *core.SortOrder_Enum) *SortOrder {
+	if ptr == nil {
+		return nil
+	}
+	return &SortOrder{Order: *ptr}
 }

--- a/go/internal/feast/model/test/sortedfeatureview_test.go
+++ b/go/internal/feast/model/test/sortedfeatureview_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"github.com/feast-dev/feast/go/internal/feast/model"
+	"testing"
+
+	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
+	"github.com/feast-dev/feast/go/protos/feast/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSortOrderFromProtoPtr(t *testing.T) {
+
+	assert.Nil(t, model.NewSortOrderFromProtoPtr(nil))
+
+	asc := core.SortOrder_ASC
+	so := model.NewSortOrderFromProtoPtr(&asc)
+	if assert.NotNil(t, so) {
+		assert.Equal(t, asc, so.Order)
+		assert.Equal(t, "ASC", so.String())
+		assert.Equal(t, asc, so.ToProto())
+	}
+}
+
+func TestNewSortKeyFilterFromProto_Equals(t *testing.T) {
+	eqVal := &types.Value{Val: &types.Value_Int64Val{Int64Val: 42}}
+
+	req := &serving.SortKeyFilter{
+		SortKeyName: "price",
+		Query:       &serving.SortKeyFilter_Equals{Equals: eqVal},
+	}
+
+	asc := core.SortOrder_ASC
+	f := model.NewSortKeyFilterFromProto(req, &asc)
+
+	assert.Equal(t, "price", f.SortKeyName)
+	assert.EqualValues(t, 42, f.Equals)
+	assert.Nil(t, f.RangeStart)
+	assert.Equal(t, asc, f.Order.Order)
+}
+
+func TestNewSortKeyFilterFromProto_Range(t *testing.T) {
+	rq := &serving.SortKeyFilter_RangeQuery{
+		RangeStart:     &types.Value{Val: &types.Value_Int64Val{Int64Val: 100}},
+		RangeEnd:       &types.Value{Val: &types.Value_Int64Val{Int64Val: 200}},
+		StartInclusive: true,
+		EndInclusive:   false,
+	}
+	req := &serving.SortKeyFilter{
+		SortKeyName: "ts",
+		Query:       &serving.SortKeyFilter_Range{Range: rq},
+	}
+
+	desc := core.SortOrder_DESC
+	f := model.NewSortKeyFilterFromProto(req, &desc)
+
+	assert.Equal(t, int64(100), f.RangeStart)
+	assert.Equal(t, int64(200), f.RangeEnd)
+	assert.True(t, f.StartInclusive)
+	assert.False(t, f.EndInclusive)
+	assert.Equal(t, desc, f.Order.Order)
+}
+
+func TestNewSortKeyFilterFromProto_NoOrderOverride(t *testing.T) {
+	req := &serving.SortKeyFilter{
+		SortKeyName: "id",
+		Query: &serving.SortKeyFilter_Equals{
+			Equals: &types.Value{Val: &types.Value_Int32Val{Int32Val: 7}},
+		},
+	}
+
+	f := model.NewSortKeyFilterFromProto(req, nil)
+
+	assert.Equal(t, "id", f.SortKeyName)
+	assert.EqualValues(t, 7, f.Equals)
+	assert.Nil(t, f.Order)
+}

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -761,14 +761,14 @@ func TestGroupSortedFeatureRefs(t *testing.T) {
 			assert.Equal(t, sortKeyFilters[0].GetEquals().GetUnixTimestampVal(), group.SortKeyFilters[0].Equals)
 			assert.Nil(t, group.SortKeyFilters[0].RangeStart)
 			assert.Nil(t, group.SortKeyFilters[0].RangeEnd)
-			assert.Equal(t, "DESC", group.SortKeyFilters[0].Order.Order.String())
+			assert.Nil(t, group.SortKeyFilters[0].Order)
 		} else {
 			assert.Equal(t, sortKeyFilters[1].SortKeyName, group.SortKeyFilters[0].SortKeyName)
 			assert.Equal(t, sortKeyFilters[1].GetRange().RangeEnd.GetDoubleVal(), group.SortKeyFilters[0].RangeEnd)
 			assert.Equal(t, sortKeyFilters[1].GetRange().EndInclusive, group.SortKeyFilters[0].EndInclusive)
 			assert.Nil(t, group.SortKeyFilters[0].RangeStart)
 			assert.Nil(t, group.SortKeyFilters[0].Equals)
-			assert.Equal(t, "ASC", group.SortKeyFilters[0].Order.Order.String())
+			assert.Nil(t, group.SortKeyFilters[0].Order)
 		}
 		assert.Equal(t, int32(10), group.Limit)
 	}


### PR DESCRIPTION
# What this PR does / why we need it:

We identify if the sort key order is reversed is true, if it is true use unbatchedOnlineReadRange instead of BatchedOnlineReadRange as ScyllaDB doesn’t allow for PARTITION BY & ORDER BY in the same query.

