### PR TITLE
fix: Add optional status parameter to grpc_server, serving-client

### DIFF
--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -98,7 +98,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 			Values: values,
 		}
 
-		if !request.GetStatus() {
+		if !request.GetOmitStatus() {
 			featureVector.Statuses = vector.Statuses
 			featureVector.EventTimestamps = vector.Timestamps
 		}
@@ -210,7 +210,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 			Values: rangeValues,
 		}
 
-		if !request.GetStatus() {
+		if !request.GetOmitStatus() {
 			featureVector.Statuses = rangeStatuses
 			featureVector.EventTimestamps = timeValues
 		}

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -99,7 +99,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		}
 
 		if request.status {
-			featureVector.status = vector.Statuses
+			featureVector.Statuses = vector.Statuses
 			featureVector.EventTimestamps = vector.Timestamps
 		}
 
@@ -206,12 +206,12 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 			timeValues[j] = &prototypes.RepeatedValue{Val: timestampValues}
 		}
 
-		featureVector := &serving.GetOnlineFeaturesResponse_FeatureVector{
+		featureVector := &serving.GetOnlineFeaturesRangeResponse_RangeFeatureVector{
 			Values: rangeValues,
 		}
 
 		if request.status {
-			featureVector.status = vector.RangeStatuses
+			featureVector.Statuses = vector.RangeStatuses
 			featureVector.EventTimestamps = vector.RangeTimestamps
 		}
 

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -98,7 +98,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 			Values: values,
 		}
 
-		if request.status {
+		if request.GetStatus() {
 			featureVector.Statuses = vector.Statuses
 			featureVector.EventTimestamps = vector.Timestamps
 		}
@@ -210,9 +210,9 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 			Values: rangeValues,
 		}
 
-		if request.status {
-			featureVector.Statuses = vector.RangeStatuses
-			featureVector.EventTimestamps = vector.RangeTimestamps
+		if !request.GetStatus() {
+			featureVector.Statuses = rangeStatuses
+			featureVector.EventTimestamps = timeValues
 		}
 
 		resp.Results = append(resp.Results, featureVector)

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -98,7 +98,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 			Values: values,
 		}
 
-		if request.GetStatus() {
+		if !request.GetStatus() {
 			featureVector.Statuses = vector.Statuses
 			featureVector.EventTimestamps = vector.Timestamps
 		}

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -94,11 +94,16 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 			entityValuesMap[vector.Name] = values
 		}
 
-		resp.Results = append(resp.Results, &serving.GetOnlineFeaturesResponse_FeatureVector{
-			Values:          values,
-			Statuses:        vector.Statuses,
-			EventTimestamps: vector.Timestamps,
-		})
+		featureVector := &serving.GetOnlineFeaturesResponse_FeatureVector{
+			Values: values,
+		}
+
+		if request.status {
+			featureVector.status = vector.Statuses
+			featureVector.EventTimestamps = vector.Timestamps
+		}
+
+		resp.Results = append(resp.Results, featureVector)
 	}
 
 	featureService := featuresOrService.FeatureService
@@ -141,7 +146,8 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		request.GetReverseSortOrder(),
 		request.GetLimit(),
 		request.GetRequestContext(),
-		request.GetFullFeatureNames())
+		request.GetFullFeatureNames(),
+	)
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")
@@ -200,11 +206,16 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 			timeValues[j] = &prototypes.RepeatedValue{Val: timestampValues}
 		}
 
-		resp.Results = append(resp.Results, &serving.GetOnlineFeaturesRangeResponse_RangeFeatureVector{
-			Values:          rangeValues,
-			Statuses:        rangeStatuses,
-			EventTimestamps: timeValues,
-		})
+		featureVector := &serving.GetOnlineFeaturesResponse_FeatureVector{
+			Values: rangeValues,
+		}
+
+		if request.status {
+			featureVector.status = vector.RangeStatuses
+			featureVector.EventTimestamps = vector.RangeTimestamps
+		}
+
+		resp.Results = append(resp.Results, featureVector)
 	}
 
 	// TODO: Implement logging for GetOnlineFeaturesRange for feature services when support for feature services is added

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -18,6 +18,7 @@ package dev.feast;
 
 import com.google.common.collect.Lists;
 import feast.proto.serving.ServingAPIProto;
