### PR TITLE
fix: Validation order for multiple missing end keys should pass

### DIFF
--- a/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
+++ b/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
@@ -56,9 +56,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 
 	entities["index_id"] = &types.RepeatedValue{
 		Val: []*types.Value{
-			{Val: &types.Value_Int64Val{Int64Val: 1}},
 			{Val: &types.Value_Int64Val{Int64Val: 2}},
-			{Val: &types.Value_Int64Val{Int64Val: 3}},
 		},
 	}
 
@@ -66,7 +64,7 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		"null_int_val", "null_long_val", "null_float_val", "null_double_val", "null_byte_val", "null_string_val", "null_timestamp_val", "null_boolean_val",
 		"null_array_int_val", "null_array_long_val", "null_array_float_val", "null_array_double_val", "null_array_byte_val", "null_array_string_val",
 		"null_array_boolean_val", "array_int_val", "array_long_val", "array_float_val", "array_double_val", "array_string_val", "array_boolean_val",
-		"array_byte_val", "array_timestamp_val", "null_array_timestamp_val"}
+		"array_byte_val", "array_timestamp_val", "null_array_timestamp_val", "event_timestamp"}
 
 	var featureNamesWithFeatureView []string
 
@@ -84,10 +82,8 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 		SortKeyFilters: []*serving.SortKeyFilter{
 			{
 				SortKeyName: "event_timestamp",
-				Query: &serving.SortKeyFilter_Range{
-					Range: &serving.SortKeyFilter_RangeQuery{
-						RangeStart: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 0}},
-					},
+				Query: &serving.SortKeyFilter_Equals{
+					Equals: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1744769171}},
 				},
 			},
 		},

