### PR TITLE
fix: Create common func to unmarshal protos and handle null timestamps

### DIFF
--- a/go/internal/feast/onlinestore/egvalkeyonlinestore.go
+++ b/go/internal/feast/onlinestore/egvalkeyonlinestore.go
@@ -276,7 +276,7 @@ func (r *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 			return nil, err
 		}
 
-		var value types.Value
+		var value *types.Value
 		var resString interface{}
 		timeStampMap := make(map[string]*timestamppb.Timestamp, 1)
 
@@ -287,7 +287,7 @@ func (r *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 
 			featureName := featureNamesWithTimeStamps[featureIndex]
 			featureViewName := featureViewNames[featureIndex]
-			value = types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}
+			value = &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}
 			resString = nil
 
 			if !featureValue.IsNil() {
@@ -301,7 +301,7 @@ func (r *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 					return nil, errors.New("error parsing Value from valkey")
 				}
 				resContainsNonNil = true
-				if err := proto.Unmarshal([]byte(valueString), &value); err != nil {
+				if value, _, err = UnmarshalStoredProto([]byte(valueString)); err != nil {
 					return nil, errors.New("error converting parsed valkey Value to types.Value")
 				}
 			}

--- a/go/internal/feast/onlinestore/redisonlinestore.go
+++ b/go/internal/feast/onlinestore/redisonlinestore.go
@@ -304,8 +304,8 @@ func (r *RedisOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.E
 				return nil, errors.New("error parsing Value from redis")
 			} else {
 				resContainsNonNil = true
-				var value types.Value
-				if err := proto.Unmarshal([]byte(valueString), &value); err != nil {
+				var value *types.Value
+				if value, _, err = UnmarshalStoredProto([]byte(valueString)); err != nil {
 					return nil, errors.New("error converting parsed redis Value to types.Value")
 				} else {
 					featureName := featureNamesWithTimeStamps[featureIndex]

--- a/go/internal/feast/onlinestore/sqliteonlinestore.go
+++ b/go/internal/feast/onlinestore/sqliteonlinestore.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	_ "github.com/mattn/go-sqlite3"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/feast-dev/feast/go/protos/feast/serving"
@@ -101,12 +100,12 @@ func (s *SqliteOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 			var feature_name string
 			var valueString []byte
 			var event_ts time.Time
-			var value types.Value
+			var value *types.Value
 			err = rows.Scan(&entity_key, &feature_name, &valueString, &event_ts)
 			if err != nil {
 				return nil, errors.New("error could not resolve row in query (entity key, feature name, value, event ts)")
 			}
-			if err := proto.Unmarshal(valueString, &value); err != nil {
+			if value, _, err = UnmarshalStoredProto(valueString); err != nil {
 				return nil, errors.New("error converting parsed value to types.Value")
 			}
 			rowIdx := entityNameToEntityIndex[utils.HashSerializedEntityKey(&entity_key)]

--- a/go/internal/feast/onlinestore/unmarshal_utils.go
+++ b/go/internal/feast/onlinestore/unmarshal_utils.go
@@ -1,7 +1,7 @@
 package onlinestore
 
 import (
-	"errors"
+	"fmt"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
 	"google.golang.org/protobuf/proto"
@@ -12,7 +12,7 @@ func UnmarshalStoredProto(valueStr []byte) (*types.Value, serving.FieldStatus, e
 	var message types.Value
 	null := &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}
 	if err := proto.Unmarshal(valueStr, &message); err != nil {
-		return nil, serving.FieldStatus_INVALID, errors.New("error converting parsed online store Value to types.Value")
+		return nil, serving.FieldStatus_INVALID, fmt.Errorf("error converting parsed online store Value to types.Value: %w", err)
 	}
 	if message.Val == nil {
 		return null, serving.FieldStatus_NULL_VALUE, nil

--- a/go/internal/feast/onlinestore/unmarshal_utils.go
+++ b/go/internal/feast/onlinestore/unmarshal_utils.go
@@ -12,7 +12,7 @@ func UnmarshalStoredProto(valueStr []byte) (*types.Value, serving.FieldStatus, e
 	var message types.Value
 	null := &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}
 	if err := proto.Unmarshal(valueStr, &message); err != nil {
-		return nil, serving.FieldStatus_INVALID, errors.New("error converting parsed Cassandra Value to types.Value")
+		return nil, serving.FieldStatus_INVALID, errors.New("error converting parsed online store Value to types.Value")
 	}
 	if message.Val == nil {
 		return null, serving.FieldStatus_NULL_VALUE, nil

--- a/go/internal/feast/onlinestore/unmarshal_utils.go
+++ b/go/internal/feast/onlinestore/unmarshal_utils.go
@@ -1,0 +1,32 @@
+package onlinestore
+
+import (
+	"errors"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
+	"github.com/feast-dev/feast/go/protos/feast/types"
+	"google.golang.org/protobuf/proto"
+	"math"
+)
+
+func UnmarshalStoredProto(valueStr []byte) (*types.Value, serving.FieldStatus, error) {
+	var message types.Value
+	null := &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}
+	if err := proto.Unmarshal(valueStr, &message); err != nil {
+		return nil, serving.FieldStatus_INVALID, errors.New("error converting parsed Cassandra Value to types.Value")
+	}
+	if message.Val == nil {
+		return null, serving.FieldStatus_NULL_VALUE, nil
+	} else {
+		switch message.Val.(type) {
+		case *types.Value_UnixTimestampVal:
+			// null timestamps are read as min int64, so we convert them to nil
+			if message.Val.(*types.Value_UnixTimestampVal).UnixTimestampVal == math.MinInt64 {
+				return null, serving.FieldStatus_NULL_VALUE, nil
+			} else {
+				return &types.Value{Val: message.Val}, serving.FieldStatus_PRESENT, nil
+			}
+		default:
+			return &types.Value{Val: message.Val}, serving.FieldStatus_PRESENT, nil
+		}
+	}
+}

--- a/go/internal/feast/server/grpc_server_integration_test.go
+++ b/go/internal/feast/server/grpc_server_integration_test.go
@@ -188,11 +188,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 
 func getValueType(value interface{}, featureName string) *types.Value {
 	if value == nil {
-		if featureName == "timestamp_val" || featureName == "null_timestamp_val" {
-			return &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: -9223372036854775808}}
-		} else {
-			return &types.Value{}
-		}
+		return &types.Value{}
 	}
 	switch value.(type) {
 	case int32:


### PR DESCRIPTION
# What this PR does / why we need it:
Currently, UnixTimestamp values that should be null or serialized as a minimum int64 value instead of a true null.

# Which issue(s) this PR fixes:
Create a common unmarshal function for serialized protos that sets timestamp values should be null to null.


# Misc

