### PR TITLE
fix: Add retry with exponential backoff for online store writes (streaming)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ requires = [
   "pybindgen==0.22.0",
   # https://amitylearning.vercel.app/?question=git-1742419854670&update=1742342400027
   "setuptools>=60,<81",
-  "setuptools_scm>=6.2",
+  "setuptools_scm>=6.2,<10",
   "sphinx!=4.0.0",
   "wheel",
 ]

--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -1,6 +1,9 @@
+import logging
 import os
+import random
+import time
 from types import MethodType
-from typing import List, Optional, Set, Union, no_type_check
+from typing import Callable, List, Optional, Set, Union, no_type_check
 
 import pandas as pd
 from pyspark import SparkContext
@@ -22,6 +25,94 @@ from feast.infra.contrib.stream_processor import (
 from feast.infra.provider import get_provider
 from feast.sorted_feature_view import SortedFeatureView
 from feast.stream_feature_view import StreamFeatureView
+
+logger = logging.getLogger(__name__)
+
+# Patterns that indicate transient errors which should be retried
+TRANSIENT_ERROR_PATTERNS = [
+    "writetimeout",
+    "readtimeout",
+    "unavailable",
+    "operationtimedout",
+    "nohostsavailable",
+    "connection refused",
+    "connection reset",
+    "timeout",
+    "overloaded",
+]
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    """Check if an exception is a transient error that should be retried."""
+    exc_str = str(exc).lower()
+    exc_type = type(exc).__name__.lower()
+
+    for pattern in TRANSIENT_ERROR_PATTERNS:
+        if pattern in exc_str or pattern in exc_type:
+            return True
+    return False
+
+
+def _write_with_retry(
+    write_fn: Callable[[], None],
+    operation_name: str,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 30.0,
+) -> None:
+    """
+    Execute a write function with exponential backoff retry for transient errors.
+
+    Args:
+        write_fn: The write function to execute
+        operation_name: Name of the operation for logging
+        max_retries: Maximum number of retry attempts
+        base_delay: Base delay in seconds for exponential backoff
+        max_delay: Maximum delay in seconds between retries
+
+    Raises:
+        Exception: The last exception if all retries are exhausted or if a
+                   non-transient error occurs
+    """
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            write_fn()
+            if attempt > 0:
+                logger.info(
+                    f"[{operation_name}] Succeeded after {attempt} retry attempt(s)"
+                )
+            return  # Success
+        except Exception as e:
+            last_exception = e
+
+            if not _is_transient_error(e):
+                # Permanent error - don't retry, bubble up immediately
+                logger.error(
+                    f"[{operation_name}] Permanent error (not retrying): "
+                    f"{type(e).__name__}: {e}"
+                )
+                raise
+
+            if attempt < max_retries:
+                # Calculate delay with exponential backoff + jitter
+                delay = min(base_delay * (2**attempt), max_delay)
+                jitter = random.uniform(0, delay * 0.1)
+                total_delay = delay + jitter
+
+                logger.warning(
+                    f"[{operation_name}] Transient error, retry {attempt + 1}/{max_retries} "
+                    f"after {total_delay:.2f}s: {type(e).__name__}: {e}"
+                )
+                time.sleep(total_delay)
+            else:
+                # Max retries exceeded - bubble up the exception
+                logger.error(
+                    f"[{operation_name}] Max retries ({max_retries}) exceeded: "
+                    f"{type(e).__name__}: {e}"
+                )
+                raise
 
 
 class SparkProcessorConfig(ProcessorConfig):
@@ -279,11 +370,28 @@ class SparkKafkaProcessor(StreamProcessor):
                 rows = self.preprocess_fn(rows)
 
             # Finally persist the data to the online store and/or offline store.
+            # Use retry with exponential backoff for transient errors.
             if rows.size > 0:
                 if to == PushMode.ONLINE or to == PushMode.ONLINE_AND_OFFLINE:
-                    self.fs.write_to_online_store(self.sfv.name, rows)
+                    _write_with_retry(
+                        write_fn=lambda: self.fs.write_to_online_store(
+                            self.sfv.name, rows
+                        ),
+                        operation_name=f"write_to_online_store[{self.sfv.name}][batch_id={batch_id}]",
+                        max_retries=3,
+                        base_delay=1.0,
+                        max_delay=30.0,
+                    )
                 if to == PushMode.OFFLINE or to == PushMode.ONLINE_AND_OFFLINE:
-                    self.fs.write_to_offline_store(self.sfv.name, rows)
+                    _write_with_retry(
+                        write_fn=lambda: self.fs.write_to_offline_store(
+                            self.sfv.name, rows
+                        ),
+                        operation_name=f"write_to_offline_store[{self.sfv.name}][batch_id={batch_id}]",
+                        max_retries=3,
+                        base_delay=1.0,
+                        max_delay=30.0,
+                    )
 
         query = (
             df.writeStream.outputMode("update")
@@ -294,4 +402,14 @@ class SparkKafkaProcessor(StreamProcessor):
         )
 
         query.awaitTermination(timeout=self.query_timeout)
+
+        # Check if the query terminated with an error and propagate it
+        # This ensures exceptions from batch_write() bubble up to the caller
+        query_exception = query.exception()
+        if query_exception is not None:
+            logger.error(
+                f"Streaming query terminated with exception: {query_exception}"
+            )
+            raise query_exception
+
         return query

--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -74,8 +74,6 @@ def _write_with_retry(
         Exception: The last exception if all retries are exhausted or if a
                    non-transient error occurs
     """
-    last_exception: Optional[Exception] = None
-
     for attempt in range(max_retries + 1):
         try:
             write_fn()
@@ -85,8 +83,6 @@ def _write_with_retry(
                 )
             return  # Success
         except Exception as e:
-            last_exception = e
-
             if not _is_transient_error(e):
                 # Permanent error - don't retry, bubble up immediately
                 logger.error(

--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -37,7 +37,6 @@ TRANSIENT_ERROR_PATTERNS = [
     "nohostsavailable",
     "connection refused",
     "connection reset",
-    "timeout",
     "overloaded",
 ]
 
@@ -397,15 +396,16 @@ class SparkKafkaProcessor(StreamProcessor):
             .start()
         )
 
-        query.awaitTermination(timeout=self.query_timeout)
+        terminated = query.awaitTermination(timeout=self.query_timeout)
 
-        # Check if the query terminated with an error and propagate it
-        # This ensures exceptions from batch_write() bubble up to the caller
-        query_exception = query.exception()
-        if query_exception is not None:
-            logger.error(
-                f"Streaming query terminated with exception: {query_exception}"
-            )
-            raise query_exception
+        if terminated:
+            # Query terminated before timeout - check if it was an error
+            # This ensures exceptions from batch_write() bubble up to the caller
+            query_exception = query.exception()
+            if query_exception is not None:
+                logger.error(
+                    f"Streaming query terminated with exception: {query_exception}"
+                )
+                raise query_exception
 
         return query

--- a/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
+++ b/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
@@ -1,0 +1,284 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from feast.infra.contrib.spark_kafka_processor import (
+    _is_transient_error,
+    _write_with_retry,
+    TRANSIENT_ERROR_PATTERNS,
+)
+
+
+class TestIsTransientError:
+    """Tests for the _is_transient_error function."""
+
+    def test_writetimeout_in_message(self):
+        """WriteTimeout errors should be classified as transient."""
+        exc = Exception("WriteTimeout during batch insert")
+        assert _is_transient_error(exc) is True
+
+    def test_readtimeout_in_message(self):
+        """ReadTimeout errors should be classified as transient."""
+        exc = Exception("ReadTimeout while fetching data")
+        assert _is_transient_error(exc) is True
+
+    def test_unavailable_in_message(self):
+        """Unavailable errors should be classified as transient."""
+        exc = Exception("Unavailable: Not enough replicas")
+        assert _is_transient_error(exc) is True
+
+    def test_operationtimedout_in_message(self):
+        """OperationTimedOut errors should be classified as transient."""
+        exc = Exception("OperationTimedOut after 10000ms")
+        assert _is_transient_error(exc) is True
+
+    def test_nohostsavailable_in_message(self):
+        """NoHostsAvailable errors should be classified as transient."""
+        exc = Exception("NoHostsAvailable: Unable to connect to any servers")
+        assert _is_transient_error(exc) is True
+
+    def test_connection_refused_in_message(self):
+        """Connection refused errors should be classified as transient."""
+        exc = Exception("Connection refused to host 192.168.1.1")
+        assert _is_transient_error(exc) is True
+
+    def test_connection_reset_in_message(self):
+        """Connection reset errors should be classified as transient."""
+        exc = Exception("Connection reset by peer")
+        assert _is_transient_error(exc) is True
+
+    def test_overloaded_in_message(self):
+        """Overloaded errors should be classified as transient."""
+        exc = Exception("Server is overloaded, try again later")
+        assert _is_transient_error(exc) is True
+
+    def test_transient_error_in_exception_type_name(self):
+        """Transient patterns in exception type name should be detected."""
+
+        class WriteTimeoutError(Exception):
+            pass
+
+        exc = WriteTimeoutError("Some message")
+        assert _is_transient_error(exc) is True
+
+    def test_case_insensitive_matching(self):
+        """Error matching should be case-insensitive."""
+        exc = Exception("WRITETIMEOUT occurred")
+        assert _is_transient_error(exc) is True
+
+        exc2 = Exception("ReadTimeOut happened")
+        assert _is_transient_error(exc2) is True
+
+    def test_permanent_error_not_classified_as_transient(self):
+        """Permanent errors should not be classified as transient."""
+        exc = Exception("Invalid query syntax")
+        assert _is_transient_error(exc) is False
+
+    def test_key_error_not_transient(self):
+        """KeyError should not be classified as transient."""
+        exc = KeyError("missing_column")
+        assert _is_transient_error(exc) is False
+
+    def test_value_error_not_transient(self):
+        """ValueError should not be classified as transient."""
+        exc = ValueError("Invalid value provided")
+        assert _is_transient_error(exc) is False
+
+    def test_authentication_error_not_transient(self):
+        """Authentication errors should not be classified as transient."""
+        exc = Exception("Authentication failed: invalid credentials")
+        assert _is_transient_error(exc) is False
+
+    def test_schema_mismatch_not_transient(self):
+        """Schema mismatch errors should not be classified as transient."""
+        exc = Exception("Schema mismatch: expected 5 columns, got 3")
+        assert _is_transient_error(exc) is False
+
+
+class TestWriteWithRetry:
+    """Tests for the _write_with_retry function."""
+
+    def test_successful_write_no_retry(self):
+        """Successful write should not trigger retries."""
+        mock_write_fn = MagicMock()
+
+        _write_with_retry(
+            write_fn=mock_write_fn,
+            operation_name="test_write",
+            max_retries=3,
+        )
+
+        mock_write_fn.assert_called_once()
+
+    def test_transient_error_triggers_retry(self):
+        """Transient errors should trigger retries."""
+        mock_write_fn = MagicMock()
+        # First call raises transient error, second call succeeds
+        mock_write_fn.side_effect = [
+            Exception("WriteTimeout during insert"),
+            None,
+        ]
+
+        with patch("feast.infra.contrib.spark_kafka_processor.time.sleep"):
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=3,
+            )
+
+        assert mock_write_fn.call_count == 2
+
+    def test_multiple_transient_errors_retry_until_success(self):
+        """Multiple transient errors should keep retrying until success."""
+        mock_write_fn = MagicMock()
+        # First two calls raise transient errors, third succeeds
+        mock_write_fn.side_effect = [
+            Exception("WriteTimeout"),
+            Exception("ReadTimeout"),
+            None,
+        ]
+
+        with patch("feast.infra.contrib.spark_kafka_processor.time.sleep"):
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=3,
+            )
+
+        assert mock_write_fn.call_count == 3
+
+    def test_max_retries_exceeded_raises_exception(self):
+        """Exceeding max retries should raise the last exception."""
+        mock_write_fn = MagicMock()
+        # All calls raise transient errors
+        mock_write_fn.side_effect = Exception("WriteTimeout")
+
+        with patch("feast.infra.contrib.spark_kafka_processor.time.sleep"):
+            with pytest.raises(Exception) as exc_info:
+                _write_with_retry(
+                    write_fn=mock_write_fn,
+                    operation_name="test_write",
+                    max_retries=3,
+                )
+
+        assert "WriteTimeout" in str(exc_info.value)
+        # Initial attempt + 3 retries = 4 total calls
+        assert mock_write_fn.call_count == 4
+
+    def test_permanent_error_no_retry(self):
+        """Permanent errors should not trigger retries."""
+        mock_write_fn = MagicMock()
+        mock_write_fn.side_effect = ValueError("Invalid schema")
+
+        with pytest.raises(ValueError) as exc_info:
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=3,
+            )
+
+        assert "Invalid schema" in str(exc_info.value)
+        mock_write_fn.assert_called_once()
+
+    def test_exponential_backoff_delay(self):
+        """Retries should use exponential backoff delays."""
+        mock_write_fn = MagicMock()
+        mock_write_fn.side_effect = [
+            Exception("WriteTimeout"),
+            Exception("WriteTimeout"),
+            None,
+        ]
+
+        sleep_calls = []
+
+        def track_sleep(delay):
+            sleep_calls.append(delay)
+
+        with patch(
+            "feast.infra.contrib.spark_kafka_processor.time.sleep",
+            side_effect=track_sleep,
+        ):
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=3,
+                base_delay=1.0,
+                max_delay=30.0,
+            )
+
+        # Should have slept twice (before retry 1 and retry 2)
+        assert len(sleep_calls) == 2
+        # First delay should be ~1.0 (base_delay * 2^0 + jitter)
+        assert 1.0 <= sleep_calls[0] <= 1.1
+        # Second delay should be ~2.0 (base_delay * 2^1 + jitter)
+        assert 2.0 <= sleep_calls[1] <= 2.2
+
+    def test_max_delay_cap(self):
+        """Delay should be capped at max_delay."""
+        mock_write_fn = MagicMock()
+        # Need enough failures to hit the max delay cap
+        mock_write_fn.side_effect = [
+            Exception("WriteTimeout"),
+            Exception("WriteTimeout"),
+            Exception("WriteTimeout"),
+            None,
+        ]
+
+        sleep_calls = []
+
+        def track_sleep(delay):
+            sleep_calls.append(delay)
+
+        with patch(
+            "feast.infra.contrib.spark_kafka_processor.time.sleep",
+            side_effect=track_sleep,
+        ):
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=3,
+                base_delay=10.0,
+                max_delay=15.0,
+            )
+
+        # Third delay would be 10 * 2^2 = 40, but capped at 15
+        assert sleep_calls[2] <= 15.0 * 1.1  # Allow for jitter
+
+    def test_zero_retries_fails_immediately(self):
+        """With max_retries=0, transient errors should fail immediately."""
+        mock_write_fn = MagicMock()
+        mock_write_fn.side_effect = Exception("WriteTimeout")
+
+        with pytest.raises(Exception) as exc_info:
+            _write_with_retry(
+                write_fn=mock_write_fn,
+                operation_name="test_write",
+                max_retries=0,
+            )
+
+        assert "WriteTimeout" in str(exc_info.value)
+        mock_write_fn.assert_called_once()
+
+
+class TestTransientErrorPatterns:
+    """Tests to verify the TRANSIENT_ERROR_PATTERNS list."""
+
+    def test_all_patterns_are_lowercase(self):
+        """All patterns should be lowercase for case-insensitive matching."""
+        for pattern in TRANSIENT_ERROR_PATTERNS:
+            assert pattern == pattern.lower(), f"Pattern '{pattern}' is not lowercase"
+
+    def test_expected_patterns_present(self):
+        """Verify expected Cassandra/ScyllaDB patterns are present."""
+        expected_patterns = [
+            "writetimeout",
+            "readtimeout",
+            "unavailable",
+            "operationtimedout",
+            "nohostsavailable",
+        ]
+        for pattern in expected_patterns:
+            assert pattern in TRANSIENT_ERROR_PATTERNS, f"Expected pattern '{pattern}' not found"
+
+    def test_generic_timeout_not_present(self):
+        """Generic 'timeout' pattern should not be present (too broad)."""
+        assert "timeout" not in TRANSIENT_ERROR_PATTERNS

--- a/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
+++ b/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
@@ -113,7 +113,6 @@ class TestWriteWithRetry:
     def test_transient_error_triggers_retry(self):
         """Transient errors should trigger retries."""
         mock_write_fn = MagicMock()
-        # First call raises transient error, second call succeeds
         mock_write_fn.side_effect = [
             Exception("WriteTimeout during insert"),
             None,
@@ -131,7 +130,6 @@ class TestWriteWithRetry:
     def test_multiple_transient_errors_retry_until_success(self):
         """Multiple transient errors should keep retrying until success."""
         mock_write_fn = MagicMock()
-        # First two calls raise transient errors, third succeeds
         mock_write_fn.side_effect = [
             Exception("WriteTimeout"),
             Exception("ReadTimeout"),
@@ -150,7 +148,6 @@ class TestWriteWithRetry:
     def test_max_retries_exceeded_raises_exception(self):
         """Exceeding max retries should raise the last exception."""
         mock_write_fn = MagicMock()
-        # All calls raise transient errors
         mock_write_fn.side_effect = Exception("WriteTimeout")
 
         with patch("feast.infra.contrib.spark_kafka_processor.time.sleep"):
@@ -162,7 +159,6 @@ class TestWriteWithRetry:
                 )
 
         assert "WriteTimeout" in str(exc_info.value)
-        # Initial attempt + 3 retries = 4 total calls
         assert mock_write_fn.call_count == 4
 
     def test_permanent_error_no_retry(self):
@@ -206,17 +202,13 @@ class TestWriteWithRetry:
                 max_delay=30.0,
             )
 
-        # Should have slept twice (before retry 1 and retry 2)
         assert len(sleep_calls) == 2
-        # First delay should be ~1.0 (base_delay * 2^0 + jitter)
         assert 1.0 <= sleep_calls[0] <= 1.1
-        # Second delay should be ~2.0 (base_delay * 2^1 + jitter)
         assert 2.0 <= sleep_calls[1] <= 2.2
 
     def test_max_delay_cap(self):
         """Delay should be capped at max_delay."""
         mock_write_fn = MagicMock()
-        # Need enough failures to hit the max delay cap
         mock_write_fn.side_effect = [
             Exception("WriteTimeout"),
             Exception("WriteTimeout"),
@@ -241,8 +233,7 @@ class TestWriteWithRetry:
                 max_delay=15.0,
             )
 
-        # Third delay would be 10 * 2^2 = 40, but capped at 15
-        assert sleep_calls[2] <= 15.0 * 1.1  # Allow for jitter
+        assert sleep_calls[2] <= 16.5  # 15.0 + 10% jitter
 
     def test_zero_retries_fails_immediately(self):
         """With max_retries=0, transient errors should fail immediately."""
@@ -266,23 +257,13 @@ class TestTransientErrorPatterns:
     def test_all_patterns_are_lowercase(self):
         """All patterns should be lowercase for case-insensitive matching."""
         for pattern in TRANSIENT_ERROR_PATTERNS:
-            assert (
-                pattern == pattern.lower()
-            ), f"Pattern '{pattern}' is not lowercase"
+            assert pattern == pattern.lower()
 
     def test_expected_patterns_present(self):
         """Verify expected Cassandra/ScyllaDB patterns are present."""
-        expected_patterns = [
-            "writetimeout",
-            "readtimeout",
-            "unavailable",
-            "operationtimedout",
-            "nohostsavailable",
-        ]
-        for pattern in expected_patterns:
-            assert (
-                pattern in TRANSIENT_ERROR_PATTERNS
-            ), f"Expected pattern '{pattern}' not found"
+        expected = ["writetimeout", "readtimeout", "unavailable", "operationtimedout"]
+        for pattern in expected:
+            assert pattern in TRANSIENT_ERROR_PATTERNS
 
     def test_generic_timeout_not_present(self):
         """Generic 'timeout' pattern should not be present (too broad)."""

--- a/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
+++ b/sdk/python/tests/unit/infra/contrib/test_spark_kafka_processor.py
@@ -1,10 +1,11 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from feast.infra.contrib.spark_kafka_processor import (
+    TRANSIENT_ERROR_PATTERNS,
     _is_transient_error,
     _write_with_retry,
-    TRANSIENT_ERROR_PATTERNS,
 )
 
 
@@ -265,7 +266,9 @@ class TestTransientErrorPatterns:
     def test_all_patterns_are_lowercase(self):
         """All patterns should be lowercase for case-insensitive matching."""
         for pattern in TRANSIENT_ERROR_PATTERNS:
-            assert pattern == pattern.lower(), f"Pattern '{pattern}' is not lowercase"
+            assert (
+                pattern == pattern.lower()
+            ), f"Pattern '{pattern}' is not lowercase"
 
     def test_expected_patterns_present(self):
         """Verify expected Cassandra/ScyllaDB patterns are present."""
@@ -277,7 +280,9 @@ class TestTransientErrorPatterns:
             "nohostsavailable",
         ]
         for pattern in expected_patterns:
-            assert pattern in TRANSIENT_ERROR_PATTERNS, f"Expected pattern '{pattern}' not found"
+            assert (
+                pattern in TRANSIENT_ERROR_PATTERNS
+            ), f"Expected pattern '{pattern}' not found"
 
     def test_generic_timeout_not_present(self):
         """Generic 'timeout' pattern should not be present (too broad)."""

--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,6 @@ setup(
     use_scm_version=use_scm_version,
     setup_requires=[
         "pybindgen==0.22.0",
-        "setuptools_scm>=6.2",
+        "setuptools_scm>=6.2,<10",
     ],
 )


### PR DESCRIPTION
# What this PR does / why we need it:
Streaming materialization to Cassandra/ScyllaDB was failing without proper                                                                                                                                     retry handling. Write failures inside Spark's foreachBatch were not being                                                                                                                                          retried, and exceptions were silently swallowed because query.exception()                                                                                                                                          
was never checked after awaitTermination().                                                                                                                                                                        
                                                                                                                                                                                                                     Changes:                                                                                                                                                                                                           
- Add _write_with_retry() helper with exponential backoff (1s -> 2s -> 4s)                                                                                                                                                 and jitter to prevent thundering herd on transient failures                                                                                                                                                      
- Add _is_transient_error() to classify retryable errors (WriteTimeout,                                                                                                                                            
  Unavailable, NoHostAvailable, connection errors, etc.)                                                                                                                                                           
- Wrap write_to_online_store() and write_to_offline_store() calls with retry                                                                                                                                       
- Check query.exception() after awaitTermination() and raise if present,                                                                                                                                           
  ensuring exceptions properly bubble up to the caller                                                                                                                                                                                                                                                                                                                                                                                  
  This fixes an issue where Cassandra transient failures (timeouts, node                                                                                                                                             
  unavailability) caused immediate streaming job failures without retry,                                                                                                                                             
  and the outer retry mechanism in the materialization layer never fired                                                                                                                                             
  because exceptions weren't propagated.                                                                                                                                                                             
                                                                                                                                                                                                                    
Retry behavior:                                                                                                                                                                                                    
- 3 retries max with exponential backoff (1s, 2s, 4s) + 10% jitter                                                                                                                                                 
- Transient errors (timeout, unavailable, connection) are retried                                                                                                                                                  
- Permanent errors (config, auth, schema) fail immediately                                                                                                                                                         
- After max retries, exception bubbles up to Spark/caller                                                                                                                                                                          

Additional Fix:                                                                                                                                                                                                    
  Pinned setuptools_scm>=6.2,<10 in setup.py and pyproject.toml to fix CI build failure caused by breaking change in setuptools_scm 10.0.3.                                                                          
  


