### PR TITLE
fix: Changing the default table name format version to Float

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -6,13 +6,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/feast-dev/feast/go/internal/feast/model"
 	"math"
 	"math/big"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/feast-dev/feast/go/internal/feast/model"
 
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/feast-dev/feast/go/internal/feast/utils"
@@ -272,7 +273,7 @@ func NewCassandraOnlineStore(project string, config *registry.RepoConfig, online
 	// parse tableNameFormatVersion
 	tableNameFormatVersion, ok := onlineStoreConfig["table_name_format_version"]
 	if !ok {
-		tableNameFormatVersion = 1
+		tableNameFormatVersion = 1.0
 		log.Warn().Msg("table_name_format_version not specified: Using 1 instead")
 	}
 	store.tableNameFormatVersion = int(tableNameFormatVersion.(float64))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Changing the default table name format version to Float. Registry converts integers to Float. Default value is INT so its throwing error when not specified in feature_store.yaml

Error is: `panic: interface conversion: interface {} is int, not float64`

# Which issue(s) this PR fixes:
fix: Changing the default table name format version to Float


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