--- a/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
+++ b/go/internal/feast/integration_tests/scylladb/scylladb_integration_test.go
@@ -56,6 +56,54 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 
 	entities["index_id"] = &types.RepeatedValue{
 		Val: []*types.Value{
+			{Val: &types.Value_Int64Val{Int64Val: 1}},
+			{Val: &types.Value_Int64Val{Int64Val: 2}},
+			{Val: &types.Value_Int64Val{Int64Val: 3}},
+		},
+	}
+
+	featureNames := []string{"int_val", "long_val", "float_val", "double_val", "byte_val", "string_val", "timestamp_val", "boolean_val",
+		"null_int_val", "null_long_val", "null_float_val", "null_double_val", "null_byte_val", "null_string_val", "null_timestamp_val", "null_boolean_val",
+		"null_array_int_val", "null_array_long_val", "null_array_float_val", "null_array_double_val", "null_array_byte_val", "null_array_string_val",
+		"null_array_boolean_val", "array_int_val", "array_long_val", "array_float_val", "array_double_val", "array_string_val", "array_boolean_val",
+		"array_byte_val", "array_timestamp_val", "null_array_timestamp_val", "event_timestamp"}
+
+	var featureNamesWithFeatureView []string
+
+	for _, featureName := range featureNames {
+		featureNamesWithFeatureView = append(featureNamesWithFeatureView, "all_dtypes_sorted:"+featureName)
+	}
+
+	request := &serving.GetOnlineFeaturesRangeRequest{
+		Kind: &serving.GetOnlineFeaturesRangeRequest_Features{
+			Features: &serving.FeatureList{
+				Val: featureNamesWithFeatureView,
+			},
+		},
+		Entities: entities,
+		SortKeyFilters: []*serving.SortKeyFilter{
+			{
+				SortKeyName: "event_timestamp",
+				Query: &serving.SortKeyFilter_Range{
+					Range: &serving.SortKeyFilter_RangeQuery{
+						RangeStart: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 0}},
+					},
+				},
+			},
+		},
+		Limit:           10,
+		IncludeMetadata: true,
+	}
+	response, err := client.GetOnlineFeaturesRange(ctx, request)
+	assert.NoError(t, err)
+	assertResponseData(t, response, featureNames, 3, true)
+}
+
+func TestGetOnlineFeaturesRange_withOnlyEqualsFilter(t *testing.T) {
+	entities := make(map[string]*types.RepeatedValue)
+
+	entities["index_id"] = &types.RepeatedValue{
+		Val: []*types.Value{
 			{Val: &types.Value_Int64Val{Int64Val: 2}},
 		},
 	}
@@ -92,7 +140,26 @@ func TestGetOnlineFeaturesRange(t *testing.T) {
 	}
 	response, err := client.GetOnlineFeaturesRange(ctx, request)
 	assert.NoError(t, err)
-	assertResponseData(t, response, featureNames, true)
+	assert.NotNil(t, response)
+	assert.Equal(t, 1, len(response.Entities))
+	for i, featureResult := range response.Results {
+		assert.Equal(t, 1, len(featureResult.Values))
+		assert.Equal(t, 1, len(featureResult.Statuses))
+		assert.Equal(t, 1, len(featureResult.EventTimestamps))
+		for j, value := range featureResult.Values {
+			assert.NotNil(t, value)
+			assert.Equal(t, 1, len(value.Val))
+			featureName := featureNames[i]
+			if strings.Contains(featureName, "null") {
+				// For null features, we expect the value to contain 1 entry with a nil value
+				assert.Nil(t, value.Val[0].Val, "Feature %s should have a nil value", featureName)
+				assert.Equal(t, serving.FieldStatus_NULL_VALUE, featureResult.Statuses[j].Status[0], "Feature %s should have a NULL_VALUE status but was %s", featureName, featureResult.Statuses[j].Status[0])
+			} else {
+				assert.NotNil(t, value.Val[0].Val, "Feature %s should have a non-nil value", featureName)
+				assert.Equal(t, serving.FieldStatus_PRESENT, featureResult.Statuses[j].Status[0], "Feature %s should have a PRESENT status but was %s", featureName, featureResult.Statuses[j].Status[0])
+			}
+		}
+	}
 }
 
 func TestGetOnlineFeaturesRange_forNonExistentEntityKey(t *testing.T) {
@@ -193,7 +260,7 @@ func TestGetOnlineFeaturesRange_includesDuplicatedRequestedFeatures(t *testing.T
 	}
 	response, err := client.GetOnlineFeaturesRange(ctx, request)
 	assert.NoError(t, err)
-	assertResponseData(t, response, featureNames, false)
+	assertResponseData(t, response, featureNames, 3, false)
 }
 
 func TestGetOnlineFeaturesRange_withEmptySortKeyFilter(t *testing.T) {
@@ -231,7 +298,7 @@ func TestGetOnlineFeaturesRange_withEmptySortKeyFilter(t *testing.T) {
 	}
 	response, err := client.GetOnlineFeaturesRange(ctx, request)
 	assert.NoError(t, err)
-	assertResponseData(t, response, featureNames, false)
+	assertResponseData(t, response, featureNames, 3, false)
 }
 
 func TestGetOnlineFeaturesRange_withFeatureService(t *testing.T) {
@@ -314,20 +381,20 @@ func TestGetOnlineFeaturesRange_withFeatureViewThrowsError(t *testing.T) {
 	assert.Equal(t, "rpc error: code = InvalidArgument desc = GetOnlineFeaturesRange does not support standard feature views [all_dtypes]", err.Error(), "Expected error message for unsupported feature view")
 }
 
-func assertResponseData(t *testing.T, response *serving.GetOnlineFeaturesRangeResponse, featureNames []string, includeMetadata bool) {
+func assertResponseData(t *testing.T, response *serving.GetOnlineFeaturesRangeResponse, featureNames []string, entitiesRequested int, includeMetadata bool) {
 	assert.NotNil(t, response)
-	assert.Equal(t, 1, len(response.Entities), "Should have 1 entity")
+	assert.Equal(t, 1, len(response.Entities), "Should have 1 list of entity")
 	indexIdEntity, exists := response.Entities["index_id"]
 	assert.True(t, exists, "Should have index_id entity")
 	assert.NotNil(t, indexIdEntity)
-	assert.Equal(t, 3, len(indexIdEntity.Val), "Entity should have 3 values")
+	assert.Equal(t, entitiesRequested, len(indexIdEntity.Val), "Entity should have %d values", entitiesRequested)
 	assert.Equal(t, len(featureNames), len(response.Results), "Should have expected number of features")
 
 	for i, featureResult := range response.Results {
-		assert.Equal(t, 3, len(featureResult.Values))
+		assert.Equal(t, entitiesRequested, len(featureResult.Values))
 		if includeMetadata {
-			assert.Equal(t, 3, len(featureResult.Statuses))
-			assert.Equal(t, 3, len(featureResult.EventTimestamps), "Feature %s should have 3 event timestamps", featureNames[i])
+			assert.Equal(t, entitiesRequested, len(featureResult.Statuses))
+			assert.Equal(t, entitiesRequested, len(featureResult.EventTimestamps), "Feature %s should have %d event timestamps", featureNames[i], entitiesRequested)
 		}
 		for j, value := range featureResult.Values {
 			featureName := featureNames[i]

--- a/go/internal/feast/onlineserving/serving_test.go
+++ b/go/internal/feast/onlineserving/serving_test.go
@@ -548,6 +548,36 @@ func TestValidateSortKeyFilters_ValidFilters(t *testing.T) {
 
 	err = ValidateSortKeyFilters(validFilters, sortedViews)
 	assert.NoError(t, err, "Valid filters should not produce an error")
+
+	validFilters = []*serving.SortKeyFilter{
+		{
+			SortKeyName: "timestamp",
+			Query: &serving.SortKeyFilter_Equals{
+				Equals: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1640995200}},
+			},
+		},
+	}
+
+	err = ValidateSortKeyFilters(validFilters, sortedViews)
+	assert.NoError(t, err, "Valid filters should not produce an error")
+
+	validFilters = []*serving.SortKeyFilter{
+		{
+			SortKeyName: "timestamp",
+			Query: &serving.SortKeyFilter_Equals{
+				Equals: &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: 1640995200}},
+			},
+		},
+		{
+			SortKeyName: "name",
+			Query: &serving.SortKeyFilter_Equals{
+				Equals: &types.Value{Val: &types.Value_StringVal{StringVal: "John"}},
+			},
+		},
+	}
+
+	err = ValidateSortKeyFilters(validFilters, sortedViews)
+	assert.NoError(t, err, "Valid filters should not produce an error")
 }
 
 func TestValidateSortKeyFilters_EmptyFilters(t *testing.T) {

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -802,6 +802,8 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		}
 	case types.ValueType_INT64:
 		switch value.Val.(type) {
+		case *types.Value_Int32Val:
+			return &types.Value{Val: &types.Value_Int64Val{Int64Val: int64(value.GetInt32Val())}}, nil
 		case *types.Value_Int64Val:
 			return value, nil
 		}
@@ -817,6 +819,8 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		}
 	case types.ValueType_DOUBLE:
 		switch value.Val.(type) {
+		case *types.Value_FloatVal:
+			return &types.Value{Val: &types.Value_DoubleVal{DoubleVal: float64(value.GetFloatVal())}}, nil
 		case *types.Value_DoubleVal:
 			return value, nil
 		}
