### PR TITLE
fix: Make http handlers common so both Hybrid and Http server are in sync

### DIFF
--- a/go/internal/feast/server/hybrid_server.go
+++ b/go/internal/feast/server/hybrid_server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -17,20 +16,7 @@ var defaultCheckTimeout = 2 * time.Second
 
 // Register default HTTP handlers specific to the hybrid server configuration.
 func DefaultHybridHandlers(s *httpServer, port int) []Handler {
-	return []Handler{
-		{
-			path:        "/get-online-features",
-			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeatures)),
-		},
-		{
-			path:        "/metrics",
-			handlerFunc: promhttp.Handler(),
-		},
-		{
-			path:        "/health",
-			handlerFunc: http.HandlerFunc(combinedHealthCheck(port)),
-		},
-	}
+	return CommonHttpHandlers(s, combinedHealthCheck(port))
 }
 
 // This function wraps an http.Handler that is registered during hybrid server creation.

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -17,4 +19,25 @@ func LogWithSpanContext(span tracer.Span) zerolog.Logger {
 		Logger()
 
 	return logger
+}
+
+func CommonHttpHandlers(s *httpServer, healthCheckHandler http.HandlerFunc) []Handler {
+	return []Handler{
+		{
+			path:        "/get-online-features",
+			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeatures)),
+		},
+		{
+			path:        "/get-online-features-range",
+			handlerFunc: recoverMiddleware(http.HandlerFunc(s.getOnlineFeaturesRange)),
+		},
+		{
+			path:        "/metrics",
+			handlerFunc: promhttp.Handler(),
+		},
+		{
+			path:        "/health",
+			handlerFunc: healthCheckHandler,
+		},
+	}
 }


### PR DESCRIPTION
# What this PR does / why we need it:
Made http handlers a common func to be reused in http and hybrid server configurations.

# Which issue(s) this PR fixes:

- fixed missing http get-online-features-range handler for hybrid server
- removed unnecessary `status` field in http range query response



