### PR TITLE
feat: Valkey Online Write Batch Vector Search Support

### DIFF
--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -27,28 +27,40 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
 )
 
+import numpy as np
 from google.protobuf.timestamp_pb2 import Timestamp
 from pydantic import StrictStr
-from valkey.exceptions import ValkeyError
+from valkey.exceptions import ResponseError, ValkeyError
 
 from feast import Entity, FeatureView, RepoConfig, utils
+from feast.field import Field
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.helpers import _mmh3, _redis_key, _redis_key_prefix
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.protos.feast.types.Value_pb2 import (
+    DoubleList,
+    FloatList,
+)
+from feast.protos.feast.types.Value_pb2 import (
+    Value as ValueProto,
+)
 from feast.repo_config import FeastConfigBaseModel
 from feast.sorted_feature_view import SortedFeatureView
+from feast.types import Array, Float32, Float64
 from feast.value_type import ValueType
 
 try:
     from valkey import Valkey
     from valkey import asyncio as valkey_asyncio
     from valkey.cluster import ClusterNode, ValkeyCluster
+    from valkey.commands.search.field import VectorField
+    from valkey.commands.search.indexDefinition import IndexDefinition, IndexType
     from valkey.sentinel import Sentinel
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
@@ -56,6 +68,90 @@ except ImportError as e:
     raise FeastExtrasDependencyImportError("eg-valkey", str(e))
 
 logger = logging.getLogger(__name__)
+
+
+def _get_vector_index_name(project: str, feature_view_name: str) -> str:
+    """Generate Valkey Search index name for vector fields."""
+    return f"{project}_{feature_view_name}_vidx"
+
+
+def _get_valkey_vector_type(feast_dtype) -> str:
+    """
+    Map Feast dtype to Valkey vector TYPE parameter.
+
+    Args:
+        feast_dtype: Feast data type (e.g., Array(Float32))
+
+    Returns:
+        Valkey vector type string: "FLOAT32" or "FLOAT64"
+    """
+    if feast_dtype == Array(Float32):
+        return "FLOAT32"
+    elif feast_dtype == Array(Float64):
+        return "FLOAT64"
+    else:
+        # Default to FLOAT32 for other numeric arrays
+        logger.warning(f"Unsupported vector dtype {feast_dtype}, defaulting to FLOAT32")
+        return "FLOAT32"
+
+
+def _serialize_vector_to_bytes(val: ValueProto, field: Field) -> bytes:
+    """
+    Serialize a vector ValueProto to raw bytes for Valkey storage.
+
+    Vector fields must be stored as raw bytes (not protobuf serialized) to be
+    compatible with Valkey Search FT.SEARCH queries.
+
+    Args:
+        val: The ValueProto containing the vector data
+        field: The Field metadata for dtype and dimension information
+
+    Returns:
+        Raw bytes in the format expected by Valkey vector search
+
+    Raises:
+        ValueError: If vector type is unsupported or dimension mismatches
+    """
+    if val.HasField("float_list_val"):
+        # Float32 array
+        vector = np.array(val.float_list_val.val, dtype=np.float32)
+    elif val.HasField("double_list_val"):
+        # Float64 array
+        vector = np.array(val.double_list_val.val, dtype=np.float64)
+    else:
+        raise ValueError(
+            f"Unsupported vector type for field {field.name}. "
+            f"Expected float_list_val or double_list_val."
+        )
+
+    # Validate dimension matches expected
+    if field.vector_length > 0 and len(vector) != field.vector_length:
+        raise ValueError(
+            f"Vector dimension mismatch for field {field.name}: "
+            f"expected {field.vector_length}, got {len(vector)}"
+        )
+
+    return vector.tobytes()
+
+
+def _deserialize_vector_from_bytes(raw_bytes: bytes, field: Field) -> ValueProto:
+    """
+    Deserialize raw vector bytes back to ValueProto.
+
+    Args:
+        raw_bytes: Raw bytes from Valkey
+        field: Field metadata for dtype information
+
+    Returns:
+        ValueProto with float_list_val or double_list_val
+    """
+    if field.dtype == Array(Float64):
+        vector = np.frombuffer(raw_bytes, dtype=np.float64)
+        return ValueProto(double_list_val=DoubleList(val=vector.tolist()))
+    else:
+        # Default to Float32
+        vector = np.frombuffer(raw_bytes, dtype=np.float32)
+        return ValueProto(float_list_val=FloatList(val=vector.tolist()))
 
 
 class EGValkeyType(str, Enum):
@@ -99,6 +195,19 @@ class EGValkeyOnlineStoreConfig(FeastConfigBaseModel):
 
     max_pipeline_commands: Optional[int] = 500
     """(Optional) The maximum number of Valkey commands to queue in a pipeline before sending them to Valkey in a single batch."""
+
+    # Vector search configuration
+    vector_index_algorithm: Literal["FLAT", "HNSW"] = "HNSW"
+    """Algorithm for vector indexing. FLAT for exact search (<100K vectors), HNSW for approximate search (large datasets)."""
+
+    vector_index_hnsw_m: Optional[int] = 16
+    """HNSW: Max number of outgoing edges per node."""
+
+    vector_index_hnsw_ef_construction: Optional[int] = 200
+    """HNSW: Size of dynamic candidate list during index construction."""
+
+    vector_index_hnsw_ef_runtime: Optional[int] = 10
+    """HNSW: Size of dynamic candidate list during search."""
 
 
 class EGValkeyOnlineStore(OnlineStore):
@@ -289,6 +398,94 @@ class EGValkeyOnlineStore(OnlineStore):
                 self._client_async = valkey_asyncio.Valkey(**kwargs)
         return self._client_async
 
+    def _create_vector_index_if_not_exists(
+        self,
+        client: Union[Valkey, ValkeyCluster],
+        config: RepoConfig,
+        table: FeatureView,
+        vector_fields: Dict[str, Field],
+    ) -> None:
+        """
+        Create Valkey Search index for vector fields if not already exists.
+
+        Uses FT.CREATE with VECTOR field type and appropriate algorithm parameters.
+
+        Args:
+            client: Valkey client
+            config: Feast repo configuration
+            table: Feature view with vector fields
+            vector_fields: Dictionary of vector field name to Field object
+        """
+        online_store_config = config.online_store
+        assert isinstance(online_store_config, EGValkeyOnlineStoreConfig)
+
+        index_name = _get_vector_index_name(config.project, table.name)
+
+        # Check if index exists
+        try:
+            client.ft(index_name).info()
+            logger.debug(f"Vector index {index_name} already exists")
+            return
+        except ResponseError:
+            pass  # Index doesn't exist, create it
+
+        # Build schema for vector fields
+        schema_fields = []
+
+        for field_name, field in vector_fields.items():
+            # Validate required properties
+            if field.vector_length <= 0:
+                raise ValueError(
+                    f"Field {field_name} has vector_index=True but vector_length is not set. "
+                    f"vector_length must be > 0 for vector indexing."
+                )
+
+            # Determine vector type from Feast dtype
+            vector_type = _get_valkey_vector_type(field.dtype)
+
+            # Build algorithm attributes
+            attributes = {
+                "TYPE": vector_type,  # "FLOAT32" or "FLOAT64"
+                "DIM": field.vector_length,
+                "DISTANCE_METRIC": field.vector_search_metric or "COSINE",
+            }
+
+            # Add algorithm-specific parameters
+            algorithm = online_store_config.vector_index_algorithm
+            if algorithm == "HNSW":
+                attributes["M"] = online_store_config.vector_index_hnsw_m
+                attributes["EF_CONSTRUCTION"] = (
+                    online_store_config.vector_index_hnsw_ef_construction
+                )
+                attributes["EF_RUNTIME"] = (
+                    online_store_config.vector_index_hnsw_ef_runtime
+                )
+
+            schema_fields.append(VectorField(field_name, algorithm, attributes))
+
+        # Define index on HASH keys with specific prefix
+        key_prefix = _redis_key_prefix(table.join_keys)
+        definition = IndexDefinition(
+            prefix=[key_prefix],
+            index_type=IndexType.HASH,
+        )
+
+        # Create the index
+        try:
+            client.ft(index_name).create_index(
+                fields=schema_fields,
+                definition=definition,
+            )
+            logger.info(
+                f"Created vector index {index_name} with {len(vector_fields)} vector field(s): {list(vector_fields.keys())}"
+            )
+        except ValkeyError as e:
+            logger.error(
+                f"Failed to create vector index {index_name}: {e}. "
+                f"Ensure Valkey Search module is loaded."
+            )
+            raise
+
     def online_write_batch(
         self,
         config: RepoConfig,
@@ -307,6 +504,7 @@ class EGValkeyOnlineStore(OnlineStore):
         feature_view = table.name
         ts_key = f"_ts:{feature_view}"
         keys = []
+
         # Track all ZSET keys touched in this batch for TTL cleanup & trimming
         zsets_to_cleanup: set[Tuple[bytes, bytes]] = (
             set()
@@ -448,6 +646,16 @@ class EGValkeyOnlineStore(OnlineStore):
                             )
                             raise
             else:
+                # Identify vector fields (only for regular FeatureViews, not SortedFeatureView)
+                vector_fields = {f.name: f for f in table.features if f.vector_index}
+                vector_field_names = set(vector_fields.keys())
+
+                # Create vector index if needed (only on first write with vector fields)
+                if vector_fields:
+                    self._create_vector_index_if_not_exists(
+                        client, config, table, vector_fields
+                    )
+
                 # check if a previous record under the key bin exists
                 # TODO: investigate if check and set is a better approach rather than pulling all entity ts and then setting
                 # it may be significantly slower but avoids potential (rare) race conditions
@@ -484,8 +692,16 @@ class EGValkeyOnlineStore(OnlineStore):
                     entity_hset[ts_key] = ts.SerializeToString()
 
                     for feature_name, val in values.items():
-                        f_key = _mmh3(f"{feature_view}:{feature_name}")
-                        entity_hset[f_key] = val.SerializeToString()
+                        if feature_name in vector_field_names:
+                            # Vector field: store with ORIGINAL name and RAW bytes
+                            vector_bytes = _serialize_vector_to_bytes(
+                                val, vector_fields[feature_name]
+                            )
+                            entity_hset[feature_name] = vector_bytes
+                        else:
+                            # Non-vector field: store with mmh3 hash and protobuf serialization
+                            f_key = _mmh3(f"{feature_view}:{feature_name}")
+                            entity_hset[f_key] = val.SerializeToString()
 
                     pipe.hset(valkey_key_bin, mapping=entity_hset)
 
@@ -580,28 +796,54 @@ class EGValkeyOnlineStore(OnlineStore):
         self,
         feature_view: FeatureView,
         requested_features: Optional[List[str]] = None,
-    ) -> Tuple[List[str], List[str]]:
+    ) -> Tuple[List[str], List[str], Set[str]]:
+        """
+        Generate HSET keys for feature retrieval.
+
+        Returns:
+            Tuple of (feature_names, hset_keys, vector_field_names)
+        """
         if not requested_features:
             requested_features = [f.name for f in feature_view.features]
 
