### PR TITLE
fix: Handle null values in Arrow list conversion to Proto values

### DIFF
--- a/go/internal/feast/featurestore_test.go
+++ b/go/internal/feast/featurestore_test.go
@@ -183,6 +183,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 				FeatureView: "driver_stats",
 				FeatureName: "conv_rate",
 				Values:      []interface{}{0.85, 0.87, 0.89},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: now.Unix() - 86400*3},
 					{Seconds: now.Unix() - 86400*2},
@@ -193,6 +194,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 				FeatureView: "driver_stats",
 				FeatureName: "acc_rate",
 				Values:      []interface{}{0.91, 0.92, 0.94},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: now.Unix() - 86400*3},
 					{Seconds: now.Unix() - 86400*2},
@@ -205,6 +207,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 				FeatureView: "driver_stats",
 				FeatureName: "conv_rate",
 				Values:      []interface{}{0.78, 0.80},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: now.Unix() - 86400*3},
 					{Seconds: now.Unix() - 86400*1},
@@ -214,6 +217,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 				FeatureView: "driver_stats",
 				FeatureName: "acc_rate",
 				Values:      []interface{}{0.85, 0.88},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: now.Unix() - 86400*3},
 					{Seconds: now.Unix() - 86400*1},

--- a/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
+++ b/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
@@ -338,7 +338,7 @@ func assertResponseData(t *testing.T, response *serving.GetOnlineFeaturesRangeRe
 			if strings.Contains(featureName, "null") {
 				// For null features, we expect the value to contain 1 entry with a nil value
 				assert.NotNil(t, value)
-				assert.Equal(t, 1, len(value.Val), "Feature %s should have one value, got %d", featureName, len(value.Val))
+				assert.Equal(t, 10, len(value.Val), "Feature %s should have one value, got %d %s", featureName, len(value.Val), value.Val)
 				assert.Nil(t, value.Val[0].Val, "Feature %s should have a nil value", featureName)
 			} else {
 				assert.NotNil(t, value)

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -722,7 +722,7 @@ func TransposeRangeFeatureRowsIntoColumns(
 			for _, rowIndex := range outputIndexes {
 				if rangeValues == nil {
 					// Represents NOT FOUND status values as NULL
-					rangeValuesByRow[rowIndex] = &prototypes.RepeatedValue{}
+					rangeValuesByRow[rowIndex] = nil
 				} else {
 					rangeValuesByRow[rowIndex] = &prototypes.RepeatedValue{Val: rangeValues}
 				}

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -721,7 +721,6 @@ func TransposeRangeFeatureRowsIntoColumns(
 
 			for _, rowIndex := range outputIndexes {
 				if rangeValues == nil {
-					// Represents NOT FOUND status values as NULL
 					rangeValuesByRow[rowIndex] = nil
 				} else {
 					rangeValuesByRow[rowIndex] = &prototypes.RepeatedValue{Val: rangeValues}

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -772,6 +772,7 @@ func processFeatureRowData(
 
 	for i, val := range featureData.Values {
 		if val == nil {
+			//rangeValues[i] = &prototypes.Value{}
 			rangeValues[i] = nil
 			if i < len(featureData.Statuses) {
 				rangeStatuses[i] = featureData.Statuses[i]
@@ -791,6 +792,7 @@ func processFeatureRowData(
 		if i < len(featureData.Statuses) &&
 			(featureData.Statuses[i] == serving.FieldStatus_NOT_FOUND ||
 				featureData.Statuses[i] == serving.FieldStatus_NULL_VALUE) {
+			//rangeValues[i] = &prototypes.Value{}
 			rangeValues[i] = nil
 		} else {
 			rangeValues[i] = protoVal

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -1171,6 +1171,7 @@ func TestTransposeRangeFeatureRowsIntoColumns(t *testing.T) {
 				FeatureView: "testView",
 				FeatureName: "f1",
 				Values:      []interface{}{42.5, 43.2},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: nowTime.Unix()},
 					{Seconds: yesterdayTime.Unix()},
@@ -1182,6 +1183,7 @@ func TestTransposeRangeFeatureRowsIntoColumns(t *testing.T) {
 				FeatureView: "testView",
 				FeatureName: "f1",
 				Values:      []interface{}{99.9},
+				Statuses:    []serving.FieldStatus{serving.FieldStatus_PRESENT},
 				EventTimestamps: []timestamp.Timestamp{
 					{Seconds: nowTime.Unix()},
 				},

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -805,9 +805,8 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 						results[rowIdx][prepCtx.featureNamesToIdx[featName]] = RangeFeatureData{
 							FeatureView: prepCtx.featureViewName,
 							FeatureName: featName,
-							//Values:      nil,
-							Values:   []interface{}{nil},
-							Statuses: []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
+							Values:      []interface{}{nil},
+							Statuses:    []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
 							EventTimestamps: []timestamppb.Timestamp{
 								{Seconds: 0, Nanos: 0},
 							},

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -805,8 +805,9 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 						results[rowIdx][prepCtx.featureNamesToIdx[featName]] = RangeFeatureData{
 							FeatureView: prepCtx.featureViewName,
 							FeatureName: featName,
-							Values:      nil,
-							Statuses:    []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
+							//Values:      nil,
+							Values:   []interface{}{nil},
+							Statuses: []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
 							EventTimestamps: []timestamppb.Timestamp{
 								{Seconds: 0, Nanos: 0},
 							},

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -805,7 +805,7 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 						results[rowIdx][prepCtx.featureNamesToIdx[featName]] = RangeFeatureData{
 							FeatureView: prepCtx.featureViewName,
 							FeatureName: featName,
-							Values:      []interface{}{nil},
+							Values:      nil,
 							Statuses:    []serving.FieldStatus{serving.FieldStatus_NOT_FOUND},
 							EventTimestamps: []timestamppb.Timestamp{
 								{Seconds: 0, Nanos: 0},

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -175,10 +175,11 @@ func processFeatureVectors(
 
 			rangeForEntity := make([]interface{}, len(repeatedValue.Val))
 			for k, val := range repeatedValue.Val {
-				if val == nil {
+				goValue := types.ValueTypeToGoType(val)
+				if goValue == nil {
 					rangeForEntity[k] = nil
 				} else {
-					rangeForEntity[k] = types.ValueTypeToGoTypeTimestampAsString(val)
+					rangeForEntity[k] = goValue
 				}
 			}
 			simplifiedValues[j] = rangeForEntity

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -187,39 +187,23 @@ func processFeatureVectors(
 		result["values"] = simplifiedValues
 
 		if includeMetadata {
-			if len(vector.RangeStatuses) > 0 {
-				statusValues := make([][]string, len(vector.RangeStatuses))
-				for j, entityStatuses := range vector.RangeStatuses {
-					statusValues[j] = make([]string, len(entityStatuses))
-					for k, stat := range entityStatuses {
-						statusValues[j][k] = stat.String()
-					}
+			statusValues := make([][]string, len(vector.RangeStatuses))
+			for j, entityStatuses := range vector.RangeStatuses {
+				statusValues[j] = make([]string, len(entityStatuses))
+				for k, stat := range entityStatuses {
+					statusValues[j][k] = stat.String()
 				}
-				result["statuses"] = statusValues
-			} else {
-				result["statuses"] = [][]string{}
 			}
+			result["statuses"] = statusValues
 
-			if len(vector.RangeTimestamps) > 0 {
-				timestampValues := make([][]interface{}, len(vector.RangeTimestamps))
-				for j, entityTimestamps := range vector.RangeTimestamps {
-					timestampValues[j] = make([]interface{}, len(entityTimestamps))
-					for k, ts := range entityTimestamps {
-						if j < len(vector.RangeStatuses) && k < len(vector.RangeStatuses[j]) {
-							statusCode := vector.RangeStatuses[j][k]
-							if statusCode == serving.FieldStatus_NOT_FOUND ||
-								statusCode == serving.FieldStatus_NULL_VALUE {
-								timestampValues[j][k] = nil
-								continue
-							}
-						}
-						timestampValues[j][k] = ts.AsTime().Format(time.RFC3339)
-					}
+			timestampValues := make([][]interface{}, len(vector.RangeTimestamps))
+			for j, entityTimestamps := range vector.RangeTimestamps {
+				timestampValues[j] = make([]interface{}, len(entityTimestamps))
+				for k, ts := range entityTimestamps {
+					timestampValues[j][k] = ts.AsTime().Format(time.RFC3339)
 				}
-				result["event_timestamps"] = timestampValues
-			} else {
-				result["event_timestamps"] = [][]interface{}{}
 			}
+			result["event_timestamps"] = timestampValues
 		}
 
 		results = append(results, result)

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -175,7 +175,7 @@ func processFeatureVectors(
 
 			rangeForEntity := make([]interface{}, len(repeatedValue.Val))
 			for k, val := range repeatedValue.Val {
-				goValue := types.ValueTypeToGoType(val)
+				goValue := types.ValueTypeToGoTypeTimestampAsString(val)
 				if goValue == nil {
 					rangeForEntity[k] = nil
 				} else {

--- a/go/internal/feast/server/http_server_test.go
+++ b/go/internal/feast/server/http_server_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -364,7 +365,7 @@ func TestProcessFeatureVectors_TimestampHandling(t *testing.T) {
 	assert.NoError(t, err, "Error processing feature vectors")
 	assert.Equal(t, []string{"feature_3"}, featureNames)
 	timestamps := results[0]["event_timestamps"].([][]interface{})
-	assert.Nil(t, timestamps[0][0])
+	assert.Equal(t, "1970-01-01T00:00:00Z", timestamps[0][0])
 	assert.Equal(t, "1970-01-01T00:00:00Z", timestamps[1][0])
 }
 
@@ -418,5 +419,5 @@ func TestProcessFeatureVectors_NullValueReturnsNull(t *testing.T) {
 	assert.Nil(t, entityFeatureValues[0])
 
 	timestamps := results[0]["event_timestamps"].([][]interface{})
-	assert.Nil(t, timestamps[0][0])
+	assert.Equal(t, time.Unix(1234567890, 0).UTC().Format(time.RFC3339), timestamps[0][0], "Expected timestamp to be zero for null value")
 }

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -259,7 +259,7 @@ func ArrowListToProtoList(listArr *array.List, inputOffsets []int32) ([]*types.V
 	pos := int(inputOffsets[0])
 	values := make([]*types.Value, len(offsets))
 	for idx := 0; idx < len(offsets); idx++ {
-		if (listValues.IsNull(idx) ) {
+		if listValues.IsNull(idx) {
 			values[idx] = &types.Value{}
 		} else {
 			switch listValues.DataType() {
@@ -425,7 +425,11 @@ func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, 
 	}
 
 	for _, val := range protoValues {
-		repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{val}})
+		if val.GetVal() == nil {
+			repeatedValues = append(repeatedValues, &types.RepeatedValue{})
+		} else {
+			repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{val}})
+		}
 	}
 
 	return repeatedValues, nil

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -377,35 +377,32 @@ func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, 
 			values := make([]*types.Value, 0, end-start)
 
 			for j := start; j < end; j++ {
-
-				if listValues.IsNull(j) {
-					values = append(values, &types.Value{})
-					continue
-				}
-
 				var protoVal *types.Value
-
-				switch listValues.DataType() {
-				case arrow.PrimitiveTypes.Int32:
-					protoVal = &types.Value{Val: &types.Value_Int32Val{Int32Val: listValues.(*array.Int32).Value(j)}}
-				case arrow.PrimitiveTypes.Int64:
-					protoVal = &types.Value{Val: &types.Value_Int64Val{Int64Val: listValues.(*array.Int64).Value(j)}}
-				case arrow.PrimitiveTypes.Float32:
-					protoVal = &types.Value{Val: &types.Value_FloatVal{FloatVal: listValues.(*array.Float32).Value(j)}}
-				case arrow.PrimitiveTypes.Float64:
-					protoVal = &types.Value{Val: &types.Value_DoubleVal{DoubleVal: listValues.(*array.Float64).Value(j)}}
-				case arrow.BinaryTypes.Binary:
-					protoVal = &types.Value{Val: &types.Value_BytesVal{BytesVal: listValues.(*array.Binary).Value(j)}}
-				case arrow.BinaryTypes.String:
-					protoVal = &types.Value{Val: &types.Value_StringVal{StringVal: listValues.(*array.String).Value(j)}}
-				case arrow.FixedWidthTypes.Boolean:
-					protoVal = &types.Value{Val: &types.Value_BoolVal{BoolVal: listValues.(*array.Boolean).Value(j)}}
-				case arrow.FixedWidthTypes.Timestamp_s:
-					protoVal = &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: int64(listValues.(*array.Timestamp).Value(j))}}
-				case arrow.Null:
+				if listValues.IsNull(j) {
 					protoVal = &types.Value{}
-				default:
-					return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
+				} else {
+					switch listValues.DataType() {
+					case arrow.PrimitiveTypes.Int32:
+						protoVal = &types.Value{Val: &types.Value_Int32Val{Int32Val: listValues.(*array.Int32).Value(j)}}
+					case arrow.PrimitiveTypes.Int64:
+						protoVal = &types.Value{Val: &types.Value_Int64Val{Int64Val: listValues.(*array.Int64).Value(j)}}
+					case arrow.PrimitiveTypes.Float32:
+						protoVal = &types.Value{Val: &types.Value_FloatVal{FloatVal: listValues.(*array.Float32).Value(j)}}
+					case arrow.PrimitiveTypes.Float64:
+						protoVal = &types.Value{Val: &types.Value_DoubleVal{DoubleVal: listValues.(*array.Float64).Value(j)}}
+					case arrow.BinaryTypes.Binary:
+						protoVal = &types.Value{Val: &types.Value_BytesVal{BytesVal: listValues.(*array.Binary).Value(j)}}
+					case arrow.BinaryTypes.String:
+						protoVal = &types.Value{Val: &types.Value_StringVal{StringVal: listValues.(*array.String).Value(j)}}
+					case arrow.FixedWidthTypes.Boolean:
+						protoVal = &types.Value{Val: &types.Value_BoolVal{BoolVal: listValues.(*array.Boolean).Value(j)}}
+					case arrow.FixedWidthTypes.Timestamp_s:
+						protoVal = &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: int64(listValues.(*array.Timestamp).Value(j))}}
+					case arrow.Null:
+						protoVal = &types.Value{}
+					default:
+						return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
+					}
 				}
 				values = append(values, protoVal)
 			}

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -259,7 +259,7 @@ func ArrowListToProtoList(listArr *array.List, inputOffsets []int32) ([]*types.V
 	pos := int(inputOffsets[0])
 	values := make([]*types.Value, len(offsets))
 	for idx := 0; idx < len(offsets); idx++ {
-		if (listArr.IsNull(idx) ) {
+		if (listValues.IsNull(idx) ) {
 			values[idx] = &types.Value{}
 		} else {
 			switch listValues.DataType() {

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -2,10 +2,9 @@ package types
 
 import (
 	"fmt"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"math"
 	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -259,61 +258,61 @@ func ArrowListToProtoList(listArr *array.List, inputOffsets []int32) ([]*types.V
 	pos := int(inputOffsets[0])
 	values := make([]*types.Value, len(offsets))
 	for idx := 0; idx < len(offsets); idx++ {
-		if listValues.IsNull(idx) {
-			values[idx] = &types.Value{}
-		} else {
-			switch listValues.DataType() {
-			case arrow.PrimitiveTypes.Int32:
-				vals := make([]int32, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Int32).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: vals}}}
-			case arrow.PrimitiveTypes.Int64:
-				vals := make([]int64, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Int64).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: vals}}}
-			case arrow.PrimitiveTypes.Float32:
-				vals := make([]float32, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Float32).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: vals}}}
-			case arrow.PrimitiveTypes.Float64:
-				vals := make([]float64, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Float64).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: vals}}}
-			case arrow.BinaryTypes.Binary:
-				vals := make([][]byte, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Binary).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: vals}}}
-			case arrow.BinaryTypes.String:
-				vals := make([]string, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.String).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: vals}}}
-			case arrow.FixedWidthTypes.Boolean:
-				vals := make([]bool, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = listValues.(*array.Boolean).Value(j)
-				}
-				values[idx] = &types.Value{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: vals}}}
-			case arrow.FixedWidthTypes.Timestamp_s:
-				vals := make([]int64, int(offsets[idx])-pos)
-				for j := pos; j < int(offsets[idx]); j++ {
-					vals[j-pos] = int64(listValues.(*array.Timestamp).Value(j))
-				}
-				values[idx] = &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: vals}}}
-			default:
-				return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
+		switch listValues.DataType() {
+		case arrow.PrimitiveTypes.Int32:
+			//if pos == int(offsets[idx]) && listValues.IsNull(pos) {
+			//	values[idx] = &types.Value{}
+			//} else {
+			vals := make([]int32, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Int32).Value(j)
 			}
+			values[idx] = &types.Value{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: vals}}}
+			//}
+		case arrow.PrimitiveTypes.Int64:
+			vals := make([]int64, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Int64).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: vals}}}
+		case arrow.PrimitiveTypes.Float32:
+			vals := make([]float32, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Float32).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: vals}}}
+		case arrow.PrimitiveTypes.Float64:
+			vals := make([]float64, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Float64).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: vals}}}
+		case arrow.BinaryTypes.Binary:
+			vals := make([][]byte, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Binary).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: vals}}}
+		case arrow.BinaryTypes.String:
+			vals := make([]string, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.String).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: vals}}}
+		case arrow.FixedWidthTypes.Boolean:
+			vals := make([]bool, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = listValues.(*array.Boolean).Value(j)
+			}
+			values[idx] = &types.Value{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: vals}}}
+		case arrow.FixedWidthTypes.Timestamp_s:
+			vals := make([]int64, int(offsets[idx])-pos)
+			for j := pos; j < int(offsets[idx]); j++ {
+				vals[j-pos] = int64(listValues.(*array.Timestamp).Value(j))
+			}
+			values[idx] = &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: vals}}}
+		default:
+			return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
 		}
 
 		// set the end of current element as start of the next
