### PR TITLE
fix: Timestamps should be seconds percision. Return null status for found null values.

### DIFF
--- a/go/embedded/online_features.go
+++ b/go/embedded/online_features.go
@@ -240,7 +240,7 @@ func (s *OnlineFeatureService) GetOnlineFeatures(
 
 		tsColumnBuilder := array.NewInt64Builder(pool)
 		for _, ts := range featureVector.Timestamps {
-			tsColumnBuilder.Append(types.GetTimestampMillis(ts))
+			tsColumnBuilder.Append(types.GetTimestampSeconds(ts))
 		}
 		tsColumn := tsColumnBuilder.NewArray()
 		outputColumns = append(outputColumns, tsColumn)

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -767,7 +767,11 @@ func processFeatureRowData(
 	for i, val := range featureData.Values {
 		if val == nil {
 			rangeValues[i] = nil
-			rangeStatuses[i] = serving.FieldStatus_NOT_FOUND
+			if i < len(featureData.Statuses) {
+				rangeStatuses[i] = featureData.Statuses[i]
+			} else {
+				rangeStatuses[i] = serving.FieldStatus_NOT_FOUND
+			}
 			rangeTimestamps[i] = &timestamppb.Timestamp{}
 			continue
 		}

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -509,6 +509,7 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 							},
 						}
 					} else {
+						// TODO: return not found status to differentiate between nulls and not found features
 						results[serializedEntityKeyToIndex[keyString]][featureNamesToIdx[featName]] = FeatureData{
 							Reference: serving.FeatureReferenceV2{
 								FeatureViewName: featureViewName,

--- a/go/internal/feast/onlinestore/cassandraonlinestore_integration_test.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore_integration_test.go
@@ -406,8 +406,8 @@ func verifyResponseData(t *testing.T, data [][]RangeFeatureData, numEntityKeys i
 		assert.NotNil(t, data[i][32].Values[0])
 		assert.IsType(t, time.Time{}, data[i][32].Values[0])
 		for _, timestamp := range data[i][32].Values {
-			assert.GreaterOrEqual(t, timestamp.(time.Time).UnixMilli(), start, "Timestamp should be greater than or equal to %d", start)
-			assert.LessOrEqual(t, timestamp.(time.Time).UnixMilli(), end, "Timestamp should be less than or equal to %d", end)
+			assert.GreaterOrEqual(t, timestamp.(time.Time).Unix(), start, "Timestamp should be greater than or equal to %d", start)
+			assert.LessOrEqual(t, timestamp.(time.Time).Unix(), end, "Timestamp should be less than or equal to %d", end)
 		}
 	}
 }

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -3,8 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/reflection"
-
 	"github.com/feast-dev/feast/go/internal/feast"
 	"github.com/feast-dev/feast/go/internal/feast/server/logging"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
@@ -13,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/reflection"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	grpcPrometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -185,7 +184,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 				for k, ts := range timestamps {
 					timestampValues[k] = &prototypes.Value{
 						Val: &prototypes.Value_UnixTimestampVal{
-							UnixTimestampVal: types.GetTimestampMillis(ts),
+							UnixTimestampVal: types.GetTimestampSeconds(ts),
 						},
 					}
 				}

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -504,9 +504,9 @@ func InterfaceToProtoValue(val interface{}) (*types.Value, error) {
 	case bool:
 		protoVal.Val = &types.Value_BoolVal{BoolVal: v}
 	case time.Time:
-		protoVal.Val = &types.Value_UnixTimestampVal{UnixTimestampVal: v.UnixMilli()}
+		protoVal.Val = &types.Value_UnixTimestampVal{UnixTimestampVal: v.Unix()}
 	case *timestamppb.Timestamp:
-		protoVal.Val = &types.Value_UnixTimestampVal{UnixTimestampVal: GetTimestampMillis(v)}
+		protoVal.Val = &types.Value_UnixTimestampVal{UnixTimestampVal: GetTimestampSeconds(v)}
 
 	case [][]byte:
 		bytesList := &types.BytesList{Val: v}
@@ -574,7 +574,7 @@ func InterfaceToProtoValue(val interface{}) (*types.Value, error) {
 	case []time.Time:
 		timestamps := make([]int64, len(v))
 		for j, t := range v {
-			timestamps[j] = t.UnixMilli()
+			timestamps[j] = t.Unix()
 		}
 		timestampList := &types.Int64List{Val: timestamps}
 		protoVal.Val = &types.Value_UnixTimestampListVal{UnixTimestampListVal: timestampList}
@@ -582,7 +582,7 @@ func InterfaceToProtoValue(val interface{}) (*types.Value, error) {
 	case []*timestamppb.Timestamp:
 		timestamps := make([]int64, len(v))
 		for j, t := range v {
-			timestamps[j] = GetTimestampMillis(t)
+			timestamps[j] = GetTimestampSeconds(t)
 		}
 		timestampList := &types.Int64List{Val: timestamps}
 		protoVal.Val = &types.Value_UnixTimestampListVal{UnixTimestampListVal: timestampList}
@@ -912,9 +912,9 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 	return nil, err
 }
 
-func GetTimestampMillis(ts *timestamppb.Timestamp) int64 {
+func GetTimestampSeconds(ts *timestamppb.Timestamp) int64 {
 	if ts == nil {
 		return 0
 	}
-	return (ts.GetSeconds() * 1000) + int64(ts.GetNanos()/1_000_000)
+	return ts.GetSeconds()
 }

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -42,9 +42,9 @@ var (
 		{{Val: &types.Value_BytesVal{[]byte{1, 2, 3}}}, {Val: &types.Value_BytesVal{[]byte{4, 5, 6}}}},
 		{nil_or_null_val, {Val: &types.Value_BoolVal{false}}},
 		{{Val: &types.Value_BoolVal{true}}, {Val: &types.Value_BoolVal{false}}},
-		{{Val: &types.Value_UnixTimestampVal{time.Now().UnixMilli()}}, nil_or_null_val},
-		{{Val: &types.Value_UnixTimestampVal{time.Now().UnixMilli()}}, {Val: &types.Value_UnixTimestampVal{time.Now().UnixMilli()}}},
-		{{Val: &types.Value_UnixTimestampVal{time.Now().UnixMilli()}}, {Val: &types.Value_UnixTimestampVal{time.Now().UnixMilli()}}, {Val: &types.Value_UnixTimestampVal{-9223372036854775808}}},
+		{{Val: &types.Value_UnixTimestampVal{time.Now().Unix()}}, nil_or_null_val},
+		{{Val: &types.Value_UnixTimestampVal{time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{time.Now().Unix()}}},
+		{{Val: &types.Value_UnixTimestampVal{time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{-9223372036854775808}}},
 
 		{
 			{Val: &types.Value_Int32ListVal{&types.Int32List{Val: []int32{0, 1, 2}}}},
@@ -75,13 +75,13 @@ var (
 			{Val: &types.Value_BoolListVal{&types.BoolList{Val: []bool{true, true}}}},
 		},
 		{
-			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().UnixMilli()}}}},
-			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().UnixMilli()}}}},
+			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().Unix()}}}},
+			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().Unix()}}}},
 		},
 		{
-			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().UnixMilli(), time.Now().UnixMilli()}}}},
-			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().UnixMilli(), time.Now().UnixMilli()}}}},
-			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{-9223372036854775808, time.Now().UnixMilli()}}}},
+			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().Unix(), time.Now().Unix()}}}},
+			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{time.Now().Unix(), time.Now().Unix()}}}},
+			{Val: &types.Value_UnixTimestampListVal{&types.Int64List{Val: []int64{-9223372036854775808, time.Now().Unix()}}}},
 		},
 	}
 )
