### PR TITLE
fix: Valkey vector search - remove unsupported SORTBY

### DIFF
--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -1153,10 +1153,7 @@ class EGValkeyOnlineStore(OnlineStore):
         # No explicit SORTBY is needed — Valkey Search does not support SORTBY
         # with KNN queries.
         query = (
-            Query(query_str)
-            .return_fields("__distance__")
-            .paging(0, top_k)
-            .dialect(2)
+            Query(query_str).return_fields("__distance__").paging(0, top_k).dialect(2)
         )
 
         try:

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -1138,26 +1138,23 @@ class EGValkeyOnlineStore(OnlineStore):
         Returns:
             List of (doc_key, distance) tuples
         """
-        # Escape double quotes in project name for DIALECT 2 quoted tag syntax
-        # This handles special characters like hyphens which would otherwise
-        # be interpreted as operators (e.g., "my-project" -> "my NOT project")
-        escaped_project = project.replace('"', '\\"')
+        # Escape special characters in project name for tag filter.
+        # In Valkey Search tag queries, characters like - . @ need backslash escaping.
+        escaped_project = project
+        for ch in r'\-.@+~<>{}[]^":|!*()':
+            escaped_project = escaped_project.replace(ch, f"\\{ch}")
 
-        # Build KNN query with project filter using quoted tag syntax (DIALECT 2)
         query_str = (
-            f'(@__project__:{{"{escaped_project}"}})'
+            f"(@__project__:{{{escaped_project}}})"
             f"=>[KNN {top_k} @{vector_field_name} $vec AS __distance__]"
         )
 
-        # Determine sort order based on metric:
-        # - COSINE, L2: lower distance = more similar → ascending
-        # - IP (Inner Product): higher score = more similar → descending
-        sort_ascending = metric.upper() != "IP"
-
+        # KNN results are already sorted by distance (ascending) by the engine.
+        # No explicit SORTBY is needed — Valkey Search does not support SORTBY
+        # with KNN queries.
         query = (
             Query(query_str)
             .return_fields("__distance__")
-            .sort_by("__distance__", asc=sort_ascending)
             .paging(0, top_k)
             .dialect(2)
         )

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -1627,7 +1627,7 @@ class TestExecuteVectorSearch:
         return EGValkeyOnlineStore()
 
     def test_project_name_with_hyphen_is_escaped(self, store):
-        """Test that project names with hyphens are properly escaped in queries."""
+        """Test that project names with hyphens are backslash-escaped in queries."""
         from unittest.mock import MagicMock
 
         mock_client = MagicMock()
@@ -1645,17 +1645,15 @@ class TestExecuteVectorSearch:
             metric="COSINE",
         )
 
-        # Verify the query was called
         mock_client.ft.return_value.search.assert_called_once()
         call_args = mock_client.ft.return_value.search.call_args
         query = call_args[0][0]
 
-        # The query string should have quoted project name for DIALECT 2
-        # This prevents hyphen from being interpreted as negation
-        assert '"my-project"' in query.query_string()
+        # Hyphen should be backslash-escaped to prevent interpretation as negation
+        assert r"my\-project" in query.query_string()
 
     def test_project_name_with_double_quote_is_escaped(self, store):
-        """Test that double quotes in project names are escaped."""
+        """Test that double quotes in project names are backslash-escaped."""
         from unittest.mock import MagicMock
 
         mock_client = MagicMock()
@@ -1677,11 +1675,11 @@ class TestExecuteVectorSearch:
         call_args = mock_client.ft.return_value.search.call_args
         query = call_args[0][0]
 
-        # Double quote should be escaped
-        assert r"\"" in query.query_string()
+        # Double quote should be backslash-escaped
+        assert r'\"' in query.query_string()
 
-    def test_sort_ascending_for_cosine_metric(self, store):
-        """Test that COSINE metric uses ascending sort (lower = better)."""
+    def test_no_sortby_in_knn_query(self, store):
+        """Test that KNN queries do not use SORTBY (engine sorts by distance automatically)."""
         from unittest.mock import MagicMock
 
         mock_client = MagicMock()
@@ -1702,60 +1700,8 @@ class TestExecuteVectorSearch:
         call_args = mock_client.ft.return_value.search.call_args
         query = call_args[0][0]
 
-        # COSINE should sort ascending (lower distance = more similar)
-        # Query._sortby is a SortbyField object with .args = [field, "ASC"/"DESC"]
-        assert query._sortby.args[0] == "__distance__"
-        assert query._sortby.args[1] == "ASC"
-
-    def test_sort_ascending_for_l2_metric(self, store):
-        """Test that L2 metric uses ascending sort (lower = better)."""
-        from unittest.mock import MagicMock
-
-        mock_client = MagicMock()
-        mock_result = MagicMock()
-        mock_result.docs = []
-        mock_client.ft.return_value.search.return_value = mock_result
-
-        store._execute_vector_search(
-            client=mock_client,
-            index_name="test_index",
-            project="test_project",
-            vector_field_name="embedding",
-            embedding_bytes=b"\x00" * 16,
-            top_k=10,
-            metric="L2",
-        )
-
-        call_args = mock_client.ft.return_value.search.call_args
-        query = call_args[0][0]
-
-        # L2 should sort ascending (lower distance = more similar)
-        assert query._sortby.args[1] == "ASC"
-
-    def test_sort_descending_for_ip_metric(self, store):
-        """Test that IP (Inner Product) metric uses descending sort (higher = better)."""
-        from unittest.mock import MagicMock
-
-        mock_client = MagicMock()
-        mock_result = MagicMock()
-        mock_result.docs = []
-        mock_client.ft.return_value.search.return_value = mock_result
-
-        store._execute_vector_search(
-            client=mock_client,
-            index_name="test_index",
-            project="test_project",
-            vector_field_name="embedding",
-            embedding_bytes=b"\x00" * 16,
-            top_k=10,
-            metric="IP",
-        )
-
-        call_args = mock_client.ft.return_value.search.call_args
-        query = call_args[0][0]
-
-        # IP should sort descending (higher score = more similar)
-        assert query._sortby.args[1] == "DESC"
+        # KNN results are sorted by the engine; no explicit SORTBY should be set
+        assert query._sortby is None
 
     def test_default_distance_is_infinity_not_zero(self, store):
         """Test that missing __distance__ defaults to infinity, not 0.0."""

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -1676,7 +1676,7 @@ class TestExecuteVectorSearch:
         query = call_args[0][0]
 
         # Double quote should be backslash-escaped
-        assert r'\"' in query.query_string()
+        assert r"\"" in query.query_string()
 
     def test_no_sortby_in_knn_query(self, store):
         """Test that KNN queries do not use SORTBY (engine sorts by distance automatically)."""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

Remove unsupported SORTBY and fix tag filter syntax

Valkey Search KNN queries return results pre-sorted by distance, so explicit SORTBY is not supported and causes a ResponseError. This removes the .sort_by() call from the query builder.

Additionally, fixes the project tag filter to use unquoted syntax with backslash escaping for special characters (e.g. hyphens, dots) instead of the quoted syntax which was returning empty results.

Updates unit tests to reflect both changes: replaces three metric-specific sort order tests with a single test asserting no SORTBY is set, and updates escaping assertions to match the new backslash-escape approach.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
