### PR TITLE
fix: limit Elasticsearch version <9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ DUCKDB_REQUIRED = ["ibis-framework[duckdb]>=9.0.0,<10"]
 
 DELTA_REQUIRED = ["deltalake"]
 
-ELASTICSEARCH_REQUIRED = ["elasticsearch>=8.13.0"]
+ELASTICSEARCH_REQUIRED = ["elasticsearch>=8.13.0,<9.0.0"]
 
 SINGLESTORE_REQUIRED = ["singlestoredb<1.8.0"]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Limits the Elasticsearch version to <9 to be compatible with version 8 Elasticsearch clusters

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://expediagroup.atlassian.net/browse/EAPC-19899

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