-        hset_keys = [_mmh3(f"{feature_view.name}:{k}") for k in requested_features]
+        # Identify vector fields
+        vector_field_names = {f.name for f in feature_view.features if f.vector_index}
+
+        hset_keys = []
+        for feature_name in requested_features:
+            if feature_name in vector_field_names:
+                # Vector field: use original name
+                hset_keys.append(feature_name)
+            else:
+                # Non-vector: use mmh3 hash
+                hset_keys.append(_mmh3(f"{feature_view.name}:{feature_name}"))
 
         ts_key = f"_ts:{feature_view.name}"
         hset_keys.append(ts_key)
-        requested_features.append(ts_key)
+        requested_features = list(requested_features) + [ts_key]
 
-        return requested_features, hset_keys
+        return requested_features, hset_keys, vector_field_names
 
     def _convert_valkey_values_to_protobuf(
         self,
         valkey_values: List[List[ByteString]],
-        feature_view: str,
+        feature_view: FeatureView,
         requested_features: List[str],
+        vector_field_names: Set[str],
     ):
+        """
+        Convert Valkey values back to protobuf, handling vector fields.
+
+        Args:
+            valkey_values: Raw values from Valkey
+            feature_view: Feature view object (not just name)
+            requested_features: List of feature names
+            vector_field_names: Set of field names that are vectors
+        """
         result: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]] = []
         for values in valkey_values:
             features = self._get_features_for_entity(
-                values, feature_view, requested_features
+                values, feature_view, requested_features, vector_field_names
             )
             result.append(features)
         return result
@@ -619,8 +861,8 @@ class EGValkeyOnlineStore(OnlineStore):
         client = self._get_client(online_store_config)
         feature_view = table
 
