### PR TITLE
fix: Http range timestamp values should return in rfc3339 format

### DIFF
--- a/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
+++ b/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	ctx = context.Background()
 	var closer func()
 
-	client, closer = server.GetClient(ctx, "", dir, "")
+	client, closer = server.GetClient(ctx, dir, "")
 
 	// Run the tests
 	exitCode := m.Run()

--- a/go/internal/feast/integration_tests/valkey/valkey_integration_test.go
+++ b/go/internal/feast/integration_tests/valkey/valkey_integration_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	ctx = context.Background()
 	var closer func()
 
-	client, closer = server.GetClient(ctx, "", dir, "")
+	client, closer = server.GetClient(ctx, dir, "")
 
 	// Run the tests
 	exitCode := m.Run()

--- a/go/internal/feast/server/grpc_server_test.go
+++ b/go/internal/feast/server/grpc_server_test.go
@@ -32,7 +32,7 @@ func TestGetFeastServingInfo(t *testing.T) {
 
 	require.Nil(t, err)
 
-	client, closer := GetClient(ctx, "", dir, "")
+	client, closer := GetClient(ctx, dir, "")
 	defer closer()
 	response, err := client.GetFeastServingInfo(ctx, &serving.GetFeastServingInfoRequest{})
 	assert.Nil(t, err)
@@ -48,7 +48,7 @@ func TestGetOnlineFeaturesSqlite(t *testing.T) {
 
 	require.Nil(t, err)
 
-	client, closer := GetClient(ctx, "", dir, "")
+	client, closer := GetClient(ctx, dir, "")
 	defer closer()
 	entities := make(map[string]*types.RepeatedValue)
 	entities["driver_id"] = &types.RepeatedValue{
@@ -109,7 +109,7 @@ func TestGetOnlineFeaturesSqliteWithLogging(t *testing.T) {
 	require.Nil(t, err)
 
 	logPath := t.TempDir()
-	client, closer := GetClient(ctx, "file", dir, logPath)
+	client, closer := GetClient(ctx, dir, logPath)
 	defer closer()
 	entities := make(map[string]*types.RepeatedValue)
 	entities["driver_id"] = &types.RepeatedValue{

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -146,7 +146,7 @@ func processFeatureVectors(
 	for entityName, entityProto := range entitiesProto {
 		entityValues := make([]interface{}, len(entityProto.Val))
 		for j, val := range entityProto.Val {
-			entityValues[j] = types.ValueTypeToGoType(val)
+			entityValues[j] = types.ValueTypeToGoTypeTimestampAsString(val)
 		}
 		entities[entityName] = entityValues
 	}
@@ -176,7 +176,7 @@ func processFeatureVectors(
 				if val == nil {
 					rangeForEntity[k] = nil
 				} else {
-					rangeForEntity[k] = types.ValueTypeToGoType(val)
+					rangeForEntity[k] = types.ValueTypeToGoTypeTimestampAsString(val)
 				}
 			}
 			simplifiedValues[j] = rangeForEntity

--- a/go/internal/feast/server/server_test_utils.go
+++ b/go/internal/feast/server/server_test_utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Starts a new grpc server, registers the serving service and returns a client.
-func GetClient(ctx context.Context, offlineStoreType string, basePath string, logPath string) (serving.ServingServiceClient, func()) {
+func GetClient(ctx context.Context, basePath string, logPath string) (serving.ServingServiceClient, func()) {
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
 

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -698,6 +698,14 @@ func appendNullByType(builder array.Builder) {
 }
 
 func ValueTypeToGoType(value *types.Value) interface{} {
+	return valueTypeToGoTypeTimestampAsString(value, false)
+}
+
+func ValueTypeToGoTypeTimestampAsString(value *types.Value) interface{} {
+	return valueTypeToGoTypeTimestampAsString(value, true)
+}
+
+func valueTypeToGoTypeTimestampAsString(value *types.Value, timestampAsString bool) interface{} {
 	if value == nil || value.Val == nil {
 		return nil
 	}
@@ -732,8 +740,18 @@ func ValueTypeToGoType(value *types.Value) interface{} {
 	case *types.Value_DoubleListVal:
 		return x.DoubleListVal.Val
 	case *types.Value_UnixTimestampVal:
+		if timestampAsString {
+			return time.UnixMilli(x.UnixTimestampVal).UTC().Format(time.RFC3339)
+		}
 		return x.UnixTimestampVal
 	case *types.Value_UnixTimestampListVal:
+		if timestampAsString {
+			timestamps := make([]string, len(x.UnixTimestampListVal.Val))
+			for i, ts := range x.UnixTimestampListVal.Val {
+				timestamps[i] = time.UnixMilli(ts).UTC().Format(time.RFC3339)
+			}
+			return timestamps
+		}
 		return x.UnixTimestampListVal.Val
 	default:
 		return nil

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -705,6 +705,8 @@ func ValueTypeToGoTypeTimestampAsString(value *types.Value) interface{} {
 	return valueTypeToGoTypeTimestampAsString(value, true)
 }
 
+var TimestampFormat = "2006-01-02 15:04:05.999999999Z0700"
+
 func valueTypeToGoTypeTimestampAsString(value *types.Value, timestampAsString bool) interface{} {
 	if value == nil || value.Val == nil {
 		return nil
@@ -741,14 +743,14 @@ func valueTypeToGoTypeTimestampAsString(value *types.Value, timestampAsString bo
 		return x.DoubleListVal.Val
 	case *types.Value_UnixTimestampVal:
 		if timestampAsString {
-			return time.UnixMilli(x.UnixTimestampVal).UTC().Format(time.RFC3339)
+			return time.UnixMilli(x.UnixTimestampVal).UTC().Format(TimestampFormat)
 		}
 		return x.UnixTimestampVal
 	case *types.Value_UnixTimestampListVal:
 		if timestampAsString {
 			timestamps := make([]string, len(x.UnixTimestampListVal.Val))
 			for i, ts := range x.UnixTimestampListVal.Val {
-				timestamps[i] = time.UnixMilli(ts).UTC().Format(time.RFC3339)
+				timestamps[i] = time.UnixMilli(ts).UTC().Format(TimestampFormat)
 			}
 			return timestamps
 		}

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -474,6 +474,14 @@ func TestValueTypeToGoType(t *testing.T) {
 		{Val: &types.Value_DoubleVal{DoubleVal: 10.0}},
 		{Val: &types.Value_BoolVal{BoolVal: true}},
 		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: timestamp}},
+		{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"a", "b", "c"}}}},
+		{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{1, 2}, {3, 4}}}}},
+		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{1, 2, 3}}}},
+		{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{4, 5, 6}}}},
+		{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{7.1, 8.2}}}},
+		{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{9.3, 10.4}}}},
+		{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{true, false}}}},
+		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp, timestamp + 3600}}}},
 		{Val: &types.Value_NullVal{NullVal: types.Null_NULL}},
 		nil,
 	}
