### PR TITLE
fix: Cast port to int in ClusterNode connection string parsing

### DIFF
--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -217,9 +217,11 @@ class EGValkeyOnlineStore(OnlineStore):
             valkey_master:6379,db=0,ssl=true,password=...
         """
         startup_nodes = [
-            dict(zip(["host", "port"], c.split(":")))
+            {"host": parts[0], "port": int(parts[1])}
             for c in connection_string.split(",")
             if "=" not in c
+            for parts in [c.split(":")]
+            if len(parts) == 2
         ]
         params = {}
         for c in connection_string.split(","):

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -216,6 +216,9 @@ class EGValkeyOnlineStore(OnlineStore):
         for Valkey Standalone:
             valkey_master:6379,db=0,ssl=true,password=...
         """
+        # Strip scheme prefix (e.g. valkey://, valkeys://) if present
+        if "://" in connection_string:
+            connection_string = connection_string.split("://", 1)[1]
         startup_nodes = [
             {"host": parts[0], "port": int(parts[1])}
             for c in connection_string.split(",")

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -209,9 +209,11 @@ class RedisOnlineStore(OnlineStore):
             redis_master:6379,db=0,ssl=true,password=...
         """
         startup_nodes = [
-            dict(zip(["host", "port"], c.split(":")))
+            {"host": parts[0], "port": int(parts[1])}
             for c in connection_string.split(",")
             if "=" not in c
+            for parts in [c.split(":")]
+            if len(parts) == 2
         ]
         params = {}
         for c in connection_string.split(","):

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -208,6 +208,9 @@ class RedisOnlineStore(OnlineStore):
         for Redis:
             redis_master:6379,db=0,ssl=true,password=...
         """
+        # Strip scheme prefix (e.g. redis://, rediss://) if present
+        if "://" in connection_string:
+            connection_string = connection_string.split("://", 1)[1]
         startup_nodes = [
             {"host": parts[0], "port": int(parts[1])}
             for c in connection_string.split(",")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Fix _parse_connection_string in both redis.py and eg_valkey.py to cast the port to int and guard against malformed entries.                                                     The ClusterNode constructor requires port as an integer, but the parser was passing it as a string via dict(zip(...)), causing `TypeError: ClusterNode.__init__() missing 1 required positional argument: 'port'`

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