@@ -868,6 +872,13 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		}
 	case types.ValueType_INT64_LIST:
 		switch value.Val.(type) {
+		case *types.Value_Int32ListVal:
+			int32List := value.GetInt32ListVal().GetVal()
+			int64List := make([]int64, len(int32List))
+			for i, v := range int32List {
+				int64List[i] = int64(v)
+			}
+			return &types.Value{Val: &types.Value_Int64ListVal{Int64ListVal: &types.Int64List{Val: int64List}}}, nil
 		case *types.Value_Int64ListVal:
 			return value, nil
 		}
@@ -888,6 +899,13 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		}
 	case types.ValueType_DOUBLE_LIST:
 		switch value.Val.(type) {
+		case *types.Value_FloatListVal:
+			floatList := value.GetFloatListVal().GetVal()
+			doubleList := make([]float64, len(floatList))
+			for i, v := range floatList {
+				doubleList[i] = float64(v)
+			}
+			return &types.Value{Val: &types.Value_DoubleListVal{DoubleListVal: &types.DoubleList{Val: doubleList}}}, nil
 		case *types.Value_DoubleListVal:
 			return value, nil
 		}
@@ -895,6 +913,13 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		switch value.Val.(type) {
 		case *types.Value_UnixTimestampListVal:
 			return value, nil
+		case *types.Value_Int32ListVal:
+			int32List := value.GetInt32ListVal().GetVal()
+			unixTimestampList := make([]int64, len(int32List))
+			for i, v := range int32List {
+				unixTimestampList[i] = int64(v)
+			}
+			return &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: unixTimestampList}}}, nil
 		case *types.Value_Int64ListVal:
 			return &types.Value{Val: &types.Value_UnixTimestampListVal{UnixTimestampListVal: &types.Int64List{Val: value.GetInt64ListVal().GetVal()}}}, nil
 		}

--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -824,6 +824,8 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		switch value.Val.(type) {
 		case *types.Value_UnixTimestampVal:
 			return value, nil
+		case *types.Value_Int32Val:
+			return &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: int64(value.GetInt32Val())}}, nil
 		case *types.Value_Int64Val:
 			return &types.Value{Val: &types.Value_UnixTimestampVal{UnixTimestampVal: value.GetInt64Val()}}, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
SortKeyFilter validation was throwing an error for if any filter was not any equals except the very last defined sort key. It should allow the last requested filter to be range even if it is not the last defined sort key.

HTTP requests sometimes unmarshal integer values as int32 instead of int64.

# Which issue(s) this PR fixes:
SortKeyFilter logic updated
Added value conversion from int32 to int64/unix timestamp for entities and sort key filters from http.


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
