### PR TITLE
fix: Change sort key filter json structure to match proto

### DIFF
--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -201,20 +201,20 @@ func (filter sortKeyFilter) ToProto() (*serving.SortKeyFilter, error) {
 	}
 
 	rangeQuery := &serving.SortKeyFilter_RangeQuery{
-		StartInclusive: filter.StartInclusive,
-		EndInclusive:   filter.EndInclusive,
+		StartInclusive: filter.Range.StartInclusive,
+		EndInclusive:   filter.Range.EndInclusive,
 	}
 
-	if filter.RangeStart != nil {
-		value, err := parseValueFromJSON(filter.RangeStart)
+	if filter.Range.RangeStart != nil {
+		value, err := parseValueFromJSON(filter.Range.RangeStart)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing range_start: %w", err)
 		}
 		rangeQuery.RangeStart = value
 	}
 
-	if filter.RangeEnd != nil {
-		value, err := parseValueFromJSON(filter.RangeEnd)
+	if filter.Range.RangeEnd != nil {
+		value, err := parseValueFromJSON(filter.Range.RangeEnd)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing range_end: %w", err)
 		}
@@ -401,10 +401,14 @@ type getOnlineFeaturesRangeRequest struct {
 }
 
 type sortKeyFilter struct {
-	SortKeyName    string          `json:"sort_key_name"`
+	SortKeyName string          `json:"sort_key_name"`
+	Range       rangeQuery      `json:"range"`
+	Equals      json.RawMessage `json:"equals"`
+}
+
+type rangeQuery struct {
 	RangeStart     json.RawMessage `json:"range_start"`
 	RangeEnd       json.RawMessage `json:"range_end"`
-	Equals         json.RawMessage `json:"equals"`
 	StartInclusive bool            `json:"start_inclusive"`
 	EndInclusive   bool            `json:"end_inclusive"`
 }


### PR DESCRIPTION
# What this PR does / why we need it:
The json structure for sortKeyFilters should match the same structure as protos with either a `range` object with range parameters or an `equals` node set to a raw value.
`"sort_key_filters": [
    {                    
      "sort_key_name": "feature_5",
      "equals": 126.8
    },
    {                    
      "sort_key_name": "event_timestamp",
      "range": {
        "range_start": 1740000000,
      	"start_inclusive": true,
      	"end_inclusive": false
	  }
    }
  ],`

# Which issue(s) this PR fixes:



# Misc

