### PR TITLE
fix: Update Feature View Not Catching SortedFeatureView/FeatureView Errors

### DIFF
--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -135,7 +135,11 @@ class HttpRegistry(BaseRegistry):
         logger.exception("Request failed with exception: %s", repr(exception))
         # If it's already an HTTPStatusError, re-raise it as is
         if isinstance(exception, HTTPStatusError):
-            raise exception
+            raise HTTPStatusError(
+                "Request failed with exception: " + repr(exception),
+                request=exception.request,
+                response=exception.response,
+            ) from exception
         raise httpx.HTTPError(
             "Request failed with exception: " + repr(exception)
         ) from exception

--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -133,6 +133,9 @@ class HttpRegistry(BaseRegistry):
 
     def _handle_exception(self, exception: Exception):
         logger.exception("Request failed with exception: %s", repr(exception))
+        # If it's already an HTTPStatusError, re-raise it as is
+        if isinstance(exception, HTTPStatusError):
+            raise exception
         raise httpx.HTTPError(
             "Request failed with exception: " + repr(exception)
         ) from exception


### PR DESCRIPTION

# What this PR does / why we need it:
Adding a check to see if HTTPStatusError is being raised within _handle_exception and if it is, to return the same so that the HTTPStatusError is executed and raises the right error when get_feature_view is called in the Http registry.