### PR TITLE
fix: Batch materialization job should not succeed in case of any erro…

### DIFF
--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -399,7 +399,7 @@ class CassandraOnlineStore(OnlineStore):
                       display progress.
         """
         is_error: bool = False
-        ex: BaseException
+        ex: Exception = Exception("Exception raised while writing a batch")
 
         def on_success(result, concurrent_queue):
             concurrent_queue.get_nowait()

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -398,16 +398,13 @@ class CassandraOnlineStore(OnlineStore):
                       rows is written to the online store. Can be used to
                       display progress.
         """
-        is_error: bool = False
-        ex: Exception = Exception("Exception raised while writing a batch")
+        ex: Optional[Exception] = None
 
         def on_success(result, concurrent_queue):
             concurrent_queue.get_nowait()
 
         def on_failure(exc, concurrent_queue):
-            nonlocal is_error
             nonlocal ex
-            is_error = True
             ex = exc
             concurrent_queue.get_nowait()
             logger.exception(f"Error writing a batch: {exc}")
@@ -622,13 +619,18 @@ class CassandraOnlineStore(OnlineStore):
                         on_failure,
                     )
 
+        if ex:
+            raise ex
+
         if not concurrent_queue.empty():
             logger.warning(
                 f"Waiting for futures. Pending are {concurrent_queue.qsize()}"
             )
             while not concurrent_queue.empty():
+                if ex:
+                    raise ex
                 time.sleep(0.001)
-            if is_error:
+            if ex:
                 raise ex
             # Spark materialization engine doesn't log info messages
             # so we print the message to stdout

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -285,7 +285,6 @@ class TestCassandraOnlineStore:
 
     def test_validate_invalid_request_error_when_sort_keys_are_null(
         self,
-        cassandra_session,
         repo_config: RepoConfig,
         online_store: CassandraOnlineStore,
     ):

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -284,10 +284,10 @@ class TestCassandraOnlineStore:
         assert count[0] == 10
 
     def test_validate_invalid_request_error_when_sort_keys_are_null(
-            self,
-            cassandra_session,
-            repo_config: RepoConfig,
-            online_store: CassandraOnlineStore,
+        self,
+        cassandra_session,
+        repo_config: RepoConfig,
+        online_store: CassandraOnlineStore,
     ):
         (
             feature_view,
@@ -303,7 +303,10 @@ class TestCassandraOnlineStore:
                 data=data,
                 progress=None,
             )
-        assert str(excinfo.value) == 'Error from server: code=2200 [Invalid query] message="Invalid null value in condition for column int"'
+        assert (
+            str(excinfo.value)
+            == 'Error from server: code=2200 [Invalid query] message="Invalid null value in condition for column int"'
+        )
 
     def test_cassandra_online_write_batch_ttl(
         self,
@@ -560,7 +563,7 @@ class TestCassandraOnlineStore:
                 },
                 datetime.utcnow(),
                 None,
-            )
+            ),
         ]
 
     def _create_n_test_sample_features_all_datatypes(self, n=10):

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime, timedelta
 
 import pytest
+from cassandra import InvalidRequest
 from cassandra.cluster import Cluster
 
 from feast import Entity, Field, FileSource, RepoConfig, ValueType
@@ -282,6 +283,28 @@ class TestCassandraOnlineStore:
         count = [row.count for row in result]
         assert count[0] == 10
 
+    def test_validate_invalid_request_error_when_sort_keys_are_null(
+            self,
+            cassandra_session,
+            repo_config: RepoConfig,
+            online_store: CassandraOnlineStore,
+    ):
+        (
+            feature_view,
+            data,
+        ) = self._create_test_sample_features_with_null_sort_keys()
+
+        online_store._create_table(repo_config, repo_config.project, feature_view)
+
+        with pytest.raises(InvalidRequest) as excinfo:
+            online_store.online_write_batch(
+                config=repo_config,
+                table=feature_view,
+                data=data,
+                progress=None,
+            )
+        assert str(excinfo.value) == 'Error from server: code=2200 [Invalid query] message="Invalid null value in condition for column int"'
+
     def test_cassandra_online_write_batch_ttl(
         self,
         cassandra_session,
@@ -479,6 +502,65 @@ class TestCassandraOnlineStore:
                 None,
             )
             for i in range(n)
+        ]
+
+    def _create_test_sample_features_with_null_sort_keys(self):
+        fv = SortedFeatureView(
+            name="sortedfv",
+            source=FileSource(
+                name="my_file_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="id")],
+            ttl=timedelta(seconds=10),
+            sort_keys=[
+                SortKey(
+                    name="int",
+                    value_type=ValueType.INT32,
+                    default_sort_order=SortOrder.DESC,
+                )
+            ],
+            schema=[
+                Field(
+                    name="id",
+                    dtype=String,
+                ),
+                Field(
+                    name="text",
+                    dtype=String,
+                ),
+                Field(
+                    name="int",
+                    dtype=Int32,
+                ),
+            ],
+        )
+        return fv, [
+            (
+                EntityKeyProto(
+                    join_keys=["id"],
+                    entity_values=[ValueProto(string_val=str(1))],
+                ),
+                {
+                    "text": ValueProto(string_val="text"),
+                    "int": ValueProto(null_val=None),
+                },
+                datetime.utcnow(),
+                None,
+            ),
+            (
+                EntityKeyProto(
+                    join_keys=["id"],
+                    entity_values=[ValueProto(string_val=str(2))],
+                ),
+                {
+                    "text": ValueProto(string_val="text"),
+                    "int": ValueProto(int32_val=1),
+                },
+                datetime.utcnow(),
+                None,
+            )
         ]
 
     def _create_n_test_sample_features_all_datatypes(self, n=10):


### PR DESCRIPTION
[test-logs.log](https://github.com/user-attachments/files/20328338/test-logs.log)
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Currently, the batch materialization spark job pretends like its successful even though there were errors during the materialization (for example, the materialization fails if the value of any primary key column is null) and the materialization was not successful in reality. This is because, the errors are never propagated from online_write_batch method. In this PR, the error is re-thrown in online_write_batch which ultimately fails the job.

# Which issue(s) this PR fixes:
https://expediagroup.atlassian.net/browse/EAPC-17414


# Test
Test logs are attached where I tried to materialize features that has null values for sort key columns and as seen in the logs, the job was failed and the error is logged there.
