### PR TITLE
fix: Keep duplicate requested features in response for range query.

### DIFF
--- a/go/internal/feast/featurestore.go
+++ b/go/internal/feast/featurestore.go
@@ -448,6 +448,11 @@ func (fs *FeatureStore) GetOnlineFeaturesRange(
 		result = append(result, vectors...)
 	}
 
+	result, err = onlineserving.KeepOnlyRequestedFeatures(result, featureRefs, featureService, fullFeatureNames)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
# What this PR does / why we need it:
GetOnlineFeaturesRange removes any requested duplicate features unlike GetOnlineFeatures.

# Which issue(s) this PR fixes:
Made KeepOnlyRequestedFeatures accept a generic vector type to work for both cases.


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
