### PR TITLE
fix: Make getUniqueEntityRows response deterministic

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -230,20 +230,16 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	})
 
 	entityKeysMatcher := mock.MatchedBy(func(keys []*types.EntityKey) bool {
-		if len(keys) != 2 {
+		if len(keys) != len(entityValues["driver_id"].Val) {
 			return false
 		}
-		if len(keys[0].JoinKeys) != 1 || keys[0].JoinKeys[0] != "driver_id" {
-			return false
-		}
-		if len(keys[0].EntityValues) != 1 || keys[0].EntityValues[0].GetInt64Val() != 1001 {
-			return false
-		}
-		if len(keys[1].JoinKeys) != 1 || keys[1].JoinKeys[0] != "driver_id" {
-			return false
-		}
-		if len(keys[1].EntityValues) != 1 || keys[1].EntityValues[0].GetInt64Val() != 1002 {
-			return false
+		for i, key := range keys {
+			if len(key.JoinKeys) != 1 || key.JoinKeys[0] != "driver_id" {
+				return false
+			}
+			if len(key.EntityValues) != 1 || key.EntityValues[0].GetInt64Val() != entityValues["driver_id"].Val[i].GetInt64Val() {
+				return false
+			}
 		}
 		return true
 	})

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -1165,8 +1165,7 @@ func getUniqueEntityRows(joinKeysProto []*prototypes.EntityKey) ([]*prototypes.E
 		if existingIndex, exists := seen[rowHash]; exists {
 			mappingIndices[existingIndex] = append(mappingIndices[existingIndex], index)
 		} else {
-			newIndex := len(uniqueEntityRows)
-			seen[rowHash] = newIndex
+			seen[rowHash] = len(uniqueEntityRows)
 			uniqueEntityRows = append(uniqueEntityRows, entityKey)
 			mappingIndices = append(mappingIndices, []int{index})
 		}

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -1151,8 +1151,9 @@ func GroupSortedFeatureRefs(
 }
 
 func getUniqueEntityRows(joinKeysProto []*prototypes.EntityKey) ([]*prototypes.EntityKey, [][]int, error) {
-	uniqueValues := make(map[[sha256.Size]byte]*prototypes.EntityKey, 0)
-	positions := make(map[[sha256.Size]byte][]int, 0)
+	uniqueValues := make(map[[sha256.Size]byte]*prototypes.EntityKey)
+	positions := make(map[[sha256.Size]byte][]int)
+	orderedHashes := make([][sha256.Size]byte, 0) // to maintain order of first occurrences
 
 	for index, entityKey := range joinKeysProto {
 		serializedRow, err := proto.Marshal(entityKey)
@@ -1164,19 +1165,21 @@ func getUniqueEntityRows(joinKeysProto []*prototypes.EntityKey) ([]*prototypes.E
 		if _, ok := uniqueValues[rowHash]; !ok {
 			uniqueValues[rowHash] = entityKey
 			positions[rowHash] = []int{index}
+			orderedHashes = append(orderedHashes, rowHash)
 		} else {
 			positions[rowHash] = append(positions[rowHash], index)
 		}
 	}
 
-	mappingIndices := make([][]int, len(uniqueValues))
-	uniqueEntityRows := make([]*prototypes.EntityKey, 0)
-	for rowHash, row := range uniqueValues {
-		nextIdx := len(uniqueEntityRows)
+	// Build results in deterministic order based on first occurrence
+	mappingIndices := make([][]int, len(orderedHashes))
+	uniqueEntityRows := make([]*prototypes.EntityKey, len(orderedHashes))
 
-		mappingIndices[nextIdx] = positions[rowHash]
-		uniqueEntityRows = append(uniqueEntityRows, row)
+	for i, rowHash := range orderedHashes {
+		mappingIndices[i] = positions[rowHash]
+		uniqueEntityRows[i] = uniqueValues[rowHash]
 	}
+
 	return uniqueEntityRows, mappingIndices, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR makes the getUniqueEntityRows method deterministic. This makes the GroupSortedFeatureRefs and GroupFeatureRefs methods return the same object every time and makes testing it easier. 
# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