@@ -355,31 +354,35 @@ func ProtoValuesToArrowArray(protoValues []*types.Value, arrowAllocator memory.A
 func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, error) {
 	repeatedValues := make([]*types.RepeatedValue, 0, arr.Len())
 
-	if listArr, ok := arr.(*array.List); ok {
-		listValues := listArr.ListValues()
-		offsets := listArr.Offsets()[1:]
-		pos := 0
-		for i := 0; i < listArr.Len(); i++ {
-			if listArr.IsNull(i) {
-				repeatedValues = append(repeatedValues, &types.RepeatedValue{})
-				continue
+	listArray := arr.(*array.List)
+	listValues := listArray.ListValues()
+
+	for i := 0; i < listArray.Len(); i++ {
+		if listArray.IsNull(i) {
+			// Null RepeatedValue
+			repeatedValues = append(repeatedValues, nil)
+			continue
+		}
+		if listOfLists, ok := listValues.(*array.List); ok {
+			start, end := listArray.ValueOffsets(i)
+			subOffsets := listOfLists.Offsets()[start : end+1]
+
+			values, err := ArrowListToProtoList(listOfLists, subOffsets)
+			if err != nil {
+				return nil, fmt.Errorf("error converting list to proto Value: %v", err)
 			}
+			repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
+		} else {
 
-			values := make([]*types.Value, 0, int(offsets[i])-pos)
+			//var values []*types.Value
 
-			if listOfLists, ok := listValues.(*array.List); ok {
-				start, end := listArr.ValueOffsets(i)
-				subOffsets := listOfLists.Offsets()[start : end+1]
-				var err error
-				values, err = ArrowListToProtoList(listOfLists, subOffsets)
-				if err != nil {
-					return nil, fmt.Errorf("error converting list to proto Value: %v", err)
-				}
-				repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
-				continue
-			}
+			start := int(listArray.Offsets()[i])
+			end := int(listArray.Offsets()[i+1])
 
-			for j := pos; j < int(offsets[i]); j++ {
+			values := make([]*types.Value, 0, end-start)
+
+			for j := start; j < end; j++ {
+
 				if listValues.IsNull(j) {
 					values = append(values, &types.Value{})
 					continue
@@ -404,14 +407,105 @@ func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, 
 					protoVal = &types.Value{Val: &types.Value_BoolVal{BoolVal: listValues.(*array.Boolean).Value(j)}}
 				case arrow.FixedWidthTypes.Timestamp_s:
 					protoVal = &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: int64(listValues.(*array.Timestamp).Value(j))}}
+				case arrow.Null:
+					protoVal = &types.Value{}
 				default:
 					return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
 				}
 
 				values = append(values, protoVal)
+
 			}
 
 			repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
+
+		}
+	}
+
+	return repeatedValues, nil
+}
+
+func ArrowValuesToRepeatedProtoValuesOld(arr arrow.Array) ([]*types.RepeatedValue, error) {
+	repeatedValues := make([]*types.RepeatedValue, 0, arr.Len())
+
+	if listArr, ok := arr.(*array.List); ok {
+		listValues := listArr.ListValues()
+		offsets := listArr.Offsets()[1:]
+		pos := 0
+		for i := 0; i < listArr.Len(); i++ {
+			// TODO: If logic is not being executed
+			if listArr.IsNull(i) {
+				repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: make([]*types.Value, 0)})
+				continue
+			}
+
+			if listOfLists, ok := listValues.(*array.List); ok {
+				start, end := listArr.ValueOffsets(i)
+				subOffsets := listOfLists.Offsets()[start : end+1]
+				if start == end {
+					// Empty Array
+					repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{}})
+				} else {
+					var err error
+					values, err := ArrowListToProtoList(listOfLists, subOffsets)
+					if err != nil {
+						return nil, fmt.Errorf("error converting list to proto Value: %v", err)
+					}
+					repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
+					//if values == nil {
+					//	repeatedValues = append(repeatedValues, &types.RepeatedValue{})
+					//} else {
+					//	repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
+					//}
+				}
+				continue
+			} else {
+
+				if int(offsets[i]) == pos {
+					// Empty Array
+					repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{}})
+					//} else if listValues.IsNull(pos) {
+					//	// Null Array
+					//	repeatedValues = append(repeatedValues, &types.RepeatedValue{})
+				} else {
+					values := make([]*types.Value, 0, int(offsets[i])-pos)
+					for j := pos; j < int(offsets[i]); j++ {
+						if listValues.IsNull(j) {
+							values = append(values, &types.Value{})
+							continue
+						}
+
+						var protoVal *types.Value
+
+						switch listValues.DataType() {
+						case arrow.PrimitiveTypes.Int32:
+							protoVal = &types.Value{Val: &types.Value_Int32Val{Int32Val: listValues.(*array.Int32).Value(j)}}
+						case arrow.PrimitiveTypes.Int64:
+							protoVal = &types.Value{Val: &types.Value_Int64Val{Int64Val: listValues.(*array.Int64).Value(j)}}
+						case arrow.PrimitiveTypes.Float32:
+							protoVal = &types.Value{Val: &types.Value_FloatVal{FloatVal: listValues.(*array.Float32).Value(j)}}
+						case arrow.PrimitiveTypes.Float64:
+							protoVal = &types.Value{Val: &types.Value_DoubleVal{DoubleVal: listValues.(*array.Float64).Value(j)}}
+						case arrow.BinaryTypes.Binary:
+							protoVal = &types.Value{Val: &types.Value_BytesVal{BytesVal: listValues.(*array.Binary).Value(j)}}
+						case arrow.BinaryTypes.String:
+							protoVal = &types.Value{Val: &types.Value_StringVal{StringVal: listValues.(*array.String).Value(j)}}
+						case arrow.FixedWidthTypes.Boolean:
+							protoVal = &types.Value{Val: &types.Value_BoolVal{BoolVal: listValues.(*array.Boolean).Value(j)}}
+						case arrow.FixedWidthTypes.Timestamp_s:
+							protoVal = &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: int64(listValues.(*array.Timestamp).Value(j))}}
+						case arrow.Null:
+							protoVal = &types.Value{}
+						default:
+							return nil, fmt.Errorf("unsupported data type in list: %s", listValues.DataType())
+						}
+
+						values = append(values, protoVal)
+					}
+
+					repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: values})
+				}
+			}
 			// set the end of current element as start of the next
 			pos = int(offsets[i])
 		}
