### PR TITLE
fix: Write one row per batch

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -291,6 +291,11 @@ class FeatureView(BaseFeatureView):
         """
         super().ensure_valid()
 
+        if self.ttl < timedelta(days=0):
+            raise ValueError(
+                "Feature view ttl cannot be negative. Please set a positive value or 0 for no ttl."
+            )
+
         if not self.entities:
             raise ValueError("Feature view has no entities.")
 


### PR DESCRIPTION
# What this PR does / why we need it:


# Which issue(s) this PR fixes:
Fix scyalldb materialization writing multiple rows per batch
validate non-negative ttl at feature view level
refactor update_write_batch logic to reduce duplicated code


# Misc

