### PR TITLE
fix: Adding Snake Case to Include Metadata Check

### DIFF
--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -363,9 +363,9 @@ func NewHttpServer(fs *feast.FeatureStore, loggingService *logging.LoggingServic
 
 func parseIncludeMetadata(r *http.Request) (bool, error) {
 	q := r.URL.Query()
-	raw := q.Get("includeMetadata")
+	raw := strings.TrimSpace(q.Get("includeMetadata"))
 	if raw == "" {
-		raw = q.Get("include_metadata")
+		raw = strings.TrimSpace(q.Get("include_metadata"))
 	}
 	if raw == "" {
 		return false, nil

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -389,13 +389,8 @@ func (s *httpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 
 	includeMetadata, err := parseIncludeMetadata(r)
 	if err != nil {
-		logSpanContext.Error().Err(err).
-			Msg("Error parsing includeMetadata query parameter")
-		writeJSONError(
-			w,
-			fmt.Errorf("error parsing includeMetadata query parameter: %w", err),
-			http.StatusBadRequest,
-		)
+		logSpanContext.Error().Err(err).Msg("Error parsing includeMetadata query parameter")
+		writeJSONError(w, fmt.Errorf("error parsing includeMetadata query parameter: %w", err), http.StatusBadRequest)
 		return
 	}
 
@@ -573,13 +568,8 @@ func (s *httpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 
 	includeMetadata, err := parseIncludeMetadata(r)
 	if err != nil {
-		logSpanContext.Error().Err(err).
-			Msg("Error parsing includeMetadata query parameter")
-		writeJSONError(
-			w,
-			fmt.Errorf("error parsing includeMetadata query parameter: %w", err),
-			http.StatusBadRequest,
-		)
+		logSpanContext.Error().Err(err).Msg("Error parsing includeMetadata query parameter")
+		writeJSONError(w, fmt.Errorf("error parsing includeMetadata query parameter: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -361,6 +361,18 @@ func NewHttpServer(fs *feast.FeatureStore, loggingService *logging.LoggingServic
 	return &httpServer{fs: fs, loggingService: loggingService}
 }
 
+func parseIncludeMetadata(r *http.Request) (bool, error) {
+	q := r.URL.Query()
+	raw := q.Get("includeMetadata")
+	if raw == "" {
+		raw = q.Get("include_metadata")
+	}
+	if raw == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(raw)
+}
+
 func (s *httpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var featureVectors []*onlineserving.FeatureVector
@@ -375,16 +387,16 @@ func (s *httpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	includeMetadataQuery := r.URL.Query().Get("includeMetadata")
-
-	includeMetadata := false
-	if includeMetadataQuery != "" {
-		includeMetadata, err = strconv.ParseBool(includeMetadataQuery)
-		if err != nil {
-			logSpanContext.Error().Err(err).Msg("Error parsing includeMetadata query parameter")
-			writeJSONError(w, fmt.Errorf("Error parsing includeMetadata query parameter: %+v", err), http.StatusBadRequest)
-			return
-		}
+	includeMetadata, err := parseIncludeMetadata(r)
+	if err != nil {
+		logSpanContext.Error().Err(err).
+			Msg("Error parsing includeMetadata query parameter")
+		writeJSONError(
+			w,
+			fmt.Errorf("error parsing includeMetadata query parameter: %w", err),
+			http.StatusBadRequest,
+		)
+		return
 	}
 
 	decoder := json.NewDecoder(r.Body)
@@ -559,15 +571,16 @@ func (s *httpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	includeMetadataQuery := r.URL.Query().Get("includeMetadata")
-	includeMetadata := false
-	if includeMetadataQuery != "" {
-		includeMetadata, err = strconv.ParseBool(includeMetadataQuery)
-		if err != nil {
-			logSpanContext.Error().Err(err).Msg("Error parsing includeMetadata query parameter")
-			writeJSONError(w, fmt.Errorf("error parsing includeMetadata query parameter: %w", err), http.StatusBadRequest)
-			return
-		}
+	includeMetadata, err := parseIncludeMetadata(r)
+	if err != nil {
+		logSpanContext.Error().Err(err).
+			Msg("Error parsing includeMetadata query parameter")
+		writeJSONError(
+			w,
+			fmt.Errorf("error parsing includeMetadata query parameter: %w", err),
+			http.StatusBadRequest,
+		)
+		return
 	}
 
 	decoder := json.NewDecoder(r.Body)


### PR DESCRIPTION

## What this PR does / why we need it:
While sending a request to the Feature Server we are only able to read the “Include Metadata” parameter in camel case, we must also include snake case option in the request. 