+import feast.proto.serving.ServingAPIProto.FieldStatus;
 import feast.proto.serving.ServingAPIProto.GetFeastServingInfoRequest;
 import feast.proto.serving.ServingAPIProto.GetFeastServingInfoResponse;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRangeRequest;
@@ -76,7 +77,7 @@ public class FeastClient implements AutoCloseable {
   public static FeastClient create(String host, int port, long requestTimeout) {
     // configure client with no security config.
     return FeastClient.createSecure(
-        host, port, SecurityConfig.newBuilder().build(), requestTimeout, Optional.empty(), false);
+        host, port, SecurityConfig.newBuilder().build(), requestTimeout, Optional.empty());
   }
 
   /**
@@ -89,7 +90,7 @@ public class FeastClient implements AutoCloseable {
    * @return {@link FeastClient}
    */
   public static FeastClient createSecure(String host, int port, SecurityConfig securityConfig) {
-    return FeastClient.createSecure(host, port, securityConfig, 0, Optional.empty(), false);
+    return FeastClient.createSecure(host, port, securityConfig, 0, Optional.empty());
   }
 
   /**
@@ -239,25 +240,24 @@ public class FeastClient implements AutoCloseable {
     return resp;
   }
 
-  public List<Row> getOnlineFeatures(GetOnlineFeaturesRequest getOnlineFeaturesRequest, List<Row> entities) {
-    if (getOnlineFeatures.getFeatureService.isEmpty() && getOnlineFeatures.getFeatures().getValCount() == 0) {
+  public List<Row> getOnlineFeatures(
+      GetOnlineFeaturesRequest getOnlineFeaturesRequest, List<Row> entities) {
+    if (getOnlineFeaturesRequest.getFeatureService().isEmpty()
+        && getOnlineFeaturesRequest.getFeatures().getValCount() == 0) {
       logger.info(
-        "Neither a featureService or featureRef was present in the request with request: {}, entities: {}",
-        getOnlineFeatures.toString(),
-        entities
-      );
+          "Neither a featureService or featureRef was present in the request with request: {}, entities: {}",
+          getOnlineFeaturesRequest.toString(),
+          entities);
 
       return Collections.emptyList();
     }
 
-    requestBuilder.putAllEntities(getEntityValuesMap(entities));
-
-    List<Row> resp = fetchOnlineFeatures(requestBuilder, entities);
+    List<Row> resp = fetchOnlineFeatures(getOnlineFeaturesRequest, entities);
 
     if (resp.size() == 0) {
       logger.info(
-          "Result was empty for getOnlineFeatures call with featureRefs: {}, entities: {}",
-          featureRefs,
+          "Result was empty for getOnlineFeatures call with getOnlineFeaturesRequest: {}, entities: {}",
+          getOnlineFeaturesRequest.toString(),
           entities);
     }
 
@@ -280,30 +280,29 @@ public class FeastClient implements AutoCloseable {
     for (int rowIdx = 0; rowIdx < response.getResults(0).getValuesCount(); rowIdx++) {
       Row row = Row.create();
       for (int featureIdx = 0; featureIdx < response.getResultsCount(); featureIdx++) {
-        if (getOnlineFeaturesRequest.hasStatus()) { 
+        if (getOnlineFeaturesRequest.getStatus()) {
           row.set(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
-              response.getResults(featureIdx).getValues(rowIdx)
-            );
-          } else {
+              response.getResults(featureIdx).getValues(rowIdx));
+        } else {
           row.setWithStatus(
-            response.getMetadata().getFeatureNames().getVal(featureIdx),
-            response.getResults(featureIdx).getValues(rowIdx),
-            response.getResults(featureIdx).getStatuses(rowIdx));
+              response.getMetadata().getFeatureNames().getVal(featureIdx),
+              response.getResults(featureIdx).getValues(rowIdx),
+              response.getResults(featureIdx).getStatuses(rowIdx));
 
           row.setEntityTimestamp(
-            Instant.ofEpochSecond(
-                response.getResults(featureIdx).getEventTimestamps(rowIdx).getSeconds()));
+              Instant.ofEpochSecond(
+                  response.getResults(featureIdx).getEventTimestamps(rowIdx).getSeconds()));
         }
       }
 
       for (Map.Entry<String, ValueProto.Value> entry :
           entities.get(rowIdx).getFields().entrySet()) {
-            if (response.hasStatus()) {
-              row.set(entry.getKey(), entry.getValue());
-          } else {
-              row.setWithStatus(entry.getKey(), entry.getValue(), FieldStatus.PRESENT);
-          }
+        if (response.getStatus()) {
+          row.set(entry.getKey(), entry.getValue());
+        } else {
+          row.setWithStatus(entry.getKey(), entry.getValue(), FieldStatus.PRESENT);
+        }
       }
 
       results.add(row);
@@ -354,8 +353,6 @@ public class FeastClient implements AutoCloseable {
     return getOnlineFeatures(featureRefs, rows);
   }
 
-
-
   /**
    * Get online features from Feast given a feature service name. Internally feature service calls
    * resolve featureViews via a call to the feature registry.
@@ -382,14 +379,14 @@ public class FeastClient implements AutoCloseable {
     return getOnlineFeatures(featureService, rows);
   }
 
-
   /**
-   * Get online features from Feast given a getOnlineFeaturesRequest proto object. 
-   * 
-   * @param getOnlineFeaturesRequest getOnlineFeaturesRequest as defined within {@link }
+   * Get online features from Feast given a getOnlineFeaturesRequest proto object.
+   *
+   * @param getOnlineFeaturesRequest getOnlineFeaturesRequest proto object
+   * @return list of {@link Row} containing retrieved data fields.
    */
