### PR TITLE
fix: When given a string for a bytes entity/sort key filter, attempt to convert as base64 string

### DIFF
--- a/go/types/typeconversion.go
+++ b/go/types/typeconversion.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/base64"
 	"fmt"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"math"
@@ -797,6 +798,15 @@ func valueTypeToGoTypeTimestampAsString(value *types.Value, timestampAsString bo
 	}
 }
 
+func transformStringToBytes(str string) []byte {
+	bytes, decodeErr := base64.StdEncoding.DecodeString(str)
+	if decodeErr != nil {
+		// If base64 decoding fails, try as a byte string
+		bytes = []byte(str)
+	}
+	return bytes
+}
+
 func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*types.Value, error) {
 	if valueType != types.ValueType_NULL {
 		if value == nil || value.Val == nil {
@@ -821,7 +831,7 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 		case *types.Value_BytesVal:
 			return value, nil
 		case *types.Value_StringVal:
-			return &types.Value{Val: &types.Value_BytesVal{BytesVal: []byte(value.GetStringVal())}}, nil
+			return &types.Value{Val: &types.Value_BytesVal{BytesVal: transformStringToBytes(value.GetStringVal())}}, nil
 		}
 	case types.ValueType_INT32:
 		switch value.Val.(type) {
@@ -884,7 +894,7 @@ func ConvertToValueType(value *types.Value, valueType types.ValueType_Enum) (*ty
 			stringList := value.GetStringListVal().GetVal()
 			bytesList := make([][]byte, len(stringList))
 			for i, str := range stringList {
-				bytesList[i] = []byte(str)
+				bytesList[i] = transformStringToBytes(str)
 			}
 			return &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: bytesList}}}, nil
 		}

--- a/go/types/typeconversion_test.go
+++ b/go/types/typeconversion_test.go
@@ -500,7 +500,8 @@ func TestConvertToValueType_Bytes(t *testing.T) {
 	}{
 		{input: &types.Value{Val: &types.Value_BytesVal{BytesVal: []byte{1, 2, 3}}}, expected: []byte{1, 2, 3}},
 		{input: &types.Value{Val: &types.Value_BytesVal{BytesVal: nil}}, expected: []byte(nil)},
-		{input: &types.Value{Val: &types.Value_StringVal{StringVal: "test"}}, expected: []byte("test")},
+		{input: &types.Value{Val: &types.Value_StringVal{StringVal: "\u0001\u0002\u0003"}}, expected: []byte{1, 2, 3}},
+		{input: &types.Value{Val: &types.Value_StringVal{StringVal: "dGVzdA=="}}, expected: []byte("test")},
 	}
 
 	for _, tc := range testCases {
@@ -632,7 +633,8 @@ func TestConvertToValueType_BytesList(t *testing.T) {
 	}{
 		{input: &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{{1, 2}, {3, 4}}}}}, expected: [][]byte{{1, 2}, {3, 4}}},
 		{input: &types.Value{Val: &types.Value_BytesListVal{BytesListVal: &types.BytesList{Val: [][]byte{}}}}, expected: [][]byte{}},
-		{input: &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"a", "b", "c"}}}}, expected: [][]byte{[]byte("a"), []byte("b"), []byte("c")}},
+		{input: &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"\u0001\u0002", "\u0003\u0004"}}}}, expected: [][]byte{{1, 2}, {3, 4}}},
+		{input: &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{"YQ==", "Yg==", "Yw=="}}}}, expected: [][]byte{[]byte("a"), []byte("b"), []byte("c")}},
 		{input: &types.Value{Val: &types.Value_StringListVal{StringListVal: &types.StringList{Val: []string{}}}}, expected: [][]byte{}},
 	}
 


### PR DESCRIPTION
# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