-        requested_features, hset_keys = self._generate_hset_keys_for_features(
-            feature_view, requested_features
+        requested_features, hset_keys, vector_field_names = (
+            self._generate_hset_keys_for_features(feature_view, requested_features)
         )
         keys = self._generate_valkey_keys_for_entities(config, entity_keys)
 
@@ -631,7 +873,7 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_values = pipe.execute()
 
         return self._convert_valkey_values_to_protobuf(
-            valkey_values, feature_view.name, requested_features
+            valkey_values, feature_view, requested_features, vector_field_names
         )
 
     async def online_read_async(
@@ -647,8 +889,8 @@ class EGValkeyOnlineStore(OnlineStore):
         client = await self._get_client_async(online_store_config)
         feature_view = table
 
-        requested_features, hset_keys = self._generate_hset_keys_for_features(
-            feature_view, requested_features
+        requested_features, hset_keys, vector_field_names = (
+            self._generate_hset_keys_for_features(feature_view, requested_features)
         )
         keys = self._generate_valkey_keys_for_entities(config, entity_keys)
 
@@ -658,27 +900,47 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_values = await pipe.execute()
 
         return self._convert_valkey_values_to_protobuf(
-            valkey_values, feature_view.name, requested_features
+            valkey_values, feature_view, requested_features, vector_field_names
         )
 
     def _get_features_for_entity(
         self,
         values: List[ByteString],
-        feature_view: str,
+        feature_view: FeatureView,
         requested_features: List[str],
+        vector_field_names: Set[str],
     ) -> Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]:
+        """
+        Parse features for a single entity, handling vector deserialization.
+
+        Args:
+            values: Raw bytes from Valkey
+            feature_view: Feature view object
+            requested_features: List of feature names (includes _ts key)
+            vector_field_names: Set of field names that are vectors
+        """
         res_val = dict(zip(requested_features, values))
 
         res_ts = Timestamp()
-        ts_val = res_val.pop(f"_ts:{feature_view}")
+        ts_val = res_val.pop(f"_ts:{feature_view.name}")
         if ts_val:
             res_ts.ParseFromString(bytes(ts_val))
 
         res = {}
         for feature_name, val_bin in res_val.items():
-            val = ValueProto()
-            if val_bin:
+            if not val_bin:
+                res[feature_name] = ValueProto()
+                continue
+
+            if feature_name in vector_field_names:
+                # Vector field: deserialize from raw bytes
+                field = next(f for f in feature_view.features if f.name == feature_name)
+                val = _deserialize_vector_from_bytes(bytes(val_bin), field)
+            else:
+                # Regular field: parse protobuf
+                val = ValueProto()
                 val.ParseFromString(bytes(val_bin))
+
             res[feature_name] = val
 
         if not res:

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -69,54 +69,57 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
-def _get_vector_index_name(project: str, feature_view_name: str) -> str:
-    """Generate Valkey Search index name for vector fields."""
-    return f"{project}_{feature_view_name}_vidx"
+def _get_vector_index_name(
+    project: str, feature_view_name: str, feature_name: str
+) -> str:
+    """Generate Valkey Search index name for a vector field."""
+    return f"{project}_{feature_view_name}_{feature_name}_vidx"
 
 
 def _get_valkey_vector_type(feast_dtype) -> str:
     """
     Map Feast dtype to Valkey vector TYPE parameter.
 
+    Valkey Search only supports FLOAT32 vectors. Float64 arrays will be
+    converted to float32 during serialization.
+
     Args:
         feast_dtype: Feast data type (e.g., Array(Float32))
 
     Returns:
-        Valkey vector type string: "FLOAT32" or "FLOAT64"
+        Valkey vector type string: always "FLOAT32"
     """
-    if feast_dtype == Array(Float32):
-        return "FLOAT32"
-    elif feast_dtype == Array(Float64):
-        return "FLOAT64"
-    else:
-        # Default to FLOAT32 for other numeric arrays
-        logger.warning(f"Unsupported vector dtype {feast_dtype}, defaulting to FLOAT32")
-        return "FLOAT32"
+    if feast_dtype == Array(Float64):
+        logger.warning(
+            "Valkey Search only supports FLOAT32 vectors. "
+            "Float64 data will be converted to float32 (possible precision loss)."
+        )
+    return "FLOAT32"
 
 
 def _serialize_vector_to_bytes(val: ValueProto, field: Field) -> bytes:
     """
-    Serialize a vector ValueProto to raw bytes for Valkey storage.
+    Serialize a vector ValueProto to raw float32 bytes for Valkey storage.
 
     Vector fields must be stored as raw bytes (not protobuf serialized) to be
-    compatible with Valkey Search FT.SEARCH queries.
+    compatible with Valkey Search FT.SEARCH queries. Valkey only supports
+    FLOAT32, so float64 data is converted to float32.
 
     Args:
         val: The ValueProto containing the vector data
         field: The Field metadata for dtype and dimension information
 
     Returns:
-        Raw bytes in the format expected by Valkey vector search
+        Raw float32 bytes in the format expected by Valkey vector search
 
     Raises:
         ValueError: If vector type is unsupported or dimension mismatches
     """
     if val.HasField("float_list_val"):
-        # Float32 array
         vector = np.array(val.float_list_val.val, dtype=np.float32)
     elif val.HasField("double_list_val"):
-        # Float64 array
-        vector = np.array(val.double_list_val.val, dtype=np.float64)
+        # Convert float64 to float32 (Valkey only supports float32)
+        vector = np.array(val.double_list_val.val, dtype=np.float32)
     else:
         raise ValueError(
             f"Unsupported vector type for field {field.name}. "
@@ -137,20 +140,18 @@ def _deserialize_vector_from_bytes(raw_bytes: bytes, field: Field) -> ValueProto
     """
     Deserialize raw vector bytes back to ValueProto.
 
+    Valkey stores all vectors as float32, so we always deserialize as float32
+    regardless of the original field dtype.
+
     Args:
-        raw_bytes: Raw bytes from Valkey
-        field: Field metadata for dtype information
+        raw_bytes: Raw float32 bytes from Valkey
+        field: Field metadata (unused, kept for API consistency)
 
     Returns:
-        ValueProto with float_list_val or double_list_val
+        ValueProto with float_list_val (always float32)
     """
-    if field.dtype == Array(Float64):
-        vector = np.frombuffer(raw_bytes, dtype=np.float64)
-        return ValueProto(double_list_val=DoubleList(val=vector.tolist()))
-    else:
-        # Default to Float32
-        vector = np.frombuffer(raw_bytes, dtype=np.float32)
-        return ValueProto(float_list_val=FloatList(val=vector.tolist()))
+    vector = np.frombuffer(raw_bytes, dtype=np.float32)
+    return ValueProto(float_list_val=FloatList(val=vector.tolist()))
 
 
 class EGValkeyType(str, Enum):
@@ -252,7 +253,12 @@ class EGValkeyOnlineStore(OnlineStore):
         deleted_count = 0
         prefix = _redis_key_prefix(table.join_keys)
 
-        valkey_hash_keys = [_mmh3(f"{table.name}:{f.name}") for f in table.features]
+        # Build list of hash keys to delete
+        # Vector fields use original name, non-vector fields use mmh3 hash
+        valkey_hash_keys = [
+            f.name.encode("utf8") if f.vector_index else _mmh3(f"{table.name}:{f.name}")
+            for f in table.features
+        ]
         valkey_hash_keys.append(bytes(f"_ts:{table.name}", "utf8"))
 
         with client.pipeline(transaction=False) as pipe:
@@ -274,16 +280,22 @@ class EGValkeyOnlineStore(OnlineStore):
         logger.debug(f"Deleted {deleted_count} rows for feature view {table.name}")
 
         # Drop vector index if it exists
-        self._drop_vector_index_if_exists(client, config.project, table.name)
+        self._drop_vector_index_if_exists(client, config.project, table)
 
     def _drop_vector_index_if_exists(
         self,
         client: Union[Valkey, ValkeyCluster],
         project: str,
-        feature_view_name: str,
+        table: FeatureView,
     ) -> None:
-        """Drop Valkey Search vector index if it exists."""
-        index_name = _get_vector_index_name(project, feature_view_name)
+        """Drop Valkey Search vector index for a feature view if it exists."""
+        vector_fields = [f for f in table.features if f.vector_index]
+        if not vector_fields:
+            return
+
+        # Index is named after the first vector field
+        first_field_name = vector_fields[0].name
+        index_name = _get_vector_index_name(project, table.name, first_field_name)
         try:
             client.ft(index_name).dropindex(delete_documents=False)
             logger.info(f"Dropped vector index {index_name}")
@@ -335,7 +347,7 @@ class EGValkeyOnlineStore(OnlineStore):
 
         # Drop vector indexes for each table
         for table in tables:
-            self._drop_vector_index_if_exists(client, config.project, table.name)
+            self._drop_vector_index_if_exists(client, config.project, table)
 
         # Delete entity values
         join_keys_to_delete = set(tuple(table.join_keys) for table in tables)
@@ -435,6 +447,7 @@ class EGValkeyOnlineStore(OnlineStore):
         Create Valkey Search index for vector fields if not already exists.
 
         Uses FT.CREATE with VECTOR field type and appropriate algorithm parameters.
+        Creates a single index containing all vector fields.
 
         Args:
             client: Valkey client
@@ -445,7 +458,11 @@ class EGValkeyOnlineStore(OnlineStore):
         online_store_config = config.online_store
         assert isinstance(online_store_config, EGValkeyOnlineStoreConfig)
 
-        index_name = _get_vector_index_name(config.project, table.name)
+        # Use first vector field name in index name (Feast currently allows only one)
+        first_field_name = next(iter(vector_fields.keys()))
+        index_name = _get_vector_index_name(
+            config.project, table.name, first_field_name
+        )
 
         # Check if index exists
         try:
@@ -457,7 +474,6 @@ class EGValkeyOnlineStore(OnlineStore):
 
         # Build schema for vector fields
         schema_fields = []
-
         for field_name, field in vector_fields.items():
             # Validate required properties
             if field.vector_length <= 0:
@@ -490,7 +506,6 @@ class EGValkeyOnlineStore(OnlineStore):
             schema_fields.append(VectorField(field_name, algorithm, attributes))
 
         # Define index on HASH keys with specific prefix
-        # TODO: Add __project__ TagField and filter in FT.SEARCH to scope results per project
         key_prefix = _redis_key_prefix(table.join_keys)
         definition = IndexDefinition(
             prefix=[key_prefix],
@@ -504,7 +519,7 @@ class EGValkeyOnlineStore(OnlineStore):
                 definition=definition,
             )
             logger.info(
-                f"Created vector index {index_name} with {len(vector_fields)} vector field(s): {list(vector_fields.keys())}"
+                f"Created vector index {index_name} with field(s): {list(vector_fields.keys())}"
             )
         except ResponseError as e:
             if "already exists" in str(e).lower():

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -27,7 +27,6 @@ from typing import (
     Literal,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Union,
 )
@@ -274,6 +273,27 @@ class EGValkeyOnlineStore(OnlineStore):
 
         logger.debug(f"Deleted {deleted_count} rows for feature view {table.name}")
 
+        # Drop vector index if it exists
+        self._drop_vector_index_if_exists(client, config.project, table.name)
+
+    def _drop_vector_index_if_exists(
+        self,
+        client: Union[Valkey, ValkeyCluster],
+        project: str,
+        feature_view_name: str,
+    ) -> None:
+        """Drop Valkey Search vector index if it exists."""
+        index_name = _get_vector_index_name(project, feature_view_name)
+        try:
+            client.ft(index_name).dropindex(delete_documents=False)
+            logger.info(f"Dropped vector index {index_name}")
+        except ResponseError as e:
+            # Index doesn't exist - this is fine
+            if "unknown index" in str(e).lower():
+                logger.debug(f"Vector index {index_name} does not exist, skipping drop")
+            else:
+                raise
+
     def update(
         self,
         config: RepoConfig,
@@ -311,8 +331,14 @@ class EGValkeyOnlineStore(OnlineStore):
         """
         We delete the keys in valkey for tables/views being removed.
         """
-        join_keys_to_delete = set(tuple(table.join_keys) for table in tables)
+        client = self._get_client(config.online_store)
 
+        # Drop vector indexes for each table
+        for table in tables:
+            self._drop_vector_index_if_exists(client, config.project, table.name)
+
+        # Delete entity values
+        join_keys_to_delete = set(tuple(table.join_keys) for table in tables)
         for join_keys in join_keys_to_delete:
             self.delete_entity_values(config, list(join_keys))
 
@@ -464,6 +490,7 @@ class EGValkeyOnlineStore(OnlineStore):
             schema_fields.append(VectorField(field_name, algorithm, attributes))
 
         # Define index on HASH keys with specific prefix
+        # TODO: Add __project__ TagField and filter in FT.SEARCH to scope results per project
         key_prefix = _redis_key_prefix(table.join_keys)
         definition = IndexDefinition(
             prefix=[key_prefix],
@@ -479,7 +506,12 @@ class EGValkeyOnlineStore(OnlineStore):
             logger.info(
                 f"Created vector index {index_name} with {len(vector_fields)} vector field(s): {list(vector_fields.keys())}"
             )
-        except ValkeyError as e:
+        except ResponseError as e:
+            if "already exists" in str(e).lower():
+                logger.debug(
+                    f"Vector index {index_name} already exists"
+                )
+                return
             logger.error(
                 f"Failed to create vector index {index_name}: {e}. "
                 f"Ensure Valkey Search module is loaded."
@@ -648,7 +680,6 @@ class EGValkeyOnlineStore(OnlineStore):
             else:
                 # Identify vector fields (only for regular FeatureViews, not SortedFeatureView)
                 vector_fields = {f.name: f for f in table.features if f.vector_index}
-                vector_field_names = set(vector_fields.keys())
 
                 # Create vector index if needed (only on first write with vector fields)
                 if vector_fields:
@@ -692,7 +723,7 @@ class EGValkeyOnlineStore(OnlineStore):
                     entity_hset[ts_key] = ts.SerializeToString()
 
                     for feature_name, val in values.items():
-                        if feature_name in vector_field_names:
+                        if feature_name in vector_fields:
                             # Vector field: store with ORIGINAL name and RAW bytes
                             vector_bytes = _serialize_vector_to_bytes(
                                 val, vector_fields[feature_name]
@@ -796,22 +827,21 @@ class EGValkeyOnlineStore(OnlineStore):
         self,
         feature_view: FeatureView,
         requested_features: Optional[List[str]] = None,
-    ) -> Tuple[List[str], List[str], Set[str]]:
+    ) -> Tuple[List[str], List[str], Dict[str, Field]]:
         """
         Generate HSET keys for feature retrieval.
 
         Returns:
-            Tuple of (feature_names, hset_keys, vector_field_names)
+            Tuple of (feature_names, hset_keys, vector_fields dict)
         """
         if not requested_features:
             requested_features = [f.name for f in feature_view.features]
 
-        # Identify vector fields
-        vector_field_names = {f.name for f in feature_view.features if f.vector_index}
+        vector_fields = {f.name: f for f in feature_view.features if f.vector_index}
 
         hset_keys = []
         for feature_name in requested_features:
-            if feature_name in vector_field_names:
+            if feature_name in vector_fields:
                 # Vector field: use original name
                 hset_keys.append(feature_name)
             else:
@@ -822,14 +852,14 @@ class EGValkeyOnlineStore(OnlineStore):
         hset_keys.append(ts_key)
         requested_features = list(requested_features) + [ts_key]
 
-        return requested_features, hset_keys, vector_field_names
+        return requested_features, hset_keys, vector_fields
 
     def _convert_valkey_values_to_protobuf(
         self,
         valkey_values: List[List[ByteString]],
         feature_view: FeatureView,
         requested_features: List[str],
-        vector_field_names: Set[str],
+        vector_fields: Dict[str, Field],
     ):
         """
         Convert Valkey values back to protobuf, handling vector fields.
@@ -838,12 +868,12 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_values: Raw values from Valkey
             feature_view: Feature view object (not just name)
             requested_features: List of feature names
-            vector_field_names: Set of field names that are vectors
+            vector_fields: Dict of field name to Field for vector fields
         """
         result: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]] = []
         for values in valkey_values:
             features = self._get_features_for_entity(
-                values, feature_view, requested_features, vector_field_names
+                values, feature_view, requested_features, vector_fields
             )
             result.append(features)
         return result
@@ -861,7 +891,7 @@ class EGValkeyOnlineStore(OnlineStore):
         client = self._get_client(online_store_config)
         feature_view = table
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             self._generate_hset_keys_for_features(feature_view, requested_features)
         )
         keys = self._generate_valkey_keys_for_entities(config, entity_keys)
@@ -873,7 +903,7 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_values = pipe.execute()
 
         return self._convert_valkey_values_to_protobuf(
-            valkey_values, feature_view, requested_features, vector_field_names
+            valkey_values, feature_view, requested_features, vector_fields
         )
 
     async def online_read_async(
@@ -889,7 +919,7 @@ class EGValkeyOnlineStore(OnlineStore):
         client = await self._get_client_async(online_store_config)
         feature_view = table
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             self._generate_hset_keys_for_features(feature_view, requested_features)
         )
         keys = self._generate_valkey_keys_for_entities(config, entity_keys)
@@ -900,7 +930,7 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_values = await pipe.execute()
 
         return self._convert_valkey_values_to_protobuf(
-            valkey_values, feature_view, requested_features, vector_field_names
+            valkey_values, feature_view, requested_features, vector_fields
         )
 
     def _get_features_for_entity(
@@ -908,7 +938,7 @@ class EGValkeyOnlineStore(OnlineStore):
         values: List[ByteString],
         feature_view: FeatureView,
         requested_features: List[str],
-        vector_field_names: Set[str],
+        vector_fields: Dict[str, Field],
     ) -> Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]:
         """
         Parse features for a single entity, handling vector deserialization.
@@ -917,7 +947,7 @@ class EGValkeyOnlineStore(OnlineStore):
             values: Raw bytes from Valkey
             feature_view: Feature view object
             requested_features: List of feature names (includes _ts key)
-            vector_field_names: Set of field names that are vectors
+            vector_fields: Dict of field name to Field for vector fields (O(1) lookup)
         """
         res_val = dict(zip(requested_features, values))
 
@@ -932,9 +962,9 @@ class EGValkeyOnlineStore(OnlineStore):
                 res[feature_name] = ValueProto()
                 continue
 
-            if feature_name in vector_field_names:
+            if feature_name in vector_fields:
                 # Vector field: deserialize from raw bytes
-                field = next(f for f in feature_view.features if f.name == feature_name)
+                field = vector_fields[feature_name]
                 val = _deserialize_vector_from_bytes(bytes(val_bin), field)
             else:
                 # Regular field: parse protobuf

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -42,16 +42,13 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.helpers import _mmh3, _redis_key, _redis_key_prefix
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import (
-    DoubleList,
-    FloatList,
-)
+from feast.protos.feast.types.Value_pb2 import FloatList
 from feast.protos.feast.types.Value_pb2 import (
     Value as ValueProto,
 )
 from feast.repo_config import FeastConfigBaseModel
 from feast.sorted_feature_view import SortedFeatureView
-from feast.types import Array, Float32, Float64
+from feast.types import Array, Float64
 from feast.value_type import ValueType
 
 try:

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -508,9 +508,7 @@ class EGValkeyOnlineStore(OnlineStore):
             )
         except ResponseError as e:
             if "already exists" in str(e).lower():