@@ -120,10 +120,10 @@ var (
 		{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}}},
 		{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}, {Val: &types.Value_BoolVal{BoolVal: false}}}},
 		{Val: []*types.Value{nil_or_null_val, {Val: &types.Value_BoolVal{BoolVal: false}}}},
-		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}}},
-		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli() + 3600}}}},
-		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}, nil_or_null_val}},
-		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: -9223372036854775808}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix() + 3600}}}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, nil_or_null_val}},
+		{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, {Val: &types.Value_UnixTimestampVal{UnixTimestampVal: -9223372036854775808}}}},
 	}
 )
 
@@ -163,8 +163,8 @@ var (
 			{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: false}}}},
 		},
 		{
-			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}}},
-			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli() + 3600}}}},
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}}},
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix() + 3600}}}},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}}},
@@ -211,8 +211,8 @@ var (
 			{Val: []*types.Value{{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{false, true}}}}}},
 		},
 		{
-			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().UnixMilli()}}}}}},
-			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().UnixMilli() + 3600}}}}}},
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix()}}}}}},
+			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix() + 3600}}}}}},
 		},
 	}
 )
@@ -439,8 +439,8 @@ func TestInterfaceToProtoValue(t *testing.T) {
 		{float32(30.5), &types.Value{Val: &types.Value_FloatVal{FloatVal: 30.5}}},
 		{float64(40.5), &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 40.5}}},
 		{true, &types.Value{Val: &types.Value_BoolVal{BoolVal: true}}},