@@ -425,10 +519,10 @@ func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, 
 	}
 
 	for _, val := range protoValues {
-		if val.GetVal() == nil {
-			repeatedValues = append(repeatedValues, &types.RepeatedValue{})
-		} else {
+		if val != nil && val.Val != nil {
 			repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{val}})
+		} else {
+			repeatedValues = append(repeatedValues, &types.RepeatedValue{Val: []*types.Value{}})
 		}
 	}
 
@@ -436,6 +530,84 @@ func ArrowValuesToRepeatedProtoValues(arr arrow.Array) ([]*types.RepeatedValue, 
 }
 
 func RepeatedProtoValuesToArrowArray(repeatedValues []*types.RepeatedValue, allocator memory.Allocator, numRows int) (arrow.Array, error) {
+	var valueType arrow.DataType
+	var protoValue *types.Value
+	var err error
+
+	for _, rv := range repeatedValues {
+		if rv != nil && len(rv.Val) > 0 {
+			for _, val := range rv.Val {
+				if val != nil && val.Val != nil {
+					protoValue = val
+					break
+				}
+			}
+			if protoValue != nil {
+				break
+			}
+		}
+	}
+
+	if protoValue != nil {
+		valueType, err = ProtoTypeToArrowType(protoValue)
+		if err != nil {
+			return nil, err
+		}
+
+		listBuilder := array.NewListBuilder(allocator, valueType)
+		defer listBuilder.Release()
+		valueBuilder := listBuilder.ValueBuilder()
+
+		for _, repeatedValue := range repeatedValues {
+
+			if repeatedValue == nil {
+				listBuilder.AppendNull()
+				continue
+			}
+
+			listBuilder.Append(true)
+
+			err = CopyProtoValuesToArrowArray(valueBuilder, repeatedValue.Val)
+			if err != nil {
+				return nil, fmt.Errorf("error copying proto values to arrow array: %v", err)
+			}
+
+		}
+
+		return listBuilder.NewArray(), nil
+
+	} else {
+		nullListBuilder := array.NewListBuilder(allocator, arrow.Null)
+		defer nullListBuilder.Release()
+		nullValueBuilder := nullListBuilder.ValueBuilder()
+		for _, repeatedVal := range repeatedValues {
+			if repeatedVal == nil {
+				nullListBuilder.AppendNull()
+				continue
+			}
+
+			nullListBuilder.Append(true)
+
+			for _, _ = range repeatedVal.Val {
+				nullValueBuilder.AppendNull()
+			}
+
+			//nullListBuilder.Append(true)
+			//if repeatedVal == nil || repeatedVal.Val == nil {
+			//	// TODO: Fix this case
+			//	//nullValueBuilder.AppendNull()
+			//} else {
+			//	for _, _ = range repeatedVal.Val {
+			//		nullValueBuilder.AppendNull()
+			//	}
+			//}
+		}
+		return nullListBuilder.NewArray(), nil
+	}
+
+}
+
+func RepeatedProtoValuesToArrowArrayOld(repeatedValues []*types.RepeatedValue, allocator memory.Allocator, numRows int) (arrow.Array, error) {
 	if len(repeatedValues) == 0 {
 		return array.NewNull(numRows), nil
 	}
@@ -457,8 +629,23 @@ func RepeatedProtoValuesToArrowArray(repeatedValues []*types.RepeatedValue, allo
 		}
 	}
 
