### PR TITLE
fix: Move use_write_time_for_ttl config to sfv instead of an online store config

### DIFF
--- a/protos/feast/core/SortedFeatureView.proto
+++ b/protos/feast/core/SortedFeatureView.proto
@@ -51,20 +51,8 @@ message SortedFeatureViewSpec {
     // List of specifications for each feature defined as part of this feature view.
     repeated FeatureSpecV2 features = 4;
 
-    // List of specifications for each entity defined as part of this feature view.
-    repeated FeatureSpecV2 entity_columns = 12;
-
-    // List of sort keys for this feature view.
-    repeated SortKey sort_keys = 13;
-
-    // Description of the feature view.
-    string description = 10;
-
     // User defined metadata
     map<string,string> tags = 5;
-
-    // Owner of the feature view.
-    string owner = 11;
 
     // Features in this feature view can only be retrieved from online serving
     // younger than ttl. Ttl is measured as the duration of time between
@@ -75,11 +63,23 @@ message SortedFeatureViewSpec {
     // Batch/Offline DataSource where this view can retrieve offline feature data.
     DataSource batch_source = 7;
 
+    // Whether these features should be served online or not
+    bool online = 8;
+
     // Streaming DataSource from where this view can consume "online" feature data.
     DataSource stream_source = 9;
 
-    // Whether these features should be served online or not
-    bool online = 8;
+    // Description of the feature view.
+    string description = 10;
+
+    // Owner of the feature view.
+    string owner = 11;
+
+    // List of specifications for each entity defined as part of this feature view.
+    repeated FeatureSpecV2 entity_columns = 12;
+
+    // List of sort keys for this feature view.
+    repeated SortKey sort_keys = 13;
 
     // Whether to use the write time or event time for TTL calculations.
     bool use_write_time_for_ttl = 14;
@@ -87,7 +87,7 @@ message SortedFeatureViewSpec {
     // User-specified specifications of this entity.
     // Adding higher index to avoid conflicts in future 
     // if Feast adds more fields
-    repeated Entity original_entities = 30;
+    repeated Entity original_entities = 15;
 }
 
 // Defines the sorting criteria for range-based feature queries.

--- a/protos/feast/core/SortedFeatureView.proto
+++ b/protos/feast/core/SortedFeatureView.proto
@@ -81,6 +81,9 @@ message SortedFeatureViewSpec {
     // Whether these features should be served online or not
     bool online = 8;
 
+    // Whether to use the write time or event time for TTL calculations.
+    bool use_write_time_for_ttl = 14;
+
     // User-specified specifications of this entity.
     // Adding higher index to avoid conflicts in future 
     // if Feast adds more fields

--- a/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
+++ b/sdk/python/feast/expediagroup/pydantic_models/feature_view_model.py
@@ -367,6 +367,7 @@ class SortedFeatureViewModel(FeatureViewModel):
     """
 
     sort_keys: List[SortedFeatureViewSortKeyModel]
+    use_write_time_for_ttl: bool = False
 
     def to_feature_view(self) -> SortedFeatureView:
         """
@@ -396,6 +397,7 @@ class SortedFeatureViewModel(FeatureViewModel):
             tags=self.tags or None,
             owner=self.owner,
             sort_keys=[sk.to_sort_key() for sk in self.sort_keys],
+            use_write_time_for_ttl=self.use_write_time_for_ttl,
         )
         sorted_fv.materialization_intervals = self.materialization_intervals
         sorted_fv.created_timestamp = self.created_timestamp
@@ -452,6 +454,7 @@ class SortedFeatureViewModel(FeatureViewModel):
                 SortedFeatureViewSortKeyModel.from_sort_key(sk)
                 for sk in sorted_feature_view.sort_keys
             ],
+            use_write_time_for_ttl=sorted_feature_view.use_write_time_for_ttl,
         )
 
 

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/cassandra_online_store.py
@@ -242,11 +242,6 @@ class CassandraOnlineStoreConfig(FeastConfigBaseModel):
     Table names should be quoted to make them case sensitive.
     """
 
-    use_write_time_for_ttl: Optional[bool] = False
-    """
-    If True, the expiration time is always calculated as now() on the Coordinator + TTL where, now() is the wall clock during the corresponding write operation.
-    """
-
 
 class CassandraOnlineStore(OnlineStore):
     """
@@ -489,10 +484,9 @@ class CassandraOnlineStore(OnlineStore):
                 batch = BatchStatement(batch_type=BatchType.UNLOGGED)
                 batch_count = 0
                 for entity_key, feat_dict, timestamp, created_ts in batch_to_write:
-                    # TODO: move use_write_time_for_ttl config to SortedFeatureView level
                     ttl = CassandraOnlineStore._get_ttl(
                         ttl_feature_view,
-                        online_store_config.use_write_time_for_ttl,
+                        table.use_write_time_for_ttl,
                         timestamp,
                     )
                     if ttl < 0:

--- a/sdk/python/feast/sorted_feature_view.py
+++ b/sdk/python/feast/sorted_feature_view.py
@@ -45,6 +45,7 @@ class SortedFeatureView(FeatureView):
         tags: Optional[Dict[str, str]] = None,
         owner: str = "",
         sort_keys: Optional[List[SortKey]] = None,
+        use_write_time_for_ttl: bool = False,
         _skip_validation: bool = False,  # only skipping validation for proto creation, internal use only
     ):
         super().__init__(
@@ -59,6 +60,7 @@ class SortedFeatureView(FeatureView):
             owner=owner,
         )
         self.sort_keys = sort_keys if sort_keys is not None else []
+        self.use_write_time_for_ttl = use_write_time_for_ttl
         if not _skip_validation:
             self.ensure_valid()
 
@@ -77,6 +79,7 @@ class SortedFeatureView(FeatureView):
             tags=copy.deepcopy(self.tags),
             owner=self.owner,
             sort_keys=copy.copy(self.sort_keys),
+            use_write_time_for_ttl=self.use_write_time_for_ttl,
         )
         sfv.entities = self.entities
         sfv.features = copy.copy(self.features)
@@ -190,6 +193,7 @@ class SortedFeatureView(FeatureView):
             stream_source=stream_source_proto,
             online=self.online,
             original_entities=original_entities,
+            use_write_time_for_ttl=self.use_write_time_for_ttl,
         )
 
         return SortedFeatureViewProto(spec=spec, meta=meta)
@@ -224,6 +228,7 @@ class SortedFeatureView(FeatureView):
             schema=None,
             entities=None,
             sort_keys=[SortKey.from_proto(sk) for sk in spec.sort_keys],
+            use_write_time_for_ttl=spec.use_write_time_for_ttl,
             _skip_validation=True,
         )
 


### PR DESCRIPTION
# What this PR does / why we need it:
use_write_time_for_ttl config should be a feature view level config instead of on the whole online store

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