-		{testTime, &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: testTime.UnixMilli()}}},
-		{&timestamppb.Timestamp{Seconds: testTime.Unix(), Nanos: int32(testTime.Nanosecond())}, &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: testTime.UnixMilli()}}},
+		{testTime, &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: testTime.Unix()}}},
+		{&timestamppb.Timestamp{Seconds: testTime.Unix(), Nanos: int32(testTime.Nanosecond())}, &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: testTime.Unix()}}},
 		{[][]byte{{1, 2}, {3, 4}}, &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{1, 2}, {3, 4}}}}}},
 		{[]string{"a", "b"}, &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"a", "b"}}}}},
 		{[]int{1, 2}, &types.Value{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{1, 2}}}}},
@@ -449,8 +449,8 @@ func TestInterfaceToProtoValue(t *testing.T) {
 		{[]float32{5.5, 6.6}, &types.Value{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{5.5, 6.6}}}}},
 		{[]float64{7.7, 8.8}, &types.Value{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{7.7, 8.8}}}}},
 		{[]bool{true, false}, &types.Value{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{true, false}}}}},
-		{[]time.Time{testTime, testTime.Add(time.Hour)}, &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{testTime.UnixMilli(), testTime.Add(time.Hour).UnixMilli()}}}}},
-		{[]*timestamppb.Timestamp{{Seconds: testTime.Unix(), Nanos: int32(testTime.Nanosecond())}, {Seconds: testTime.Add(time.Hour).Unix(), Nanos: int32(testTime.Add(time.Hour).Nanosecond())}}, &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{testTime.UnixMilli(), testTime.Add(time.Hour).UnixMilli()}}}}},
+		{[]time.Time{testTime, testTime.Add(time.Hour)}, &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{testTime.Unix(), testTime.Add(time.Hour).Unix()}}}}},
+		{[]*timestamppb.Timestamp{{Seconds: testTime.Unix(), Nanos: int32(testTime.Nanosecond())}, {Seconds: testTime.Add(time.Hour).Unix(), Nanos: int32(testTime.Add(time.Hour).Nanosecond())}}, &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{testTime.Unix(), testTime.Add(time.Hour).Unix()}}}}},
 		{&types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}, &types.Value{Val: &types.Value_NullVal{NullVal: types.Null_NULL}}},
 		{&types.Value{Val: &types.Value_StringVal{StringVal: "test"}}, &types.Value{Val: &types.Value_StringVal{StringVal: "test"}}},
 	}
@@ -464,7 +464,7 @@ func TestInterfaceToProtoValue(t *testing.T) {
 }
 
 func TestValueTypeToGoType(t *testing.T) {
-	timestamp := time.Now().UnixMilli()
+	timestamp := time.Now().Unix()
 	testCases := []*types.Value{
 		{Val: &types.Value_StringVal{StringVal: "test"}},
 		{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}},
@@ -514,7 +514,7 @@ func TestValueTypeToGoType(t *testing.T) {
 }
 
 func TestValueTypeToGoTypeTimestampAsString(t *testing.T) {
-	timestamp := time.Now().UnixMilli()
+	timestamp := time.Now().Unix()
 	testCases := []*types.Value{
 		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: timestamp}},
 		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp, timestamp + 3600}}}},
@@ -654,8 +654,8 @@ func TestConvertToValueType_Timestamp(t *testing.T) {
 		input    *types.Value
 		expected interface{}
 	}{
-		{input: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().UnixMilli()}}, expected: time.Now().UnixMilli()},
-		{input: &types.Value{Val: &types.Value_Int64Val{Int64Val: time.Now().UnixMilli()}}, expected: time.Now().UnixMilli()},
+		{input: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: time.Now().Unix()}}, expected: time.Now().Unix()},
+		{input: &types.Value{Val: &types.Value_Int64Val{Int64Val: time.Now().Unix()}}, expected: time.Now().Unix()},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
# What this PR does / why we need it:
UnixTimestamps are materialized with second precision, not millisecond precision.
Statuses should differeniate between stored null feature values and non-existent feature values

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