+	// If all values in repeatedValues are NULL
 	if protoValue == nil {
-		return array.NewNull(numRows), nil
+		nullListBuilder := array.NewListBuilder(allocator, arrow.Null)
+		defer nullListBuilder.Release()
+		nullValueBuilder := nullListBuilder.ValueBuilder()
+		for _, repeatedVal := range repeatedValues {
+			nullListBuilder.Append(true)
+			if repeatedVal == nil || repeatedVal.Val == nil {
+				// TODO: Fix this case
+				//nullValueBuilder.AppendNull()
+			} else {
+				for _, _ = range repeatedVal.Val {
+					nullValueBuilder.AppendNull()
+				}
+			}
+		}
+		return nullListBuilder.NewArray(), nil
 	}
 
 	var err error
@@ -474,7 +661,13 @@ func RepeatedProtoValuesToArrowArray(repeatedValues []*types.RepeatedValue, allo
 	for _, repeatedValue := range repeatedValues {
 		listBuilder.Append(true)
 
-		if repeatedValue == nil || len(repeatedValue.Val) == 0 {
+		//if repeatedValue == nil || len(repeatedValue.Val) == 0 {
+		//	continue
+		//}
+
+		if repeatedValue == nil || repeatedValue.Val == nil {
+			// TODO: Check valueBuilder or listBuilder
+			valueBuilder.AppendNull()
 			continue
 		}
 		err = CopyProtoValuesToArrowArray(valueBuilder, repeatedValue.Val)

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -410,7 +410,6 @@ func TestValueTypeToGoType(t *testing.T) {
 		nil,
 		{},
 		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}},
-		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{1, 2, 3}}}},
 	}
 
 	expectedTypes := []interface{}{
@@ -436,7 +435,6 @@ func TestValueTypeToGoType(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		[]int32{1, 2, 3},
 	}
 
 	for i, testCase := range testCases {

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -185,34 +185,62 @@ var (
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{10, 11}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 21}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{100, 101}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{200, 201}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{1.1, 1.2}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{2.1, 2.2}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{1.1, 1.2}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{2.1, 2.2}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{1, 2}, {3, 4}}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{5, 6}, {7, 8}}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"row1", "row2"}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"row3", "row4"}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{true, false}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{false, true}}}}}},
+			{Val: []*types.Value{}},
+			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix()}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix() + 3600}}}}}},
+			{Val: []*types.Value{}},
+			{},
+		},
+		{
+			{Val: []*types.Value{}},
+			{Val: []*types.Value{}},
+			{Val: []*types.Value{}},
+			{Val: []*types.Value{}},
+		},
+		{
+			{},
+			{},
+			{},
+			{},
 		},
 	}
 )