@@ -487,12 +495,41 @@ func TestValueTypeToGoType(t *testing.T) {
 		float64(10.0),
 		true,
 		timestamp,
+		[]string{"a", "b", "c"},
+		[][]byte{{1, 2}, {3, 4}},
+		[]int32{1, 2, 3},
+		[]int64{4, 5, 6},
+		[]float32{7.1, 8.2},
+		[]float64{9.3, 10.4},
+		[]bool{true, false},
+		[]int64{timestamp, timestamp + 3600},
 		nil,
 		nil,
 	}
 
 	for i, testCase := range testCases {
 		actual := ValueTypeToGoType(testCase)
+		assert.Equal(t, expectedTypes[i], actual)
+	}
+}
+
+func TestValueTypeToGoTypeTimestampAsString(t *testing.T) {
+	timestamp := time.Now().UnixMilli()
+	testCases := []*types.Value{
+		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: timestamp}},
+		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp, timestamp + 3600}}}},
+	}
+
+	expectedTypes := []interface{}{
+		time.UnixMilli(timestamp).UTC().Format(time.RFC3339),
+		[]string{
+			time.UnixMilli(timestamp).UTC().Format(time.RFC3339),
+			time.UnixMilli(timestamp + 3600).UTC().Format(time.RFC3339),
+		},
+	}
+
+	for i, testCase := range testCases {
+		actual := ValueTypeToGoTypeTimestampAsString(testCase)
 		assert.Equal(t, expectedTypes[i], actual)
 	}
 }

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -521,10 +521,10 @@ func TestValueTypeToGoTypeTimestampAsString(t *testing.T) {
 	}
 
 	expectedTypes := []interface{}{
-		time.UnixMilli(timestamp).UTC().Format(time.RFC3339),
+		time.UnixMilli(timestamp).UTC().Format(TimestampFormat),
 		[]string{
-			time.UnixMilli(timestamp).UTC().Format(time.RFC3339),
-			time.UnixMilli(timestamp + 3600).UTC().Format(time.RFC3339),
+			time.UnixMilli(timestamp).UTC().Format(TimestampFormat),
+			time.UnixMilli(timestamp + 3600).UTC().Format(TimestampFormat),
 		},
 	}
 


### PR DESCRIPTION
# What this PR does / why we need it:
Http range timestamp values should return in rfc3339 format to match how get features timestamps are returned.

Timestampp spec states that datetimes should always be displayed as UTC in json.

Arrow marshaling uses a slight variation of RFC3339, using their format string to remain consistent.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