-                logger.debug(
-                    f"Vector index {index_name} already exists"
-                )
+                logger.debug(f"Vector index {index_name} already exists")
                 return
             logger.error(
                 f"Failed to create vector index {index_name}: {e}. "

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -288,23 +288,23 @@ class EGValkeyOnlineStore(OnlineStore):
         project: str,
         table: FeatureView,
     ) -> None:
-        """Drop Valkey Search vector index for a feature view if it exists."""
+        """Drop Valkey Search vector indexes for all vector fields in a feature view."""
         vector_fields = [f for f in table.features if f.vector_index]
-        if not vector_fields:
-            return
 
-        # Index is named after the first vector field
-        first_field_name = vector_fields[0].name
-        index_name = _get_vector_index_name(project, table.name, first_field_name)
-        try:
-            client.ft(index_name).dropindex(delete_documents=False)
-            logger.info(f"Dropped vector index {index_name}")
-        except ResponseError as e:
-            # Index doesn't exist - this is fine
-            if "unknown index" in str(e).lower():
-                logger.debug(f"Vector index {index_name} does not exist, skipping drop")
-            else:
-                raise
+        # Drop index for each vector field
+        for field in vector_fields:
+            index_name = _get_vector_index_name(project, table.name, field.name)
+            try:
+                client.ft(index_name).dropindex(delete_documents=False)
+                logger.info(f"Dropped vector index {index_name}")
+            except ResponseError as e:
+                # Index doesn't exist - this is fine
+                if "unknown index" in str(e).lower():
+                    logger.debug(
+                        f"Vector index {index_name} does not exist, skipping drop"
+                    )
+                else:
+                    raise
 
     def update(
         self,
@@ -444,10 +444,10 @@ class EGValkeyOnlineStore(OnlineStore):
         vector_fields: Dict[str, Field],
     ) -> None:
         """
-        Create Valkey Search index for vector fields if not already exists.
+        Create Valkey Search index for each vector field if not already exists.
 
         Uses FT.CREATE with VECTOR field type and appropriate algorithm parameters.
-        Creates a single index containing all vector fields.
+        Creates one index per vector field for future multi-vector support.
 
         Args:
             client: Valkey client
@@ -458,23 +458,25 @@ class EGValkeyOnlineStore(OnlineStore):
         online_store_config = config.online_store
         assert isinstance(online_store_config, EGValkeyOnlineStoreConfig)
 
-        # Use first vector field name in index name (Feast currently allows only one)
-        first_field_name = next(iter(vector_fields.keys()))
-        index_name = _get_vector_index_name(
-            config.project, table.name, first_field_name
+        # Define index on HASH keys with specific prefix (shared across all indexes)
+        key_prefix = _redis_key_prefix(table.join_keys)
+        definition = IndexDefinition(
+            prefix=[key_prefix],
+            index_type=IndexType.HASH,
         )
 
-        # Check if index exists
-        try:
-            client.ft(index_name).info()
-            logger.debug(f"Vector index {index_name} already exists")
-            return
-        except ResponseError:
-            pass  # Index doesn't exist, create it
-
-        # Build schema for vector fields
-        schema_fields = []
+        # Create one index per vector field
         for field_name, field in vector_fields.items():
+            index_name = _get_vector_index_name(config.project, table.name, field_name)
+
+            # Check if index exists
+            try:
+                client.ft(index_name).info()
+                logger.debug(f"Vector index {index_name} already exists")
+                continue
+            except ResponseError:
+                pass  # Index doesn't exist, create it
+
             # Validate required properties
             if field.vector_length <= 0:
                 raise ValueError(
@@ -487,7 +489,7 @@ class EGValkeyOnlineStore(OnlineStore):
 
             # Build algorithm attributes
             attributes = {
-                "TYPE": vector_type,  # "FLOAT32" or "FLOAT64"
+                "TYPE": vector_type,  # Always FLOAT32 (Valkey limitation)
                 "DIM": field.vector_length,
                 "DISTANCE_METRIC": field.vector_search_metric or "COSINE",
             }
@@ -503,33 +505,22 @@ class EGValkeyOnlineStore(OnlineStore):
                     online_store_config.vector_index_hnsw_ef_runtime
                 )
 
-            schema_fields.append(VectorField(field_name, algorithm, attributes))
-
-        # Define index on HASH keys with specific prefix
-        key_prefix = _redis_key_prefix(table.join_keys)
-        definition = IndexDefinition(
-            prefix=[key_prefix],
-            index_type=IndexType.HASH,
-        )
-
-        # Create the index
-        try:
-            client.ft(index_name).create_index(
-                fields=schema_fields,
-                definition=definition,
-            )
-            logger.info(
-                f"Created vector index {index_name} with field(s): {list(vector_fields.keys())}"
-            )
-        except ResponseError as e:
-            if "already exists" in str(e).lower():
-                logger.debug(f"Vector index {index_name} already exists")
-                return
-            logger.error(
-                f"Failed to create vector index {index_name}: {e}. "
-                f"Ensure Valkey Search module is loaded."
-            )
-            raise
+            # Create the index with single vector field
+            try:
+                client.ft(index_name).create_index(
+                    fields=[VectorField(field_name, algorithm, attributes)],
+                    definition=definition,
+                )
+                logger.info(f"Created vector index {index_name} for field {field_name}")
+            except ResponseError as e:
+                if "already exists" in str(e).lower():
+                    logger.debug(f"Vector index {index_name} already exists")
+                    continue
+                logger.error(
+                    f"Failed to create vector index {index_name}: {e}. "
+                    f"Ensure Valkey Search module is loaded."
+                )
+                raise
 
     def online_write_batch(
         self,

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -477,15 +477,15 @@ class TestVectorIndexName:
     def test_get_vector_index_name(self):
         """Test index name generation follows expected format."""
         assert (
-            _get_vector_index_name("my_project", "item_embeddings")
-            == "my_project_item_embeddings_vidx"
+            _get_vector_index_name("my_project", "item_embeddings", "embedding")
+            == "my_project_item_embeddings_embedding_vidx"
         )
 
     def test_get_vector_index_name_with_special_chars(self):
         """Test index name with underscores in names."""
         assert (
-            _get_vector_index_name("prod_project", "user_item_embeddings")
-            == "prod_project_user_item_embeddings_vidx"
+            _get_vector_index_name("prod_project", "user_item_embeddings", "vec_field")
+            == "prod_project_user_item_embeddings_vec_field_vidx"
         )
 
 
@@ -496,12 +496,12 @@ class TestGetValkeyVectorType:
         """Test Float32 array maps to FLOAT32."""
         assert _get_valkey_vector_type(Array(Float32)) == "FLOAT32"
 
-    def test_get_valkey_vector_type_float64(self):
-        """Test Float64 array maps to FLOAT64."""
-        assert _get_valkey_vector_type(Array(Float64)) == "FLOAT64"
+    def test_get_valkey_vector_type_float64_converts_to_float32(self):
+        """Test Float64 array also maps to FLOAT32 (Valkey only supports float32)."""
+        assert _get_valkey_vector_type(Array(Float64)) == "FLOAT32"
 
     def test_get_valkey_vector_type_unsupported_defaults_to_float32(self):
-        """Test unsupported types default to FLOAT32 with warning."""
+        """Test unsupported types default to FLOAT32."""
         # Int32 array is not a valid vector type, should default to FLOAT32
         assert _get_valkey_vector_type(Array(Int32)) == "FLOAT32"
 
@@ -524,8 +524,8 @@ class TestSerializeVectorToBytes:
         expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32).tobytes()
         assert result == expected
 
-    def test_serialize_vector_float64(self):
-        """Test Float64 vector serialization to raw bytes."""
+    def test_serialize_vector_float64_converts_to_float32(self):
+        """Test Float64 vector is converted to float32 bytes (Valkey limitation)."""
         val = ValueProto(double_list_val=DoubleList(val=[0.1, 0.2, 0.3, 0.4]))
         field = Field(
             name="embedding",
@@ -536,7 +536,8 @@ class TestSerializeVectorToBytes:
 
         result = _serialize_vector_to_bytes(val, field)
 
-        expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64).tobytes()
+        # Should be float32 bytes, not float64
+        expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32).tobytes()
         assert result == expected
 
     def test_serialize_vector_dimension_mismatch(self):
@@ -601,10 +602,11 @@ class TestDeserializeVectorFromBytes:
             result.float_list_val.val, original, decimal=5
         )
 
-    def test_deserialize_vector_float64(self):
-        """Test Float64 vector deserialization from raw bytes."""
-        original = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64)
+    def test_deserialize_always_returns_float32(self):
+        """Test deserialization always returns float32 (Valkey only supports float32)."""
+        original = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
         raw_bytes = original.tobytes()
+        # Even with Float64 field dtype, result should be float32
         field = Field(
             name="embedding",
             dtype=Array(Float64),
@@ -614,9 +616,10 @@ class TestDeserializeVectorFromBytes:
 
         result = _deserialize_vector_from_bytes(raw_bytes, field)
 
-        assert result.HasField("double_list_val")
+        # Should always return float_list_val regardless of field dtype
+        assert result.HasField("float_list_val")
         np.testing.assert_array_almost_equal(
-            result.double_list_val.val, original, decimal=10
+            result.float_list_val.val, original, decimal=5
         )
 
     def test_roundtrip_float32(self):
@@ -637,8 +640,8 @@ class TestDeserializeVectorFromBytes:
             result.float_list_val.val, original_values, decimal=5
         )
 
-    def test_roundtrip_float64(self):
-        """Test serialize then deserialize preserves Float64 vector values."""
+    def test_roundtrip_float64_converts_to_float32(self):
+        """Test Float64 input is converted to float32 during roundtrip."""
         original_values = [0.123456789, 0.987654321, 0.111111111, 0.999999999]
         val = ValueProto(double_list_val=DoubleList(val=original_values))
         field = Field(
@@ -651,8 +654,10 @@ class TestDeserializeVectorFromBytes:
         raw_bytes = _serialize_vector_to_bytes(val, field)
         result = _deserialize_vector_from_bytes(raw_bytes, field)
 
+        # Result is float32, so we get float_list_val with reduced precision
+        assert result.HasField("float_list_val")
         np.testing.assert_array_almost_equal(
-            result.double_list_val.val, original_values, decimal=10
+            result.float_list_val.val, original_values, decimal=5
         )
 
 

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -734,7 +734,7 @@ class TestGenerateHsetKeysForFeatures:
         """Test that vector fields use original name as hset key."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_with_vector, requested_features=["embedding"]
             )