@@ -484,6 +512,7 @@ func TestValueTypeToGoType(t *testing.T) {
 		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp.Unix(), timestamp.Unix() + 3600}}}},
 		{Val: &types.Value_NullVal{NullVal: types.Null_NULL}},
 		nil,
+		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}},
 	}
 
 	expectedTypes := []interface{}{
@@ -503,6 +532,7 @@ func TestValueTypeToGoType(t *testing.T) {
 		[]float64{9.3, 10.4},
 		[]bool{true, false},
 		[]time.Time{timestamp, timestamp.Add(3600 * time.Second)},
+		nil,
 		nil,
 		nil,
 	}

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -196,6 +196,8 @@ var (
 			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 30}}}}}},
 			nil,
 			{Val: []*types.Value{}},
+			// TODO: Fix tests to render correctly for below case
+			//{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 21}}}}, {Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{30, 31}}}}, nil_or_null_val}},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{100, 101}}}}}},

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -49,6 +49,7 @@ var (
 		{
 			{Val: &types.Value_Int32ListVal{&types.Int32List{Val: []int32{0, 1, 2}}}},
 			{Val: &types.Value_Int32ListVal{&types.Int32List{Val: []int32{3, 4, 5}}}},
+			{Val: &types.Value_Int32ListVal{&types.Int32List{Val: []int32{}}}},
 		},
 		{
 			{Val: &types.Value_Int64ListVal{&types.Int64List{Val: []int64{0, 1, 2, 553248634761893728}}}},
@@ -91,6 +92,8 @@ var (
 		{Val: []*types.Value{}},
 		{Val: []*types.Value{nil_or_null_val}},
 		{Val: []*types.Value{nil_or_null_val, nil_or_null_val}},
+		{Val: []*types.Value{{}, {}}},
+		{Val: []*types.Value{{Val: &types.Value_Int32Val{}}}},
 		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
 		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{Int32Val: 20}}}},
 		{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, nil_or_null_val}},
