### PR TITLE
feat: Streaming ingestion latency improvements

### DIFF
--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -1,3 +1,4 @@
+import os
 from types import MethodType
 from typing import List, Optional, Set, Union, no_type_check
 
@@ -252,6 +253,13 @@ class SparkKafkaProcessor(StreamProcessor):
         # Validation occurs at the fs.write_to_online_store() phase against the stream feature view schema.
         def batch_write(row: DataFrame, batch_id: int):
             rows: pd.DataFrame = row.toPandas()
+
+            num_driver_cores = self.spark.sparkContext.getConf().get(
+                "spark.driver.cores"
+            )
+            if num_driver_cores is not None:
+                # This environment variable is used in passthrough provider to determine the number of processes to spawn
+                os.environ["SPARK_DRIVER_CORES"] = num_driver_cores
 
             # Extract the latest feature values for each unique entity row (i.e. the join keys).
             # Also add a 'created' column.

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -296,9 +296,9 @@ class PassthroughProvider(Provider):
         }
         num_spark_driver_cores = int(os.environ.get("SPARK_DRIVER_CORES", 1))
 
-        if num_spark_driver_cores > 3:
-            # Leaving a couple of cores for operating system and other background processes
-            num_processes = num_spark_driver_cores - 2
+        if num_spark_driver_cores > 2:
+            # Leaving one core for operating system and other background processes
+            num_processes = num_spark_driver_cores - 1
 
             if table.num_rows < num_processes:
                 num_processes = table.num_rows

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -311,12 +311,9 @@ class PassthroughProvider(Provider):
             ]
 
             with Pool(processes=num_processes) as pool:
-                pool.starmap(self.process_chunk, chunks_to_parallelize)
+                pool.starmap(self.process, chunks_to_parallelize)
         else:
-            rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-            self.online_write_batch(
-                self.repo_config, feature_view, rows_to_write, progress=None
-            )
+            self.process(table, feature_view, join_keys)
 
     def split_table(self, num_processes, table):
         num_table_rows = table.num_rows
@@ -332,7 +329,7 @@ class PassthroughProvider(Provider):
             offset += length
         return chunks
 
-    def process_chunk(self, table, feature_view: FeatureView, join_keys):
+    def process(self, table, feature_view: FeatureView, join_keys):
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
         self.online_write_batch(
             self.repo_config, feature_view, rows_to_write, progress=None

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -1,5 +1,7 @@
 import logging
+import os
 from datetime import datetime, timedelta
+from multiprocessing import Pool
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import pandas as pd
@@ -292,6 +294,46 @@ class PassthroughProvider(Provider):
             entity.name: entity.dtype.to_value_type()
             for entity in feature_view.entity_columns
         }
+        num_spark_driver_cores = int(os.environ.get("SPARK_DRIVER_CORES", 1))
+
+        if num_spark_driver_cores > 3:
+            # Leaving a couple of cores for operating system and other background processes
+            num_processes = num_spark_driver_cores - 2
+
+            if table.num_rows < num_processes:
+                num_processes = table.num_rows
+
+            # Input table is split into smaller chunks and processed in parallel
+            chunks = self.split_table(num_processes, table)
+
+            chunks_to_parallelize = [
+                (chunk, feature_view, join_keys) for chunk in chunks
+            ]
+
+            with Pool(processes=num_processes) as pool:
+                pool.starmap(self.process_chunk, chunks_to_parallelize)
+        else:
+            rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
+
+            self.online_write_batch(
+                self.repo_config, feature_view, rows_to_write, progress=None
+            )
+
+    def split_table(self, num_processes, table):
+        num_table_rows = table.num_rows
+        size = num_table_rows // num_processes  # base size of each chunk
+        remainder = num_table_rows % num_processes  # extra rows to distribute
+
+        chunks = []
+        offset = 0
+        for i in range(num_processes):
+            # Distribute the remainder one per split until exhausted
+            length = size + (1 if i < remainder else 0)
+            chunks.append(table.slice(offset, length))
+            offset += length
+        return chunks
+
+    def process_chunk(self, table, feature_view: FeatureView, join_keys):
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
 
         self.online_write_batch(

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -314,7 +314,6 @@ class PassthroughProvider(Provider):
                 pool.starmap(self.process_chunk, chunks_to_parallelize)
         else:
             rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
             self.online_write_batch(
                 self.repo_config, feature_view, rows_to_write, progress=None
             )
@@ -335,7 +334,6 @@ class PassthroughProvider(Provider):
 
     def process_chunk(self, table, feature_view: FeatureView, join_keys):
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
         self.online_write_batch(
             self.repo_config, feature_view, rows_to_write, progress=None
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Streaming ingestion latencies were ranging from 10sec to 30sec after 1K TPS, which is not desirable. The purpose of this PR is to improve the latencies by parallelizing the time-consuming portions of the code using multiprocessing. Most of the latencies are coming from [arrow_to_proto conversion](https://github.com/ExpediaGroup/feast/blob/bf641bd1230d11fc77b64383f6446dc9b4d101b1/sdk/python/feast/infra/passthrough_provider.py#L295) and [online_write_batch](https://github.com/ExpediaGroup/feast/blob/bf641bd1230d11fc77b64383f6446dc9b4d101b1/sdk/python/feast/infra/passthrough_provider.py#L297). To address that, in this PR, the input dataframe/ arrow table is split into smaller inputs, and then they are processed in parallel on multiple cores/processes using multiprocessing.

The number of processes spawned is (number of cores allocated to Spark driver-2), as I left a couple of cores for OS and other background processes. 
In this PR, multiprocessing kicks in only if the number of cores allocated to spark driver is > 3. Because otherwise, lets say if the number of driver cores =3 and if we leave 2 cores for OS & other processes, then we will be left with 1 core in which case it will be same as not having multiprocessing. Also, at lower TPS (like 1K TPS) where 2-3 driver cores are used, the latency looks fine without multiprocessing, and hence it's not needed. 

Perf test results with multiprocessing:
https://expediagroup.atlassian.net/wiki/spaces/PE/pages/790170632/Range+Query+-+Streaming+ingestion+load+test+results-+ScyllaDB#Performance-test-results-using-the-above-proposed-solution-(multiprocessing)%3A