@@ -742,13 +742,13 @@ class TestGenerateHsetKeysForFeatures:
 
         # Vector field should use original name
         assert "embedding" in hset_keys
-        assert "embedding" in vector_field_names
+        assert "embedding" in vector_fields
 
     def test_non_vector_field_uses_mmh3_hash(self, feature_view_with_vector):
         """Test that non-vector fields use mmh3 hash as hset key."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_with_vector, requested_features=["scalar_feature"]
             )
@@ -757,13 +757,13 @@ class TestGenerateHsetKeysForFeatures:
         # Non-vector field should use mmh3 hash
         expected_hash = _mmh3(f"{feature_view_with_vector.name}:scalar_feature")
         assert expected_hash in hset_keys
-        assert "scalar_feature" not in vector_field_names
+        assert "scalar_feature" not in vector_fields
 
     def test_timestamp_key_appended(self, feature_view_with_vector):
         """Test that timestamp key is always appended to hset keys."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_with_vector, requested_features=["embedding"]
             )
@@ -777,7 +777,7 @@ class TestGenerateHsetKeysForFeatures:
         """Test that mixed vector and non-vector fields get correct keys."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_with_vector,
                 requested_features=["embedding", "scalar_feature", "string_feature"],
@@ -793,14 +793,14 @@ class TestGenerateHsetKeysForFeatures:
         assert scalar_hash in hset_keys
         assert string_hash in hset_keys
 
-        # Only embedding should be in vector_field_names
-        assert vector_field_names == {"embedding"}
+        # Only embedding should be in vector_fields (now a dict)
+        assert set(vector_fields.keys()) == {"embedding"}
 
     def test_no_requested_features_uses_all(self, feature_view_with_vector):
         """Test that None requested_features returns all feature view features."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_with_vector, requested_features=None
             )