@@ -130,13 +133,15 @@ var (
 var (
 	MULTIPLE_REPEATED_PROTO_VALUES = [][]*types.RepeatedValue{
 		{
-			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 20}}}},
+			{Val: []*types.Value{}}, // Empty Array
+			nil,                     // NULL or Not Found Values
 		},
 		{
-			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}}},
-			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{Int32Val: 20}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 30}}}},
+			{Val: []*types.Value{}},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int64Val{Int64Val: 100}}}},
@@ -159,7 +164,7 @@ var (
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: true}}}},
-			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{}},
 			{Val: []*types.Value{{Val: &types.Value_BoolVal{BoolVal: false}}}},
 		},
 		{
@@ -173,10 +178,9 @@ var (
 		{
 			{Val: []*types.Value{
 				{Val: &types.Value_Int32Val{Int32Val: 10}},
-				nil_or_null_val,
 				{Val: &types.Value_Int32Val{Int32Val: 30}},
 			}},
-			{Val: []*types.Value{nil_or_null_val}},
+			{Val: []*types.Value{}},
 			{Val: []*types.Value{
 				{Val: &types.Value_Int32Val{Int32Val: 40}},
 				{Val: &types.Value_Int32Val{Int32Val: 50}},
@@ -185,62 +189,53 @@ var (
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{10, 11}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 21}}}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{}}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{10, 11}}}}}},
+			{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 30}}}}}},
+			nil,
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{100, 101}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{200, 201}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{1.1, 1.2}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_FloatListVal{FloatListVal: &types.FloatList{Val: []float32{2.1, 2.2}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{1.1, 1.2}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: []float64{2.1, 2.2}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{1, 2}, {3, 4}}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{5, 6}, {7, 8}}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"row1", "row2"}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"row3", "row4"}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{true, false}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_BoolListVal{BoolListVal: &types.BoolList{Val: []bool{false, true}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix()}}}}}},
 			{Val: []*types.Value{{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{time.Now().Unix() + 3600}}}}}},
 			{Val: []*types.Value{}},