-  public List<Row> getOnlineFeatures(GetOnlineFeaturesRequest getOnlineFeaturesRequest, List<Row> rows, String project) {
-    return getOnlineFeatures(getOnlineFeaturesRequest, rows);
+  public List<Row> getOnlineFeatures(GetOnlineFeaturesRequest getOnlineFeaturesRequest) {
+    return getOnlineFeatures(getOnlineFeaturesRequest);
   }
 
   /**
@@ -411,9 +408,10 @@ public class FeastClient implements AutoCloseable {
       List<Row> entities,
       List<SortKeyFilterModel> sortKeyFilters,
       int limit,
-      boolean reverseSortOrder) {
+      boolean reverseSortOrder,
+      boolean status) {
     GetOnlineFeaturesRangeRequest.Builder requestBuilder =
-        GetOnlineFeaturesRangeRequest.newBuilder();
+        GetOnlineFeaturesRangeRequest.newBuilder().setStatus(status);
 
     requestBuilder.setFeatures(
         ServingAPIProto.FeatureList.newBuilder().addAllVal(featureRefs).build());
@@ -445,15 +443,21 @@ public class FeastClient implements AutoCloseable {
     for (int rowIdx = 0; rowIdx < response.getResults(0).getValuesCount(); rowIdx++) {
       RangeRow row = RangeRow.create();
       for (int featureIdx = 0; featureIdx < response.getResultsCount(); featureIdx++) {
-        row.setWithValues(
-            response.getMetadata().getFeatureNames().getVal(featureIdx),
-            response.getResults(featureIdx).getValues(rowIdx).getValList(),
-            response.getResults(featureIdx).getStatuses(rowIdx).getStatusList());
+        if (status) {
+          row.setWithValues(
+              response.getMetadata().getFeatureNames().getVal(featureIdx),
+              response.getResults(featureIdx).getValues(rowIdx).getValList());
+        } else {
+          row.setWithValuesWithStatus(
+              response.getMetadata().getFeatureNames().getVal(featureIdx),
+              response.getResults(featureIdx).getValues(rowIdx).getValList(),
+              response.getResults(featureIdx).getStatuses(rowIdx).getStatusList());
 
-        row.setEntityTimestamp(
-            response.getResults(featureIdx).getEventTimestamps(rowIdx).getValList().stream()
-                .map(v -> Instant.ofEpochSecond(v.getUnixTimestampVal()))
-                .collect(Collectors.toList()));
+          row.setEntityTimestamp(
+              response.getResults(featureIdx).getEventTimestamps(rowIdx).getValList().stream()
+                  .map(v -> Instant.ofEpochSecond(v.getUnixTimestampVal()))
+                  .collect(Collectors.toList()));
+        }
       }
       for (Map.Entry<String, ValueProto.Value> entry :
           entities.get(rowIdx).getFields().entrySet()) {
@@ -472,7 +476,20 @@ public class FeastClient implements AutoCloseable {
       int limit,
       boolean reverseSortOrder,
       String project) {
-    return getOnlineFeaturesRange(featureRefs, rows, sortKeyFilters, limit, reverseSortOrder);
+    return getOnlineFeaturesRange(
+        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, false);
+  }
+
+  public List<RangeRow> getOnlineFeaturesRange(
+      List<String> featureRefs,
+      List<Row> rows,
+      List<SortKeyFilterModel> sortKeyFilters,
+      int limit,
+      boolean reverseSortOrder,
+      String project,
+      boolean status) {
+    return getOnlineFeaturesRange(
+        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, status);
   }
 
   protected FeastClient(ManagedChannel channel, Optional<CallCredentials> credentials) {

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -280,12 +280,12 @@ public class FeastClient implements AutoCloseable {
     for (int rowIdx = 0; rowIdx < response.getResults(0).getValuesCount(); rowIdx++) {
       Row row = Row.create();
       for (int featureIdx = 0; featureIdx < response.getResultsCount(); featureIdx++) {
-        if (getOnlineFeaturesRequest.getStatus()) {
+        if (getOnlineFeaturesRequest.getOmitStatus()) {
           row.set(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
               response.getResults(featureIdx).getValues(rowIdx));
         } else {
-          row.setWithStatus(
+          row.setWithFieldStatus(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
               response.getResults(featureIdx).getValues(rowIdx),
               response.getResults(featureIdx).getStatuses(rowIdx));
@@ -298,10 +298,10 @@ public class FeastClient implements AutoCloseable {
 
       for (Map.Entry<String, ValueProto.Value> entry :
           entities.get(rowIdx).getFields().entrySet()) {
-        if (response.getStatus()) {
+        if (getOnlineFeaturesRequest.getOmitStatus()) {
           row.set(entry.getKey(), entry.getValue());
         } else {
-          row.setWithStatus(entry.getKey(), entry.getValue(), FieldStatus.PRESENT);
+          row.setWithFieldStatus(entry.getKey(), entry.getValue(), FieldStatus.PRESENT);
         }
       }
 
@@ -385,8 +385,9 @@ public class FeastClient implements AutoCloseable {
    * @param getOnlineFeaturesRequest getOnlineFeaturesRequest proto object
    * @return list of {@link Row} containing retrieved data fields.
    */
-  public List<Row> getOnlineFeatures(GetOnlineFeaturesRequest getOnlineFeaturesRequest) {
-    return getOnlineFeatures(getOnlineFeaturesRequest);
+  public List<Row> getOnlineFeatures(
+      GetOnlineFeaturesRequest getOnlineFeaturesRequest, List<Row> entities, String project) {
+    return getOnlineFeatures(getOnlineFeaturesRequest, entities);
   }
 
   /**
@@ -409,9 +410,9 @@ public class FeastClient implements AutoCloseable {
       List<SortKeyFilterModel> sortKeyFilters,
       int limit,
       boolean reverseSortOrder,
-      boolean status) {
+      boolean omit_status) {
     GetOnlineFeaturesRangeRequest.Builder requestBuilder =
-        GetOnlineFeaturesRangeRequest.newBuilder().setStatus(status);
+        GetOnlineFeaturesRangeRequest.newBuilder().setOmitStatus(omit_status);
 
     requestBuilder.setFeatures(
         ServingAPIProto.FeatureList.newBuilder().addAllVal(featureRefs).build());
@@ -443,12 +444,12 @@ public class FeastClient implements AutoCloseable {
     for (int rowIdx = 0; rowIdx < response.getResults(0).getValuesCount(); rowIdx++) {
       RangeRow row = RangeRow.create();
       for (int featureIdx = 0; featureIdx < response.getResultsCount(); featureIdx++) {
-        if (status) {
+        if (omit_status) {
           row.setWithValues(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
               response.getResults(featureIdx).getValues(rowIdx).getValList());
         } else {
-          row.setWithValuesWithStatus(
+          row.setWithValuesWithFieldStatus(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
               response.getResults(featureIdx).getValues(rowIdx).getValList(),
               response.getResults(featureIdx).getStatuses(rowIdx).getStatusList());
@@ -487,9 +488,9 @@ public class FeastClient implements AutoCloseable {
       int limit,
       boolean reverseSortOrder,
       String project,
-      boolean status) {
+      boolean omit_status) {
     return getOnlineFeaturesRange(
-        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, status);
+        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, omit_status);
   }
 
   protected FeastClient(ManagedChannel channel, Optional<CallCredentials> credentials) {

--- a/java/serving-client/src/main/java/dev/feast/FeastClient.java
+++ b/java/serving-client/src/main/java/dev/feast/FeastClient.java
@@ -410,9 +410,9 @@ public class FeastClient implements AutoCloseable {
       List<SortKeyFilterModel> sortKeyFilters,
       int limit,
       boolean reverseSortOrder,
-      boolean omit_status) {
+      boolean omitStatus) {
     GetOnlineFeaturesRangeRequest.Builder requestBuilder =
-        GetOnlineFeaturesRangeRequest.newBuilder().setOmitStatus(omit_status);
+        GetOnlineFeaturesRangeRequest.newBuilder().setOmitStatus(omitStatus);
 
     requestBuilder.setFeatures(
         ServingAPIProto.FeatureList.newBuilder().addAllVal(featureRefs).build());
@@ -444,7 +444,7 @@ public class FeastClient implements AutoCloseable {
     for (int rowIdx = 0; rowIdx < response.getResults(0).getValuesCount(); rowIdx++) {
       RangeRow row = RangeRow.create();
       for (int featureIdx = 0; featureIdx < response.getResultsCount(); featureIdx++) {
-        if (omit_status) {
+        if (omitStatus) {
           row.setWithValues(
               response.getMetadata().getFeatureNames().getVal(featureIdx),
               response.getResults(featureIdx).getValues(rowIdx).getValList());
@@ -488,9 +488,9 @@ public class FeastClient implements AutoCloseable {
       int limit,
       boolean reverseSortOrder,
       String project,
-      boolean omit_status) {
+      boolean omitStatus) {
     return getOnlineFeaturesRange(
-        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, omit_status);
+        featureRefs, rows, sortKeyFilters, limit, reverseSortOrder, omitStatus);
   }
 
   protected FeastClient(ManagedChannel channel, Optional<CallCredentials> credentials) {

--- a/java/serving-client/src/main/java/dev/feast/RangeRow.java
+++ b/java/serving-client/src/main/java/dev/feast/RangeRow.java
@@ -86,7 +86,7 @@ public class RangeRow {
     return this;
   }
 
-  public RangeRow setWithValuesWithStatus(
+  public RangeRow setWithValuesWithFieldStatus(
       String fieldName, List<Value> values, List<FieldStatus> statuses) {
     fields.put(fieldName, values);
     fieldStatuses.put(fieldName, statuses);

--- a/java/serving-client/src/main/java/dev/feast/RangeRow.java
+++ b/java/serving-client/src/main/java/dev/feast/RangeRow.java
@@ -81,7 +81,13 @@ public class RangeRow {
     return this;
   }
 
-  public RangeRow setWithValues(String fieldName, List<Value> values, List<FieldStatus> statuses) {
+  public RangeRow setWithValues(String fieldName, List<Value> values) {
+    fields.put(fieldName, values);
+    return this;
+  }
+
+  public RangeRow setWithValuesWithStatus(
+      String fieldName, List<Value> values, List<FieldStatus> statuses) {
     fields.put(fieldName, values);
     fieldStatuses.put(fieldName, statuses);
     return this;

--- a/java/serving-client/src/main/java/dev/feast/Row.java
+++ b/java/serving-client/src/main/java/dev/feast/Row.java
@@ -58,12 +58,13 @@ public class Row {
   }
 
   public Row set(String fieldName, Object value) {
-    return this.set(fieldName, value, FieldStatus.PRESENT);
-  }
-
-  public Row set(String fieldName, Object value, FieldStatus status) {
     fields.put(fieldName, RequestUtil.objectToValue(value));
-    fieldStatuses.put(fieldName, status);
+    return this;
+}
+
+  public Row setWithStatus(String fieldName, Object value, FieldStatus status) {
+    fields.put(fieldName, RequestUtil.objectToValue(value));
+    this.setStatus(fieldName, status);
     return this;
   }
 

--- a/java/serving-client/src/main/java/dev/feast/Row.java
+++ b/java/serving-client/src/main/java/dev/feast/Row.java
@@ -60,11 +60,11 @@ public class Row {
   public Row set(String fieldName, Object value) {
     fields.put(fieldName, RequestUtil.objectToValue(value));
     return this;
-}
+  }
 
   public Row setWithStatus(String fieldName, Object value, FieldStatus status) {
     fields.put(fieldName, RequestUtil.objectToValue(value));
-    this.setStatus(fieldName, status);
+    this.fieldStatuses.put(fieldName, status);
     return this;
   }
 

--- a/java/serving-client/src/main/java/dev/feast/Row.java
+++ b/java/serving-client/src/main/java/dev/feast/Row.java
@@ -62,7 +62,7 @@ public class Row {
     return this;
   }
 
-  public Row setWithStatus(String fieldName, Object value, FieldStatus status) {
+  public Row setWithFieldStatus(String fieldName, Object value, FieldStatus status) {
     fields.put(fieldName, RequestUtil.objectToValue(value));
     this.fieldStatuses.put(fieldName, status);
     return this;

--- a/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
+++ b/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
@@ -214,8 +214,6 @@ public class FeastClientTest {
     for (String fieldName : rows.get(0).getFields().keySet()) {
       assertNull(
           "Field " + fieldName + " should not have a status", rows.get(0).getStatus(fieldName));
-      assertNull(
-          "Field " + fieldName + " should not have a timestamp", rows.get(0).getEntityTimestamp());
     }
   }
 

--- a/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
+++ b/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
@@ -16,6 +16,7 @@
  */
 package dev.feast;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.mock;
@@ -38,6 +39,7 @@ import io.grpc.testing.GrpcCleanupRule;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -63,7 +65,9 @@ public class FeastClientTest {
                     GetOnlineFeaturesRequest request,
                     StreamObserver<GetOnlineFeaturesResponse> responseObserver) {
                   if (!request.equals(FeastClientTest.getFakeOnlineFeaturesRefRequest())
-                      && !request.equals(FeastClientTest.getFakeOnlineFeaturesServiceRequest())) {
+                      && !request.equals(FeastClientTest.getFakeOnlineFeaturesServiceRequest())
+                      && !request.equals(
+                          FeastClientTest.getFakeOnlineFeaturesRefRequestWithoutStatus())) {
                     responseObserver.onError(Status.FAILED_PRECONDITION.asRuntimeException());
                   }
 
@@ -114,6 +118,11 @@ public class FeastClientTest {
   @Test
   public void shouldGetOnlineFeaturesFeatureService() {
     shouldGetOnlineFeaturesFeatureService(this.client);
+  }
+
+  @Test
+  public void shouldGetOnlineFeaturesWithoutStatus() {
+    shouldGetOnlineFeaturesWithoutStatus(this.client);
   }
 
   @Test
@@ -183,6 +192,33 @@ public class FeastClientTest {
         });
   }
 
+  private void shouldGetOnlineFeaturesWithoutStatus(FeastClient client) {
+
+    List<Row> rows =
+        client.getOnlineFeatures(
+            getFakeOnlineFeaturesRefRequestWithoutStatus(),
+            Collections.singletonList(Row.create().set("driver_id", 1)),
+            "driver_project");
+
+    assertEquals(
+        rows.get(0).getFields(),
+        new HashMap<String, Value>() {
+          {
+            put("driver_id", intValue(1));
+            put("driver:name", strValue("david"));
+            put("driver:rating", intValue(3));
+            put("driver:null_value", Value.newBuilder().build());
+          }
+        });
+
+    for (String fieldName : rows.get(0).getFields().keySet()) {
+      assertNull(
+          "Field " + fieldName + " should not have a status", rows.get(0).getStatus(fieldName));
+      assertNull(
+          "Field " + fieldName + " should not have a timestamp", rows.get(0).getEntityTimestamp());
+    }
+  }
+
   private void shouldGetOnlineFeaturesRangeWithClient(FeastClient client) {
     List<RangeRow> rows =
         client.getOnlineFeaturesRange(
@@ -232,6 +268,20 @@ public class FeastClientTest {
                 .addVal("driver:null_value")
                 .build())
         .putEntities("driver_id", ValueProto.RepeatedValue.newBuilder().addVal(intValue(1)).build())
+        .build();
+  }
+
+  private static GetOnlineFeaturesRequest getFakeOnlineFeaturesRefRequestWithoutStatus() {
+    // setup mock serving service stub
+    return GetOnlineFeaturesRequest.newBuilder()
+        .setFeatures(
+            ServingAPIProto.FeatureList.newBuilder()
+                .addVal("driver:name")
+                .addVal("driver:rating")
+                .addVal("driver:null_value")
+                .build())
+        .putEntities("driver_id", ValueProto.RepeatedValue.newBuilder().addVal(intValue(1)).build())
+        .setOmitStatus(true)
         .build();
   }
 

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -93,6 +93,9 @@ message GetOnlineFeaturesRequest {
     // (was moved to dedicated parameter to avoid unnecessary separation logic on serving side)
     // A map of variable name -> list of values
     map<string, feast.types.RepeatedValue> request_context = 5;
+
+    // Used to omit the timestamp/status from the response
+    bool status = 6;
 }
 
 message GetOnlineFeaturesResponse {
@@ -182,6 +185,9 @@ message GetOnlineFeaturesRangeRequest {
     // Context for OnDemand Feature Transformation
     // A map of variable name -> list of values
     map<string, feast.types.RepeatedValue> request_context = 8;
+
+    // Used to omit the timestamp/status from the response
+    bool status = 9;
 }
 
 message GetOnlineFeaturesRangeResponse {

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -95,7 +95,7 @@ message GetOnlineFeaturesRequest {
     map<string, feast.types.RepeatedValue> request_context = 5;
 
     // Used to omit the timestamp/status from the response
-    bool status = 6;
+    bool omit_status = 6;
 }
 
 message GetOnlineFeaturesResponse {
@@ -187,7 +187,7 @@ message GetOnlineFeaturesRangeRequest {
     map<string, feast.types.RepeatedValue> request_context = 8;
 
     // Used to omit the timestamp/status from the response
-    bool status = 9;
+    bool omit_status = 9;
 }
 
 message GetOnlineFeaturesRangeResponse {


### PR DESCRIPTION
1/ Add status parameter as FieldStatus/Timestamps increase the size of the response body. Currently we support the inclusion of status via a query parameter 'status' for the http_server.
2/ Remove status/timestamps from the serving-client body. We do not parse the FieldStatus/timestamps in the middleware currently.