### PR TITLE
fix: Upgraded java grpc version from 1.30.2 to 1.53.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,7 +42,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.custom.groupId>dev.feast</project.custom.groupId>
 
-        <grpc.version>1.30.2</grpc.version>
+        <grpc.version>1.53.0</grpc.version>
         <protoc.version>3.12.2</protoc.version>
         <protobuf.version>3.16.1</protobuf.version>
         <com.google.cloud.version>1.111.1</com.google.cloud.version>

--- a/java/serving/src/test/java/feast/serving/it/ServingRedisS3RegistryIT.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingRedisS3RegistryIT.java
@@ -34,7 +34,7 @@ import org.testcontainers.junit.jupiter.Container;
 public class ServingRedisS3RegistryIT extends ServingBaseTests {
   private static final String TEST_REGION = "us-east-1";
   private static final String TEST_BUCKET = "test-bucket";
-  @Container static final S3MockContainer s3Mock = new S3MockContainer("2.2.3");
+  @Container static final S3MockContainer s3Mock = new S3MockContainer("4.3.0");
   private static final AWSStaticCredentialsProvider credentials =
       new AWSStaticCredentialsProvider(new BasicAWSCredentials("anyAccessKey", "anySecretKey"));
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Upgrading GRPC version 1.30.2 to 1.53.0. 1.30.2 is very old version (Jun, 2020) upgrading to 1.53.0 (which is also not latest). 1.53.0 is the current lowest version used internally. This eventually upgrades to Latest version. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