-			{},
 		},
 		{
 			{Val: []*types.Value{}},
 			{Val: []*types.Value{}},
 			{Val: []*types.Value{}},
 			{Val: []*types.Value{}},
-		},
-		{
-			{},
-			{},
-			{},
-			{},
 		},
 	}
 )
@@ -268,6 +263,20 @@ func protoValuesEquals(t *testing.T, a, b []*types.Value) {
 	}
 }
 
+func protoRepeatedValueEquals(t *testing.T, a *types.RepeatedValue, b *types.RepeatedValue, index int) {
+	assert.Truef(t, proto.Equal(a, b),
+		"Values are not equal for testcase[%d]. Diff %v != %v", index, a, b)
+}
+
+func protoRepeatedValuesEquals(t *testing.T, a, b []*types.RepeatedValue, index int) {
+	assert.Equal(t, len(a), len(b))
+
+	for idx, left := range a {
+		assert.Truef(t, proto.Equal(left, b[idx]),
+			"Arrays are not equal for testcase[%d]. Diff[%d] %v != %v", index, idx, left, b[idx])
+	}
+}
+
 func TestRepeatedValueRoundTrip(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
@@ -280,45 +289,7 @@ func TestRepeatedValueRoundTrip(t *testing.T) {
 
 		assert.Equal(t, 1, len(result), "Should have 1 result for case %d", i)
 
-		if len(repeatedValue.Val) == 0 {
-			if len(result[0].Val) > 1 {
-				t.Errorf("Case %d: Expected empty value or single null, got %d values",
-					i, len(result[0].Val))
-			} else if len(result[0].Val) == 1 && result[0].Val[0] != nil && result[0].Val[0].Val != nil {
-				t.Errorf("Case %d: Expected null value, got a non-null value", i)
-			}
-			continue
-		}
-
-		for j := 0; j < len(repeatedValue.Val); j++ {
-			if repeatedValue.Val[j] != nil && repeatedValue.Val[j].Val != nil {
-				if j >= len(result[0].Val) {
-					continue
-				}
-
-				switch v := repeatedValue.Val[j].Val.(type) {
-				case *types.Value_FloatVal:
-					if math.IsNaN(float64(v.FloatVal)) {
-						assert.True(t, math.IsNaN(float64(result[0].Val[j].GetFloatVal())),
-							"Float NaN not preserved at index %d in case %d", j, i)
-					} else {
-						assert.Equal(t, v.FloatVal, result[0].Val[j].GetFloatVal(),
-							"Float value mismatch at index %d in case %d", j, i)
-					}
-				case *types.Value_DoubleVal:
-					if math.IsNaN(v.DoubleVal) {
-						assert.True(t, math.IsNaN(result[0].Val[j].GetDoubleVal()),
-							"Double NaN not preserved at index %d in case %d", j, i)
-					} else {
-						assert.Equal(t, v.DoubleVal, result[0].Val[j].GetDoubleVal(),
-							"Double value mismatch at index %d in case %d", j, i)
-					}
-				default:
-					assert.True(t, proto.Equal(repeatedValue.Val[j], result[0].Val[j]),
-						"Value mismatch at index %d in case %d", j, i)
-				}
-			}
-		}
+		protoRepeatedValueEquals(t, repeatedValue, result[0], i)
 	}
 }
 