@@ -811,18 +811,18 @@ class TestGenerateHsetKeysForFeatures:
         assert len(requested_features) == 4  # 3 features + timestamp key
 
     def test_feature_view_without_vectors(self, feature_view_no_vector):
-        """Test feature view with no vector fields returns empty vector_field_names."""
+        """Test feature view with no vector fields returns empty vector_fields dict."""
         store = EGValkeyOnlineStore()
 
-        requested_features, hset_keys, vector_field_names = (
+        requested_features, hset_keys, vector_fields = (
             store._generate_hset_keys_for_features(
                 feature_view_no_vector,
                 requested_features=["scalar_feature", "string_feature"],
             )
         )
 
-        # No vector fields
-        assert vector_field_names == set()
+        # No vector fields (empty dict)
+        assert vector_fields == {}
 
         # All fields should use mmh3 hash
         for key in hset_keys:

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -1,22 +1,36 @@
 import time
 from datetime import datetime, timedelta, timezone
 
+import numpy as np
 import pytest
 from valkey import Valkey
 
-from feast import Entity, Field, FileSource, RepoConfig, ValueType
+from feast import Entity, FeatureView, Field, FileSource, RepoConfig, ValueType
 from feast.infra.online_stores.eg_valkey import (
     EGValkeyOnlineStore,
     EGValkeyOnlineStoreConfig,
+    _deserialize_vector_from_bytes,
+    _get_valkey_vector_type,
+    _get_vector_index_name,
+    _serialize_vector_to_bytes,
 )
 from feast.infra.online_stores.helpers import _mmh3, _redis_key
 from feast.protos.feast.core.SortedFeatureView_pb2 import SortOrder
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.protos.feast.types.Value_pb2 import (
+    DoubleList,
+    FloatList,
+)
+from feast.protos.feast.types.Value_pb2 import (
+    Value as ValueProto,
+)
 from feast.sorted_feature_view import SortedFeatureView, SortKey
 from feast.types import (
+    Array,
     Float32,
+    Float64,
     Int32,
+    Int64,
     String,
     UnixTimestamp,
 )
@@ -455,3 +469,790 @@ def test_ttl_cleanup_no_expired_members(repo_config):
 
     remaining = redis_client.zrange(zset_key, 0, -1)
     assert active_member in remaining
+
+
+class TestVectorIndexName:
+    """Tests for _get_vector_index_name helper function."""
+
+    def test_get_vector_index_name(self):
+        """Test index name generation follows expected format."""
+        assert (
+            _get_vector_index_name("my_project", "item_embeddings")
+            == "my_project_item_embeddings_vidx"
+        )
+
+    def test_get_vector_index_name_with_special_chars(self):
+        """Test index name with underscores in names."""
+        assert (
+            _get_vector_index_name("prod_project", "user_item_embeddings")
+            == "prod_project_user_item_embeddings_vidx"
+        )
+
+
+class TestGetValkeyVectorType:
+    """Tests for _get_valkey_vector_type helper function."""
+
+    def test_get_valkey_vector_type_float32(self):
+        """Test Float32 array maps to FLOAT32."""
+        assert _get_valkey_vector_type(Array(Float32)) == "FLOAT32"
+
+    def test_get_valkey_vector_type_float64(self):
+        """Test Float64 array maps to FLOAT64."""
+        assert _get_valkey_vector_type(Array(Float64)) == "FLOAT64"
+
+    def test_get_valkey_vector_type_unsupported_defaults_to_float32(self):
+        """Test unsupported types default to FLOAT32 with warning."""
+        # Int32 array is not a valid vector type, should default to FLOAT32
+        assert _get_valkey_vector_type(Array(Int32)) == "FLOAT32"
+
+
+class TestSerializeVectorToBytes:
+    """Tests for _serialize_vector_to_bytes helper function."""
+
+    def test_serialize_vector_float32(self):
+        """Test Float32 vector serialization to raw bytes."""
+        val = ValueProto(float_list_val=FloatList(val=[0.1, 0.2, 0.3, 0.4]))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        result = _serialize_vector_to_bytes(val, field)
+
+        expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32).tobytes()
+        assert result == expected
+
+    def test_serialize_vector_float64(self):
+        """Test Float64 vector serialization to raw bytes."""
+        val = ValueProto(double_list_val=DoubleList(val=[0.1, 0.2, 0.3, 0.4]))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float64),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        result = _serialize_vector_to_bytes(val, field)
+
+        expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64).tobytes()
+        assert result == expected
+
+    def test_serialize_vector_dimension_mismatch(self):
+        """Test error when vector dimension doesn't match expected length."""
+        val = ValueProto(float_list_val=FloatList(val=[0.1, 0.2, 0.3]))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=128,  # Expected 128, but vector has 3 elements
+        )
+
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            _serialize_vector_to_bytes(val, field)
+
+    def test_serialize_vector_unsupported_type(self):
+        """Test error when vector type is not float_list or double_list."""
+        val = ValueProto(int32_val=123)  # Not a list type
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        with pytest.raises(ValueError, match="Unsupported vector type"):
+            _serialize_vector_to_bytes(val, field)
+
+    def test_serialize_vector_no_length_validation_when_zero(self):
+        """Test that vector_length=0 skips dimension validation."""
+        val = ValueProto(float_list_val=FloatList(val=[0.1, 0.2, 0.3]))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=0,  # No validation
+        )
+
+        # Should not raise
+        result = _serialize_vector_to_bytes(val, field)
+        assert len(result) == 3 * 4  # 3 floats * 4 bytes each
+
+
+class TestDeserializeVectorFromBytes:
+    """Tests for _deserialize_vector_from_bytes helper function."""
+
+    def test_deserialize_vector_float32(self):
+        """Test Float32 vector deserialization from raw bytes."""
+        original = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        raw_bytes = original.tobytes()
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        result = _deserialize_vector_from_bytes(raw_bytes, field)
+
+        assert result.HasField("float_list_val")
+        np.testing.assert_array_almost_equal(
+            result.float_list_val.val, original, decimal=5
+        )
+
+    def test_deserialize_vector_float64(self):
+        """Test Float64 vector deserialization from raw bytes."""
+        original = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64)
+        raw_bytes = original.tobytes()
+        field = Field(
+            name="embedding",
+            dtype=Array(Float64),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        result = _deserialize_vector_from_bytes(raw_bytes, field)
+
+        assert result.HasField("double_list_val")
+        np.testing.assert_array_almost_equal(
+            result.double_list_val.val, original, decimal=10
+        )
+
+    def test_roundtrip_float32(self):
+        """Test serialize then deserialize preserves Float32 vector values."""
+        original_values = [0.123, 0.456, 0.789, 1.0]
+        val = ValueProto(float_list_val=FloatList(val=original_values))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        raw_bytes = _serialize_vector_to_bytes(val, field)
+        result = _deserialize_vector_from_bytes(raw_bytes, field)
+
+        np.testing.assert_array_almost_equal(
+            result.float_list_val.val, original_values, decimal=5
+        )
+
+    def test_roundtrip_float64(self):
+        """Test serialize then deserialize preserves Float64 vector values."""
+        original_values = [0.123456789, 0.987654321, 0.111111111, 0.999999999]
+        val = ValueProto(double_list_val=DoubleList(val=original_values))
+        field = Field(
+            name="embedding",
+            dtype=Array(Float64),
+            vector_index=True,
+            vector_length=4,
+        )
+
+        raw_bytes = _serialize_vector_to_bytes(val, field)
+        result = _deserialize_vector_from_bytes(raw_bytes, field)
+
+        np.testing.assert_array_almost_equal(
+            result.double_list_val.val, original_values, decimal=10
+        )
+
+
+class TestVectorConfigOptions:
+    """Tests for vector-related configuration options."""
+
+    def test_default_vector_config_values(self):
+        """Test that vector config has sensible defaults."""
+        config = EGValkeyOnlineStoreConfig()
+
+        assert config.vector_index_algorithm == "HNSW"
+        assert config.vector_index_hnsw_m == 16
+        assert config.vector_index_hnsw_ef_construction == 200
+        assert config.vector_index_hnsw_ef_runtime == 10
+
+    def test_vector_config_custom_values(self):
+        """Test that vector config can be customized."""
+        config = EGValkeyOnlineStoreConfig(
+            vector_index_algorithm="FLAT",
+            vector_index_hnsw_m=32,
+            vector_index_hnsw_ef_construction=400,
+            vector_index_hnsw_ef_runtime=20,
+        )
+
+        assert config.vector_index_algorithm == "FLAT"
+        assert config.vector_index_hnsw_m == 32
+        assert config.vector_index_hnsw_ef_construction == 400
+        assert config.vector_index_hnsw_ef_runtime == 20
+
+
+class TestGenerateHsetKeysForFeatures:
+    """Tests for _generate_hset_keys_for_features helper method."""
+
+    @pytest.fixture
+    def feature_view_with_vector(self):
+        """Create a FeatureView with mixed vector and non-vector fields."""
+        return FeatureView(
+            name="test_fv",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="entity_id")],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="entity_id", dtype=Int64),
+                Field(name="scalar_feature", dtype=Float32),
+                Field(name="string_feature", dtype=String),
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=4,
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def feature_view_no_vector(self):
+        """Create a FeatureView with only non-vector fields."""
+        return FeatureView(
+            name="test_fv_no_vec",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="entity_id")],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="entity_id", dtype=Int64),
+                Field(name="scalar_feature", dtype=Float32),
+                Field(name="string_feature", dtype=String),
+            ],
+        )
+
+    def test_vector_field_uses_original_name(self, feature_view_with_vector):
+        """Test that vector fields use original name as hset key."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_with_vector, requested_features=["embedding"]
+            )
+        )
+
+        # Vector field should use original name
+        assert "embedding" in hset_keys
+        assert "embedding" in vector_field_names
+
+    def test_non_vector_field_uses_mmh3_hash(self, feature_view_with_vector):
+        """Test that non-vector fields use mmh3 hash as hset key."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_with_vector, requested_features=["scalar_feature"]
+            )
+        )
+
+        # Non-vector field should use mmh3 hash
+        expected_hash = _mmh3(f"{feature_view_with_vector.name}:scalar_feature")
+        assert expected_hash in hset_keys
+        assert "scalar_feature" not in vector_field_names
+
+    def test_timestamp_key_appended(self, feature_view_with_vector):
+        """Test that timestamp key is always appended to hset keys."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_with_vector, requested_features=["embedding"]
+            )
+        )
+
+        ts_key = f"_ts:{feature_view_with_vector.name}"
+        assert ts_key in hset_keys
+        assert ts_key in requested_features
+
+    def test_mixed_fields_correct_keys(self, feature_view_with_vector):
+        """Test that mixed vector and non-vector fields get correct keys."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_with_vector,
+                requested_features=["embedding", "scalar_feature", "string_feature"],
+            )
+        )
+
+        # Vector field uses original name
+        assert "embedding" in hset_keys
+
+        # Non-vector fields use mmh3 hash
+        scalar_hash = _mmh3(f"{feature_view_with_vector.name}:scalar_feature")
+        string_hash = _mmh3(f"{feature_view_with_vector.name}:string_feature")
+        assert scalar_hash in hset_keys
+        assert string_hash in hset_keys
+
+        # Only embedding should be in vector_field_names
+        assert vector_field_names == {"embedding"}
+
+    def test_no_requested_features_uses_all(self, feature_view_with_vector):
+        """Test that None requested_features returns all feature view features."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_with_vector, requested_features=None
+            )
+        )
+
+        # Should include all features from the feature view
+        # Features are: scalar_feature, string_feature, embedding (excluding entity_id which is join key)
+        assert len(requested_features) == 4  # 3 features + timestamp key
+
+    def test_feature_view_without_vectors(self, feature_view_no_vector):
+        """Test feature view with no vector fields returns empty vector_field_names."""
+        store = EGValkeyOnlineStore()
+
+        requested_features, hset_keys, vector_field_names = (
+            store._generate_hset_keys_for_features(
+                feature_view_no_vector,
+                requested_features=["scalar_feature", "string_feature"],
+            )
+        )
+
+        # No vector fields
+        assert vector_field_names == set()
+
+        # All fields should use mmh3 hash
+        for key in hset_keys:
+            if not isinstance(key, str) or not key.startswith("_ts:"):
+                assert isinstance(key, bytes)  # mmh3 returns bytes
+
+
+class TestVectorFieldValidation:
+    """Tests for vector field validation during index creation."""
+
+    def test_vector_field_missing_vector_length_raises_error(
+        self, valkey_online_store, repo_config_without_docker_connection_string
+    ):
+        """Test that vector field without vector_length raises ValueError."""
+        from unittest.mock import MagicMock
+
+        from valkey.exceptions import ResponseError
+
+        # Create a FeatureView with vector field but no vector_length
+        fv = FeatureView(
+            name="test_missing_length",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="item_id")],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="item_id", dtype=Int64),
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    # vector_length intentionally not set (defaults to 0)
+                ),
+            ],
+        )
+
+        # Get vector fields
+        vector_fields = {f.name: f for f in fv.features if f.vector_index}
+
+        # Mock client to avoid actual connection
+        mock_client = MagicMock()
+        # Simulate index doesn't exist (ResponseError is raised by valkey-py)
+        mock_client.ft.return_value.info.side_effect = ResponseError("Unknown index")
+
+        with pytest.raises(ValueError, match="vector_length"):
+            valkey_online_store._create_vector_index_if_not_exists(
+                mock_client,
+                repo_config_without_docker_connection_string,
+                fv,
+                vector_fields,
+            )
+
+    def test_vector_field_with_negative_vector_length_raises_error(
+        self, valkey_online_store, repo_config_without_docker_connection_string
+    ):
+        """Test that vector field with negative vector_length raises ValueError."""
+        from unittest.mock import MagicMock
+
+        from valkey.exceptions import ResponseError
+
+        # Create a FeatureView with vector field with negative vector_length
+        fv = FeatureView(
+            name="test_negative_length",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="item_id")],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="item_id", dtype=Int64),
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=-1,
+                ),
+            ],
+        )
+
+        vector_fields = {f.name: f for f in fv.features if f.vector_index}
+
+        mock_client = MagicMock()
+        mock_client.ft.return_value.info.side_effect = ResponseError("Unknown index")
+
+        with pytest.raises(ValueError, match="vector_length"):
+            valkey_online_store._create_vector_index_if_not_exists(
+                mock_client,
+                repo_config_without_docker_connection_string,
+                fv,
+                vector_fields,
+            )
+
+
+# ============================================================================
+# Vector Support Integration Tests (Docker Required)
+# ============================================================================
+
+
+def _create_feature_view_with_vector_field():
+    """Create a FeatureView with a vector embedding field."""
+    fv = FeatureView(
+        name="item_embeddings",
+        source=FileSource(
+            name="item_source",
+            path="test.parquet",
+            timestamp_field="event_timestamp",
+        ),
+        entities=[Entity(name="item_id")],
+        ttl=timedelta(days=1),
+        schema=[
+            Field(name="item_id", dtype=Int64),
+            Field(name="item_name", dtype=String),
+            Field(
+                name="embedding",
+                dtype=Array(Float32),
+                vector_index=True,
+                vector_length=4,
+                vector_search_metric="COSINE",
+            ),
+        ],
+    )
+    return fv
+
+
+def _make_vector_rows():
+    """Generate rows with vector embeddings."""
+    now = datetime.now(tz=timezone.utc)
+    return [
+        (
+            EntityKeyProto(
+                join_keys=["item_id"],
+                entity_values=[ValueProto(int64_val=1)],
+            ),
+            {
+                "item_name": ValueProto(string_val="item_1"),
+                "embedding": ValueProto(
+                    float_list_val=FloatList(val=[0.1, 0.2, 0.3, 0.4])
+                ),
+            },
+            now,
+            None,
+        ),
+        (
+            EntityKeyProto(
+                join_keys=["item_id"],
+                entity_values=[ValueProto(int64_val=2)],
+            ),
+            {
+                "item_name": ValueProto(string_val="item_2"),
+                "embedding": ValueProto(
+                    float_list_val=FloatList(val=[0.5, 0.6, 0.7, 0.8])
+                ),
+            },
+            now,
+            None,
+        ),
+    ]
+
+
+@pytest.mark.docker
+def test_valkey_online_write_batch_with_vector_field(
+    repo_config: RepoConfig,
+    valkey_online_store: EGValkeyOnlineStore,
+):
+    """Test writing a FeatureView with vector field stores data correctly."""
+    feature_view = _create_feature_view_with_vector_field()
+    data = _make_vector_rows()
+
+    # Write data - note: index creation will fail without Search module,
+    # but the write itself should work for storage verification
+    try:
+        valkey_online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+    except Exception as e:
+        # If Search module is not available, index creation will fail
+        # This is expected with basic Valkey container
+        if "Search" in str(e) or "unknown command" in str(e).lower():
+            pytest.skip("Valkey Search module not available in test container")
+        raise
+
+    # Verify data was stored
+    redis_client = _make_redis_client(repo_config)
+
+    entity_key = EntityKeyProto(
+        join_keys=["item_id"],
+        entity_values=[ValueProto(int64_val=1)],
+    )
+    valkey_key_bin = _redis_key(
+        repo_config.project,
+        entity_key,
+        entity_key_serialization_version=repo_config.entity_key_serialization_version,
+    )
+
+    stored_data = redis_client.hgetall(valkey_key_bin)
+
+    # Verify vector field is stored with original name (not hashed)
+    assert b"embedding" in stored_data
+
+    # Verify non-vector field is stored with mmh3 hash
+    item_name_key = _mmh3(f"{feature_view.name}:item_name")
+    assert item_name_key in stored_data
+
+    # Verify vector bytes can be deserialized
+    embedding_bytes = stored_data[b"embedding"]
+    vector = np.frombuffer(embedding_bytes, dtype=np.float32)
+    np.testing.assert_array_almost_equal(vector, [0.1, 0.2, 0.3, 0.4], decimal=5)
+
+
+@pytest.mark.docker
+def test_valkey_online_read_with_vector_field(
+    repo_config: RepoConfig,
+    valkey_online_store: EGValkeyOnlineStore,
+):
+    """Test reading a FeatureView with vector field deserializes correctly."""
+    feature_view = _create_feature_view_with_vector_field()
+    data = _make_vector_rows()
+
+    # Write data first
+    try:
+        valkey_online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+    except Exception as e:
+        if "Search" in str(e) or "unknown command" in str(e).lower():
+            pytest.skip("Valkey Search module not available in test container")
+        raise
+
+    # Read data back
+    entity_keys = [
+        EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=1)],
+        ),
+        EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=2)],
+        ),
+    ]
+
+    results = valkey_online_store.online_read(
+        config=repo_config,
+        table=feature_view,
+        entity_keys=entity_keys,
+    )
+
+    # Verify results
+    assert len(results) == 2
+
+    # Check first entity
+    ts1, features1 = results[0]
+    assert ts1 is not None
+    assert "embedding" in features1
+    assert "item_name" in features1
+
+    # Verify vector values
+    embedding1 = features1["embedding"]
+    assert embedding1.HasField("float_list_val")
+    np.testing.assert_array_almost_equal(
+        embedding1.float_list_val.val, [0.1, 0.2, 0.3, 0.4], decimal=5
+    )
+
+    # Check second entity
+    ts2, features2 = results[1]
+    embedding2 = features2["embedding"]
+    np.testing.assert_array_almost_equal(
+        embedding2.float_list_val.val, [0.5, 0.6, 0.7, 0.8], decimal=5
+    )
+
+
+@pytest.mark.docker
+def test_valkey_online_read_with_requested_features_vector_only(
+    repo_config: RepoConfig,
+    valkey_online_store: EGValkeyOnlineStore,
+):
+    """Test reading only the vector field using requested_features parameter."""
+    feature_view = _create_feature_view_with_vector_field()
+    data = _make_vector_rows()
+
+    # Write data first
+    try:
+        valkey_online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+    except Exception as e:
+        if "Search" in str(e) or "unknown command" in str(e).lower():
+            pytest.skip("Valkey Search module not available in test container")
+        raise
+
+    entity_keys = [
+        EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=1)],
+        ),
+    ]
+
+    # Request only the vector field
+    results = valkey_online_store.online_read(
+        config=repo_config,
+        table=feature_view,
+        entity_keys=entity_keys,
+        requested_features=["embedding"],
+    )
+
+    assert len(results) == 1
+    ts, features = results[0]
+
+    # Should only have the embedding feature
+    assert "embedding" in features
+    assert "item_name" not in features
+
+    # Verify vector values
+    embedding = features["embedding"]
+    assert embedding.HasField("float_list_val")
+    np.testing.assert_array_almost_equal(
+        embedding.float_list_val.val, [0.1, 0.2, 0.3, 0.4], decimal=5
+    )
+
+
+@pytest.mark.docker
+def test_valkey_online_read_with_requested_features_non_vector_only(
+    repo_config: RepoConfig,
+    valkey_online_store: EGValkeyOnlineStore,
+):
+    """Test reading only non-vector fields using requested_features parameter."""
+    feature_view = _create_feature_view_with_vector_field()
+    data = _make_vector_rows()
+
+    # Write data first
+    try:
+        valkey_online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+    except Exception as e:
+        if "Search" in str(e) or "unknown command" in str(e).lower():
+            pytest.skip("Valkey Search module not available in test container")
+        raise
+
+    entity_keys = [
+        EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=1)],
+        ),
+    ]
+
+    # Request only the non-vector field
+    results = valkey_online_store.online_read(
+        config=repo_config,
+        table=feature_view,
+        entity_keys=entity_keys,
+        requested_features=["item_name"],
+    )
+
+    assert len(results) == 1
+    ts, features = results[0]
+
+    # Should only have the item_name feature
+    assert "item_name" in features
+    assert "embedding" not in features
+
+    # Verify string value
+    assert features["item_name"].string_val == "item_1"
+
+
+@pytest.mark.docker
+def test_valkey_online_read_with_requested_features_mixed(
+    repo_config: RepoConfig,
+    valkey_online_store: EGValkeyOnlineStore,
+):
+    """Test reading a mix of vector and non-vector fields using requested_features."""
+    feature_view = _create_feature_view_with_vector_field()
+    data = _make_vector_rows()
+
+    # Write data first
+    try:
+        valkey_online_store.online_write_batch(
+            config=repo_config,
+            table=feature_view,
+            data=data,
+            progress=None,
+        )
+    except Exception as e:
+        if "Search" in str(e) or "unknown command" in str(e).lower():
+            pytest.skip("Valkey Search module not available in test container")
+        raise
+
+    entity_keys = [
+        EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=2)],
+        ),
+    ]
+
+    # Request both vector and non-vector fields
+    results = valkey_online_store.online_read(
+        config=repo_config,
+        table=feature_view,
+        entity_keys=entity_keys,
+        requested_features=["embedding", "item_name"],
+    )
+
+    assert len(results) == 1
+    ts, features = results[0]
+
+    # Should have both features
+    assert "embedding" in features
+    assert "item_name" in features
+
+    # Verify vector values
+    embedding = features["embedding"]
+    np.testing.assert_array_almost_equal(
+        embedding.float_list_val.val, [0.5, 0.6, 0.7, 0.8], decimal=5
+    )
+
+    # Verify string value
+    assert features["item_name"].string_val == "item_2"


### PR DESCRIPTION
 # What this PR does / why we need it:                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                     Adds vector embedding storage and indexing support to the Valkey online store, enabling vector similarity search capabilities in Feast (Phase 1 - Write Support).                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  Changes                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  Implementation (eg_valkey.py):                                                                                                                                                                                                                                                                                                                                                                                                     
  - Add vector field detection via field.vector_index property
  - Store vector fields with original field names + raw numpy bytes (required for Valkey Search FT.SEARCH)
  - Store non-vector fields with mmh3 hash + protobuf (existing behavior preserved)                       
  - Automatic vector index creation (FT.CREATE) on first write when vector fields are present                                                                                                                                                                                                                                                                                                                                        
  - Support for FLAT and HNSW index algorithms with configurable parameters                                                                                                                                                                                                                                                                                                                                                          
  - Support for Float32 and Float64 vector types                                                                                                                                                                                                                                                                                                                                                                                     
  - Vector dimension validation against field.vector_length                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  Configuration (EGValkeyOnlineStoreConfig):                                                                                                                                                                                                                                                                                                                                                                                         
  - vector_index_algorithm: FLAT or HNSW (default: HNSW)
  - vector_index_hnsw_m: Max outgoing edges per node (default: 16)
  - vector_index_hnsw_ef_construction: Index build quality (default: 200)
  - vector_index_hnsw_ef_runtime: Search quality (default: 10)

  Design Decisions
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - Vector support for regular FeatureViews only (not SortedFeatureView, consistent with Milvus/ES)                                                                                                                                                                                                                                                                                                                                  
  - Single vector per FeatureView (matches current Feast API constraint)
  - Backward compatible: non-vector feature views work unchanged    