@@ -335,50 +306,7 @@ func TestMultipleRepeatedValueRoundTrip(t *testing.T) {
 		assert.Equal(t, len(batch), len(results),
 			"Row count mismatch for batch %d", i)
 
-		for j := 0; j < len(batch); j++ {
-			original := batch[j]
-			result := results[j]
-
-			if len(original.Val) == 0 {
-				if len(result.Val) > 1 {
-					t.Errorf("Batch %d, row %d: Expected empty value or single null, got %d values",
-						i, j, len(result.Val))
-				} else if len(result.Val) == 1 && result.Val[0] != nil && result.Val[0].Val != nil {
-					t.Errorf("Batch %d, row %d: Expected null value, got a non-null value", i, j)
-				}
-				continue
-			}
-
-			for k := 0; k < len(original.Val); k++ {
-				if original.Val[k] != nil && original.Val[k].Val != nil {
-					if k >= len(result.Val) {
-						continue
-					}
-
-					switch v := original.Val[k].Val.(type) {
-					case *types.Value_FloatVal:
-						if math.IsNaN(float64(v.FloatVal)) {
-							assert.True(t, math.IsNaN(float64(result.Val[k].GetFloatVal())),
-								"Float NaN not preserved in batch %d, row %d, index %d", i, j, k)
-						} else {
-							assert.Equal(t, v.FloatVal, result.Val[k].GetFloatVal(),
-								"Float value mismatch in batch %d, row %d, index %d", i, j, k)
-						}
-					case *types.Value_DoubleVal:
-						if math.IsNaN(v.DoubleVal) {
-							assert.True(t, math.IsNaN(result.Val[k].GetDoubleVal()),
-								"Double NaN not preserved in batch %d, row %d, index %d", i, j, k)
-						} else {
-							assert.Equal(t, v.DoubleVal, result.Val[k].GetDoubleVal(),
-								"Double value mismatch in batch %d, row %d, index %d", i, j, k)
-						}
-					default:
-						assert.True(t, proto.Equal(original.Val[k], result.Val[k]),
-							"Value mismatch in batch %d, row %d, index %d", i, j, k)
-					}
-				}
-			}
-		}
+		protoRepeatedValuesEquals(t, batch, results, i)
 	}
 }
 
@@ -512,6 +440,7 @@ func TestValueTypeToGoType(t *testing.T) {
 		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp.Unix(), timestamp.Unix() + 3600}}}},
 		{Val: &types.Value_NullVal{NullVal: types.Null_NULL}},
 		nil,
+		{},
 		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}},
 	}
 
@@ -532,6 +461,8 @@ func TestValueTypeToGoType(t *testing.T) {
 		[]float64{9.3, 10.4},
 		[]bool{true, false},
 		[]time.Time{timestamp, timestamp.Add(3600 * time.Second)},
+		nil,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -448,6 +448,8 @@ func TestValueTypeToGoTypeTimestampAsString(t *testing.T) {
 	testCases := []*types.Value{
 		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: timestamp}},
 		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp, timestamp + 3600}}}},
+		{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: math.MinInt64}},
+		{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: []int64{timestamp, timestamp + 3600, math.MinInt64}}}},
 	}
 
 	expectedTypes := []interface{}{
@@ -455,6 +457,12 @@ func TestValueTypeToGoTypeTimestampAsString(t *testing.T) {
 		[]string{
 			time.Unix(timestamp, 0).UTC().Format(TimestampFormat),
 			time.Unix(timestamp+3600, 0).UTC().Format(TimestampFormat),
+		},
+		"292277026596-12-04 15:30:08Z",
+		[]string{
+			time.Unix(timestamp, 0).UTC().Format(TimestampFormat),
+			time.Unix(timestamp+3600, 0).UTC().Format(TimestampFormat),
+			"292277026596-12-04 15:30:08Z",
 		},
 	}
 

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -134,7 +134,8 @@ var (
 var (
 	MULTIPLE_REPEATED_PROTO_VALUES = [][]*types.RepeatedValue{
 		{
-			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{}}}},
+			// nil and {} are represented as same during Arrow conversion
+			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 10}}, {Val: &types.Value_Int32Val{}}, nil, {}}},
 			{Val: []*types.Value{{Val: &types.Value_Int32Val{Int32Val: 20}}}},
 			{Val: []*types.Value{}}, // Empty Array
 			nil,                     // NULL or Not Found Values
@@ -197,7 +198,9 @@ var (
 			nil,
 			{Val: []*types.Value{}},
 			// TODO: Fix tests to render correctly for below case
-			//{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 21}}}}, {Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{30, 31}}}}, nil_or_null_val}},
+			// Arrow List Builder is of specific Type (Ex: Int32).
+			// So nil or null values are represented as Empty Arrays
+			//{Val: []*types.Value{{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{20, 21}}}}, {Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{30, 31}}}}, {Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}}, {Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{}}}, nil, {}}},
 		},
 		{
 			{Val: []*types.Value{{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: []int64{100, 101}}}}}},

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -410,6 +410,7 @@ func TestValueTypeToGoType(t *testing.T) {
 		nil,
 		{},
 		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{}}}},
+		{Val: &types.Value_Int32ListVal{Int32ListVal: &types.Int32List{Val: []int32{1, 2, 3}}}},
 	}
 
 	expectedTypes := []interface{}{
@@ -434,6 +435,8 @@ func TestValueTypeToGoType(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		[]int32{1, 2, 3},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
1. Fail if number of values doesn't match with number of Status fields
2. When requested entity key has all NULL values for limit specified, it was represented as array with null value. Now its represented as array of null values with requested limit or number of records exists in Database
3. RepeatedProtoValuesToArrowArray appends NULL values if repeatedValue is nil. 
4. Removed unused code in ArrowValuesToRepeatedProtoValues. Removed invalid test TestProtoValuesToRepeatedConversion and associated code
5. Logic changed for HTTP response when metadata is requested. Currently it shows NIL values and empty timestamps. Updated it to represent correctly. 
6. Updated valueTypeToGoTypeTimestampAsString to represent NULL values in HTTP response as NULL instead of empty array `[]`

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
