### PR TITLE
feat: Add retrieve_online_documents_v3 SDK with multi-vector and hybrid fusion

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2879,9 +2879,8 @@ class FeatureStore:
             )
             return OnlineResponse(online_features_response)
 
-        table_entity_values, idxs, output_len = utils._get_unique_entities_from_values(
-            entity_key_dict,
-        )
+        output_len = len(datevals)
+        idxs = tuple([i] for i in range(output_len))
 
         feature_data = utils._convert_rows_to_protobuf(
             requested_features=features_to_request,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2577,14 +2577,14 @@ class FeatureStore:
                 Keys are embedding field names and/or "bm25".
             rrf_k: RRF rank constant (default 60).
             distance_metric: Override distance metric.
-            include_signal_scores: Reserved for future use. When True, will
-                request per-signal score breakdowns for fusion strategies
-                (RRF, WEIGHTED_LINEAR) at additional latency cost. Currently
-                ignored — signal_scores follows the best-effort behavior
-                documented in the V3 design.
+            include_signal_scores: When True, requests per-signal score
+                breakdowns for fusion strategies (RRF, WEIGHTED_LINEAR) at
+                additional latency cost. Currently a no-op — signal_scores
+                always follows the best-effort behavior documented in the V3
+                design, and the parameter is plumbed through so callers can
+                opt in today and automatically pick up the explain-based
+                path when it lands. Default False.
         """
-        del include_signal_scores
-
         if not embeddings:
             raise ValueError(
                 "V3 requires at least one embedding. "
@@ -2675,6 +2675,7 @@ class FeatureStore:
             signal_weights,
             rrf_k,
             distance_metric,
+            include_signal_scores,
         )
 
     def _retrieve_from_online_store(
@@ -2833,6 +2834,7 @@ class FeatureStore:
         signal_weights: Optional[Dict[str, float]],
         rrf_k: int,
         distance_metric: Optional[str],
+        include_signal_scores: bool,
     ) -> OnlineResponse:
         documents = provider.retrieve_online_documents_v3(
             config=self.config,
@@ -2845,6 +2847,7 @@ class FeatureStore:
             signal_weights=signal_weights,
             rrf_k=rrf_k,
             distance_metric=distance_metric,
+            include_signal_scores=include_signal_scores,
         )
 
         entity_key_dict: Dict[str, List[ValueProto]] = {}

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2547,6 +2547,136 @@ class FeatureStore:
             query_string,
         )
 
+    def retrieve_online_documents_v3(
+        self,
+        features: List[str],
+        top_k: int,
+        embeddings: Optional[Dict[str, List[float]]] = None,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = False,
+    ) -> OnlineResponse:
+        """
+        Retrieve documents using multi-vector search with configurable fusion.
+
+        Args:
+            features: Feature references (e.g., ["doc_fv:title", "doc_fv:body"]).
+            top_k: Number of results to return.
+            embeddings: Map of vector field name to query vector. Required.
+                Single entry is equivalent to V2's embedding param.
+                Special case: the key "embedding" auto-resolves to the
+                FeatureView's single vector field, easing V2 to V3 migration.
+                FeatureViews with multiple vector fields require explicit names.
+            query_string: Text query. Ranking signal on Elasticsearch; logged + dropped
+                on Valkey (Valkey does not support text-as-ranking).
+            fusion_strategy: AUTO | RRF | WEIGHTED_LINEAR | VECTOR_ONLY.
+            signal_weights: Per-signal weights for WEIGHTED_LINEAR.
+                Keys are embedding field names and/or "bm25".
+            rrf_k: RRF rank constant (default 60).
+            distance_metric: Override distance metric.
+            include_signal_scores: Reserved for future use. When True, will
+                request per-signal score breakdowns for fusion strategies
+                (RRF, WEIGHTED_LINEAR) at additional latency cost. Currently
+                ignored — signal_scores follows the best-effort behavior
+                documented in the V3 design.
+        """
+        del include_signal_scores
+
+        if not embeddings:
+            raise ValueError(
+                "V3 requires at least one embedding. "
+                "For text-only search, use retrieve_online_documents_v2."
+            )
+
+        effective_strategy = fusion_strategy.upper()
+        valid_strategies = {"AUTO", "RRF", "WEIGHTED_LINEAR", "VECTOR_ONLY"}
+        if effective_strategy not in valid_strategies:
+            raise ValueError(
+                f"Unknown fusion_strategy '{fusion_strategy}'. "
+                f"Must be one of: {', '.join(sorted(valid_strategies))}"
+            )
+
+        if effective_strategy == "VECTOR_ONLY":
+            query_string = None
+
+        (
+            available_feature_views,
+            available_odfv_views,
+        ) = utils._get_feature_views_to_use(
+            registry=self._registry,
+            project=self.project,
+            features=features,
+            allow_cache=True,
+            hide_dummy_entity=False,
+        )
+
+        feature_view_set = {f.split(":")[0] for f in features}
+        if len(feature_view_set) > 1:
+            raise ValueError("Document retrieval only supports a single feature view.")
+
+        requested_features = [
+            f.split(":")[1] for f in features if isinstance(f, str) and ":" in f
+        ]
+
+        if not available_feature_views and not available_odfv_views:
+            raise ValueError(f"No feature view found for features {features}.")
+
+        if not available_feature_views:
+            available_feature_views.extend(available_odfv_views)  # type: ignore[arg-type]
+
+        requested_feature_view = available_feature_views[0]
+
+        if isinstance(requested_feature_view, OnDemandFeatureView):
+            raise ValueError(
+                "V3 vector search is not supported on OnDemandFeatureViews. "
+                "Use a regular FeatureView with vector-indexed fields."
+            )
+
+        RESERVED_NAMES = {"final_score", "signal_scores"}
+        collisions = set(requested_features) & RESERVED_NAMES
+        if collisions:
+            raise ValueError(
+                f"Feature names {sorted(collisions)} are reserved by V3 and cannot be "
+                f"requested directly. Rename your feature view fields or use V2."
+            )
+
+        # "embedding" magic key: auto-resolve to the FeatureView's single vector field
+        if len(embeddings) == 1 and list(embeddings.keys()) == ["embedding"]:
+            vector_fields = {
+                f.name: f for f in requested_feature_view.features if f.vector_index
+            }
+            if len(vector_fields) == 0:
+                raise ValueError(
+                    f"FeatureView '{requested_feature_view.name}' has no vector-indexed "
+                    f"fields. Cannot perform vector search."
+                )
+            elif len(vector_fields) == 1:
+                actual_name = next(iter(vector_fields.keys()))
+                embeddings = {actual_name: embeddings["embedding"]}
+            else:
+                raise ValueError(
+                    f"FeatureView '{requested_feature_view.name}' has multiple vector "
+                    f"fields {sorted(vector_fields.keys())}. "
+                    f"Specify the field name explicitly in embeddings."
+                )
+
+        provider = self._get_provider()
+        return self._retrieve_from_online_store_v3(
+            provider,
+            requested_feature_view,
+            requested_features,
+            embeddings,
+            top_k,
+            query_string,
+            effective_strategy,
+            signal_weights,
+            rrf_k,
+            distance_metric,
+        )
+
     def _retrieve_from_online_store(
         self,
         provider: Provider,
@@ -2655,6 +2785,88 @@ class FeatureStore:
         if not datevals:
             online_features_response = GetOnlineFeaturesResponse(results=[])
             for feature in features_to_request:
+                field = online_features_response.results.add()
+                field.values.extend([])
+                field.statuses.extend([])
+                field.event_timestamps.extend([])
+            online_features_response.metadata.feature_names.val.extend(
+                features_to_request
+            )
+            return OnlineResponse(online_features_response)
+
+        table_entity_values, idxs, output_len = utils._get_unique_entities_from_values(
+            entity_key_dict,
+        )
+
+        feature_data = utils._convert_rows_to_protobuf(
+            requested_features=features_to_request,
+            read_rows=list(zip(datevals, list_of_feature_dicts)),
+        )
+
+        online_features_response = GetOnlineFeaturesResponse(results=[])
+        utils._populate_response_from_feature_data(
+            feature_data=feature_data,
+            indexes=idxs,
+            online_features_response=online_features_response,
+            full_feature_names=False,
+            requested_features=features_to_request,
+            table=table,
+            output_len=output_len,
+        )
+
+        utils._populate_result_rows_from_columnar(
+            online_features_response=online_features_response,
+            data=entity_key_dict,
+        )
+
+        return OnlineResponse(online_features_response)
+
+    def _retrieve_from_online_store_v3(
+        self,
+        provider: Provider,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str],
+        fusion_strategy: str,
+        signal_weights: Optional[Dict[str, float]],
+        rrf_k: int,
+        distance_metric: Optional[str],
+    ) -> OnlineResponse:
+        documents = provider.retrieve_online_documents_v3(
+            config=self.config,
+            table=table,
+            requested_features=requested_features,
+            embeddings=embeddings,
+            top_k=top_k,
+            query_string=query_string,
+            fusion_strategy=fusion_strategy,
+            signal_weights=signal_weights,
+            rrf_k=rrf_k,
+            distance_metric=distance_metric,
+        )
+
+        entity_key_dict: Dict[str, List[ValueProto]] = {}
+        datevals, list_of_feature_dicts = [], []
+        for row_ts, entity_key, feature_dict in documents:  # type: ignore[misc]
+            datevals.append(row_ts)
+            list_of_feature_dicts.append(feature_dict)
+            if entity_key:
+                for key, value in zip(entity_key.join_keys, entity_key.entity_values):
+                    python_value = value
+                    if key not in entity_key_dict:
+                        entity_key_dict[key] = []
+                    entity_key_dict[key].append(python_value)
+
+        features_to_request: List[str] = requested_features + [
+            "final_score",
+            "signal_scores",
+        ]
+
+        if not datevals:
+            online_features_response = GetOnlineFeaturesResponse(results=[])
+            for _ in features_to_request:
                 field = online_features_response.results.add()
                 field.values.extend([])
                 field.statuses.extend([])

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -237,10 +237,6 @@ class FeatureView(BaseFeatureView):
             else:
                 features.append(field)
 
-        assert len([f for f in features if f.vector_index]) < 2, (
-            f"Only one vector feature is allowed per feature view. Please update {self.name}."
-        )
-
         # TODO(felixwang9817): Add more robust validation of features.
         if self.batch_source is not None:
             cols = [field.name for field in schema]

--- a/sdk/python/feast/infra/online_stores/_signal_scores.py
+++ b/sdk/python/feast/infra/online_stores/_signal_scores.py
@@ -1,0 +1,18 @@
+import json
+from typing import Dict
+
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+
+
+def encode_signal_scores(scores: Dict[str, float]) -> ValueProto:
+    """Encode a signal_scores dict as a JSON string in ValueProto."""
+    val = ValueProto()
+    val.string_val = json.dumps(scores, separators=(",", ":"), sort_keys=True)
+    return val
+
+
+def decode_signal_scores(value: ValueProto) -> Dict[str, float]:
+    """Decode a signal_scores ValueProto back to a dict."""
+    if not value.HasField("string_val") or not value.string_val:
+        return {}
+    return json.loads(value.string_val)

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -1112,9 +1112,12 @@ class EGValkeyOnlineStore(OnlineStore):
           use text as a ranking signal)
 
         Returns the same tuple shape as V2 with final_score and signal_scores
-        added to the feature dict. final_score is the raw Valkey distance
-        (lower = better for COSINE/L2, higher = better for IP). See the V3
-        design doc for cross-backend score semantics.
+        added to the feature dict. final_score is the raw Valkey
+        ``__distance__`` from ``FT.SEARCH KNN`` — lower = better for all
+        supported metrics (COSINE returns ``1 - cos``, L2 returns squared
+        distance, IP returns ``1 - inner_product``). Note this ordering is
+        the opposite of Elasticsearch's ``final_score``, which is a
+        relevance score where higher = better.
 
         Reserved parameters (accepted but currently unused):
         - ``include_signal_scores``: Reserved for future use.

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -1094,7 +1094,7 @@ class EGValkeyOnlineStore(OnlineStore):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],
@@ -1120,7 +1120,10 @@ class EGValkeyOnlineStore(OnlineStore):
         relevance score where higher = better.
 
         Reserved parameters (accepted but currently unused):
-        - ``include_signal_scores``: Reserved for future use.
+        - ``include_signal_scores``: No-op today. ``signal_scores`` is
+          populated best-effort (single-entry dict for the one vector
+          signal). Reserved so callers can opt in now and automatically
+          pick up a richer breakdown when the explain-based path lands.
         """
         del include_signal_scores
         valid_strategies = {"AUTO", "RRF", "WEIGHTED_LINEAR", "VECTOR_ONLY"}

--- a/sdk/python/feast/infra/online_stores/eg_valkey.py
+++ b/sdk/python/feast/infra/online_stores/eg_valkey.py
@@ -42,6 +42,7 @@ from feast.infra.key_encoding_utils import (
     deserialize_entity_key,
     serialize_entity_key,
 )
+from feast.infra.online_stores._signal_scores import encode_signal_scores
 from feast.infra.online_stores.helpers import _mmh3, _redis_key, _redis_key_prefix
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
@@ -1080,6 +1081,115 @@ class EGValkeyOnlineStore(OnlineStore):
             requested_features=requested_features,
             search_results=search_results,
         )
+
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        """
+        V3 document retrieval on Valkey backend.
+
+        Valkey supports a subset of V3 features:
+        - Single embedding only (multi-embedding raises ValueError)
+        - AUTO and VECTOR_ONLY fusion strategies (others raise ValueError)
+        - query_string is silently dropped with a warning (Valkey cannot
+          use text as a ranking signal)
+
+        Returns the same tuple shape as V2 with final_score and signal_scores
+        added to the feature dict. final_score is the raw Valkey distance
+        (lower = better for COSINE/L2, higher = better for IP). See the V3
+        design doc for cross-backend score semantics.
+
+        Reserved parameters (accepted but currently unused):
+        - ``include_signal_scores``: Reserved for future use.
+        """
+        del include_signal_scores
+        valid_strategies = {"AUTO", "RRF", "WEIGHTED_LINEAR", "VECTOR_ONLY"}
+        effective_strategy = fusion_strategy.upper()
+        if effective_strategy not in valid_strategies:
+            raise ValueError(
+                f"Unknown fusion_strategy '{fusion_strategy}'. "
+                f"Valid options: {sorted(valid_strategies)}"
+            )
+
+        if not embeddings:
+            raise ValueError(
+                "V3 requires at least one embedding. "
+                "Pass embeddings={field_name: vector}."
+            )
+
+        if len(embeddings) > 1:
+            raise ValueError(
+                "Multi-vector fusion requires the Elasticsearch backend. "
+                "Valkey supports single-vector search only. "
+                "Use a single embedding or switch to the Elasticsearch online store."
+            )
+
+        if effective_strategy in ("RRF", "WEIGHTED_LINEAR"):
+            raise ValueError(
+                f"Fusion strategy '{effective_strategy}' is not supported on Valkey. "
+                "Use fusion_strategy='AUTO' or 'VECTOR_ONLY', "
+                "or switch to the Elasticsearch backend for fusion support."
+            )
+
+        if query_string is not None and effective_strategy != "VECTOR_ONLY":
+            logger.warning(
+                "query_string is being dropped — Valkey backend does not support "
+                "text search as a ranking signal. To use text as a ranking signal, "
+                "switch to the Elasticsearch backend."
+            )
+
+        embed_key, embed_vector = next(iter(embeddings.items()))
+
+        v2_results = self.retrieve_online_documents_v2(
+            config=config,
+            table=table,
+            requested_features=requested_features,
+            embedding=embed_vector,
+            top_k=top_k,
+            distance_metric=distance_metric,
+            query_string=None,  # Valkey does not support query_string
+        )
+
+        v3_results: List[
+            Tuple[
+                Optional[datetime],
+                Optional[EntityKeyProto],
+                Optional[Dict[str, ValueProto]],
+            ]
+        ] = []
+        for timestamp, entity_key_proto, feature_dict in v2_results:
+            if feature_dict is None:
+                v3_results.append((timestamp, entity_key_proto, None))
+                continue
+
+            distance_val = feature_dict.pop("distance", None)
+            if distance_val is not None and distance_val.HasField("double_val"):
+                feature_dict["final_score"] = distance_val
+                signal_scores = {f"vec_{embed_key}": distance_val.double_val}
+            else:
+                signal_scores = {}
+
+            feature_dict["signal_scores"] = encode_signal_scores(signal_scores)
+            v3_results.append((timestamp, entity_key_proto, feature_dict))
+
+        return v3_results
 
     def _get_vector_field_for_search(
         self,

--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -723,7 +723,7 @@ class ElasticSearchOnlineStore(OnlineStore):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],
@@ -747,8 +747,10 @@ class ElasticSearchOnlineStore(OnlineStore):
         Reserved parameters (accepted but currently unused):
         - ``distance_metric``: V3-ES always uses the metric configured in the
           index mapping; this param is reserved for future per-query override.
-        - ``include_signal_scores``: Reserved for future use. Currently always
-          populated when available.
+        - ``include_signal_scores``: No-op today. ``signal_scores`` is always
+          populated best-effort (see Reserved output fields). Reserved for a
+          future ES-explain path that will expose per-signal scores after
+          fusion at extra latency cost.
         """
         del distance_metric
         del include_signal_scores

--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -657,6 +657,7 @@ class ElasticSearchOnlineStore(OnlineStore):
         elif execution_mode == "rrf":
             top_retriever = {"rrf": {"retrievers": retrievers, "rank_constant": rrf_k}}
         else:
+            assert signal_weights is not None
             weighted = []
             for signal_name, retriever in retrievers_with_names:
                 weight = signal_weights[signal_name]

--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import base64
 import json
 import logging
+import math
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -15,6 +16,7 @@ from feast.infra.key_encoding_utils import (
     get_list_val_str,
     serialize_entity_key,
 )
+from feast.infra.online_stores._signal_scores import encode_signal_scores
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.infra.online_stores.vector_store import VectorStoreConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
@@ -497,6 +499,218 @@ class ElasticSearchOnlineStore(OnlineStore):
                     feature_dict[feature] = _to_value_proto(value)
 
             result.append((timestamp, entity_key_proto, feature_dict))
+        return result
+
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        """
+        V3 document retrieval on Elasticsearch backend.
+
+        Uses the ES retriever API (ES 8.14+) for all query types: single-signal
+        kNN, multi-signal RRF, and weighted linear fusion.
+
+        Reserved output fields (always present in each result's feature_dict):
+        - ``final_score``: ES _score (higher = better). For single-signal this
+          is the raw kNN score; for fusion it is the rank-based composite score.
+        - ``signal_scores``: JSON-encoded Dict[str, float] with per-signal
+          scores when available, empty dict for fused results (ES does not
+          expose per-retriever scores after fusion).
+
+        Reserved parameters (accepted but currently unused):
+        - ``distance_metric``: V3-ES always uses the metric configured in the
+          index mapping; this param is reserved for future per-query override.
+        - ``include_signal_scores``: Reserved for future use. Currently always
+          populated when available.
+        """
+        del distance_metric
+        del include_signal_scores
+
+        valid_strategies = {"AUTO", "RRF", "WEIGHTED_LINEAR", "VECTOR_ONLY"}
+        effective_strategy = fusion_strategy.upper()
+        if effective_strategy not in valid_strategies:
+            raise ValueError(
+                f"Unknown fusion_strategy '{fusion_strategy}'. "
+                f"Valid options: {sorted(valid_strategies)}"
+            )
+
+        if not embeddings:
+            raise ValueError(
+                "V3 requires at least one embedding. "
+                "Pass embeddings={field_name: vector}."
+            )
+
+        if not config.online_store.vector_enabled:
+            raise ValueError("Vector search is not enabled in the online store config.")
+
+        if effective_strategy == "VECTOR_ONLY":
+            query_string = None
+
+        # Normalize empty/whitespace query_string to None
+        if query_string is not None and not query_string.strip():
+            query_string = None
+
+        # Validate embedding keys against FeatureView schema
+        vector_fields = {f.name: f for f in table.features if f.vector_index}
+        for key in embeddings:
+            if key not in vector_fields:
+                available = sorted(vector_fields.keys())
+                if not available:
+                    raise ValueError(
+                        f"FeatureView '{table.name}' has no vector-indexed fields. "
+                        f"Cannot perform vector search."
+                    )
+                raise ValueError(
+                    f"Embedding key '{key}' does not match any vector-indexed field "
+                    f"in FeatureView '{table.name}'. "
+                    f"Available vector fields: {available}"
+                )
+
+        # Build retrievers: one kNN per embedding, optional BM25 for query_string
+        retrievers_with_names: List[Tuple[str, Dict[str, Any]]] = []
+        for field_name, vec in embeddings.items():
+            knn_retriever: Dict[str, Any] = {
+                "knn": {
+                    "field": f"{field_name}.vector_value",
+                    "query_vector": vec,
+                }
+            }
+            retrievers_with_names.append((field_name, knn_retriever))
+
+        has_text_signal = query_string is not None
+        if has_text_signal:
+            text_retriever: Dict[str, Any] = {
+                "standard": {"query": {"query_string": {"query": query_string}}}
+            }
+            retrievers_with_names.append(("bm25", text_retriever))
+
+        is_single_signal = len(retrievers_with_names) == 1
+
+        if is_single_signal and effective_strategy in ("RRF", "WEIGHTED_LINEAR"):
+            logger.warning(
+                "Only one signal present — fusion_strategy '%s' has no effect. "
+                "The query will execute as a single-signal retrieval.",
+                effective_strategy,
+            )
+
+        # Set inner k based on signal count
+        multiplier = (
+            getattr(config.online_store, "knn_num_candidates_multiplier", 2.0) or 2.0
+        )
+        if is_single_signal:
+            inner_k = top_k
+        else:
+            inner_k = min(max(top_k * 10, 100), 1000)
+        num_candidates = max(inner_k, math.ceil(inner_k * multiplier))
+
+        for _, retriever in retrievers_with_names:
+            if "knn" in retriever:
+                retriever["knn"]["k"] = inner_k
+                retriever["knn"]["num_candidates"] = num_candidates
+
+        # Resolve execution mode
+        if is_single_signal:
+            execution_mode = "single"
+        elif effective_strategy == "WEIGHTED_LINEAR":
+            execution_mode = "linear"
+        else:
+            execution_mode = "rrf"
+
+        # Validate WEIGHTED_LINEAR signal coverage
+        if execution_mode == "linear":
+            expected_signals = {name for name, _ in retrievers_with_names}
+            provided = set(signal_weights.keys()) if signal_weights else set()
+            missing = expected_signals - provided
+            if missing:
+                raise ValueError(
+                    f"WEIGHTED_LINEAR fusion missing weights for signals: "
+                    f"{sorted(missing)}. Provide a weight for each signal: "
+                    f"embedding field names and/or 'bm25'."
+                )
+
+        # Compose query body
+        retrievers = [r for _, r in retrievers_with_names]
+        composite_key_name = _get_composite_key_name(table)
+        source_fields = requested_features.copy()
+        source_fields += ["entity_key", "timestamp"]
+        source_fields += composite_key_name
+
+        if execution_mode == "single":
+            top_retriever = retrievers[0]
+        elif execution_mode == "rrf":
+            top_retriever = {"rrf": {"retrievers": retrievers, "rank_constant": rrf_k}}
+        else:
+            weighted = []
+            for signal_name, retriever in retrievers_with_names:
+                weight = signal_weights[signal_name]
+                weighted.append({"retriever": retriever, "weight": weight})
+            top_retriever = {"linear": {"retrievers": weighted}}
+
+        body: Dict[str, Any] = {
+            "retriever": top_retriever,
+            "size": top_k,
+            "_source": source_fields,
+        }
+
+        response = self._get_client(config).search(index=table.name, body=body)
+
+        # Parse results
+        result: List[
+            Tuple[
+                Optional[datetime],
+                Optional[EntityKeyProto],
+                Optional[Dict[str, ValueProto]],
+            ]
+        ] = []
+
+        rows = response["hits"]["hits"][:top_k]
+        for row in rows:
+            entity_key = row["_source"]["entity_key"]
+            entity_key_proto = deserialize_entity_key(
+                base64.b64decode(entity_key),
+                entity_key_serialization_version=config.entity_key_serialization_version,
+            )
+            timestamp = datetime.fromisoformat(row["_source"]["timestamp"])
+
+            feature_dict: Dict[str, ValueProto] = {}
+            feature_dict["final_score"] = _to_value_proto(float(row["_score"]))
+
+            signal_scores: Dict[str, float] = {}
+            if is_single_signal:
+                embed_key = next(iter(embeddings.keys()))
+                signal_scores[f"vec_{embed_key}"] = float(row["_score"])
+
+            feature_dict["signal_scores"] = encode_signal_scores(signal_scores)
+
+            join_key_values = _extract_join_keys(entity_key_proto)
+            feature_dict.update(join_key_values)
+
+            for feature in requested_features:
+                if feature in ("final_score", "signal_scores"):
+                    continue
+                value = row["_source"].get(feature, None)
+                if value is not None:
+                    feature_dict[feature] = _to_value_proto(value)
+
+            result.append((timestamp, entity_key_proto, feature_dict))
+
         return result
 
 

--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -747,10 +747,12 @@ class ElasticSearchOnlineStore(OnlineStore):
         Reserved parameters (accepted but currently unused):
         - ``distance_metric``: V3-ES always uses the metric configured in the
           index mapping; this param is reserved for future per-query override.
-        - ``include_signal_scores``: No-op today. ``signal_scores`` is always
-          populated best-effort (see Reserved output fields). Reserved for a
-          future ES-explain path that will expose per-signal scores after
-          fusion at extra latency cost.
+        - ``include_signal_scores``: No-op today. ``signal_scores`` follows
+          best-effort behavior — populated for single-signal queries, empty
+          for RRF/WEIGHTED_LINEAR fusion (ES does not expose per-retriever
+          scores after fusion). Reserved for a future ES-explain path that
+          will populate the breakdown for fusion strategies at extra latency
+          cost.
         """
         del distance_metric
         del include_signal_scores

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -467,6 +467,31 @@ class OnlineStore(ABC):
             f"Online store {self.__class__.__name__} does not support online retrieval"
         )
 
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        raise NotImplementedError(
+            f"Online store {self.__class__.__name__} does not support "
+            f"V3 document retrieval"
+        )
+
     async def initialize(self, config: RepoConfig) -> None:
         pass
 

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -479,7 +479,7 @@ class OnlineStore(ABC):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],

--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -329,6 +329,31 @@ class RemoteOnlineStore(OnlineStore):
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        raise NotImplementedError(
+            "V3 document retrieval is not yet supported via the remote online store. "
+            "Use the SDK directly against a local online store."
+        )
+
     def _extract_requested_feature_value(
         self,
         response_json: dict,

--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -341,7 +341,7 @@ class RemoteOnlineStore(OnlineStore):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -447,7 +447,7 @@ class PassthroughProvider(Provider):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List:
         result = []
         if self.online_store:

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -435,6 +435,37 @@ class PassthroughProvider(Provider):
             )
         return result
 
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: Optional[List[str]],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List:
+        result = []
+        if self.online_store:
+            result = self.online_store.retrieve_online_documents_v3(
+                config,
+                table,
+                requested_features,
+                embeddings,
+                top_k,
+                query_string,
+                fusion_strategy,
+                signal_weights,
+                rrf_k,
+                distance_metric,
+                include_signal_scores,
+            )
+        return result
+
     @staticmethod
     def _prep_table_and_join_keys_for_ingestion(
         feature_view: Union[BaseFeatureView, FeatureView, OnDemandFeatureView],

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -509,7 +509,7 @@ class Provider(ABC):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -497,6 +497,29 @@ class Provider(ABC):
         pass
 
     @abstractmethod
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        pass
+
+    @abstractmethod
     def validate_data_source(
         self,
         config: RepoConfig,

--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -1421,10 +1421,6 @@ def _get_feature_view_vector_field_metadata(
     feature_view,
 ) -> Optional[Field]:
     vector_fields = [field for field in feature_view.schema if field.vector_index]
-    if len(vector_fields) > 1:
-        raise ValueError(
-            f"Feature view {feature_view.name} has multiple vector fields. Only one vector field per feature view is supported."
-        )
     if not vector_fields:
         return None
     return vector_fields[0]

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -184,6 +184,28 @@ class FooProvider(Provider):
     ]:
         return []
 
+    def retrieve_online_documents_v3(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embeddings: Dict[str, List[float]],
+        top_k: int,
+        query_string: Optional[str] = None,
+        fusion_strategy: str = "AUTO",
+        signal_weights: Optional[Dict[str, float]] = None,
+        rrf_k: int = 60,
+        distance_metric: Optional[str] = None,
+        include_signal_scores: bool = True,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        return []
+
     def validate_data_source(
         self,
         config: RepoConfig,

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -196,7 +196,7 @@ class FooProvider(Provider):
         signal_weights: Optional[Dict[str, float]] = None,
         rrf_k: int = 60,
         distance_metric: Optional[str] = None,
-        include_signal_scores: bool = True,
+        include_signal_scores: bool = False,
     ) -> List[
         Tuple[
             Optional[datetime],

--- a/sdk/python/tests/unit/infra/online_store/test_valkey.py
+++ b/sdk/python/tests/unit/infra/online_store/test_valkey.py
@@ -1732,3 +1732,424 @@ class TestExecuteVectorSearch:
         assert len(results) == 1
         doc_key, distance = results[0]
         assert distance == float("inf")
+
+
+class TestRetrieveOnlineDocumentsV3Validation:
+    """Tests for retrieve_online_documents_v3 input validation on Valkey."""
+
+    @pytest.fixture
+    def store(self):
+        return EGValkeyOnlineStore()
+
+    @pytest.fixture
+    def feature_view_with_vector(self):
+        return FeatureView(
+            name="test_fv",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="item_id", value_type=ValueType.INT64)],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="item_id", dtype=Int64),
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=4,
+                    vector_search_metric="COSINE",
+                ),
+                Field(name="title", dtype=String),
+            ],
+        )
+
+    @pytest.fixture
+    def feature_view_multi_vector(self):
+        return FeatureView(
+            name="test_fv_multi",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="item_id", value_type=ValueType.INT64)],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="item_id", dtype=Int64),
+                Field(
+                    name="title_vec",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=4,
+                    vector_search_metric="COSINE",
+                ),
+                Field(
+                    name="body_vec",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=4,
+                    vector_search_metric="COSINE",
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def repo_config(self):
+        return RepoConfig(
+            project="test_project",
+            provider="local",
+            registry="test_registry.db",
+            online_store=EGValkeyOnlineStoreConfig(
+                type="eg-valkey",
+                connection_string="localhost:6379",
+            ),
+            entity_key_serialization_version=3,
+        )
+
+    def test_empty_embeddings_raises(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        with pytest.raises(ValueError, match="at least one embedding"):
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={},
+                top_k=5,
+            )
+
+    def test_multi_embedding_raises(
+        self, store, repo_config, feature_view_multi_vector
+    ):
+        with pytest.raises(ValueError, match="single-vector search only"):
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_multi_vector,
+                requested_features=["item_id"],
+                embeddings={
+                    "title_vec": [0.1, 0.2, 0.3, 0.4],
+                    "body_vec": [0.5, 0.6, 0.7, 0.8],
+                },
+                top_k=5,
+            )
+
+    def test_rrf_strategy_raises(self, store, repo_config, feature_view_with_vector):
+        with pytest.raises(ValueError, match="not supported on Valkey"):
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="RRF",
+            )
+
+    def test_weighted_linear_strategy_raises(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        with pytest.raises(ValueError, match="not supported on Valkey"):
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="WEIGHTED_LINEAR",
+                signal_weights={"embedding": 1.0},
+            )
+
+    def test_unknown_fusion_strategy_raises(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        with pytest.raises(ValueError, match="Unknown fusion_strategy"):
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="BOGUS",
+            )
+
+    def test_auto_strategy_accepted(self, store, repo_config, feature_view_with_vector):
+        """AUTO should not raise — it delegates to V2."""
+        from unittest.mock import patch
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {"distance": ValueProto(double_val=0.5)},
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="AUTO",
+            )
+        assert len(results) == 1
+
+    def test_vector_only_strategy_accepted(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        from unittest.mock import patch
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {"distance": ValueProto(double_val=0.3)},
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="VECTOR_ONLY",
+            )
+        assert len(results) == 1
+
+    def test_query_string_warns_and_dropped(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        """query_string should trigger a logger.warning and be passed as None to V2."""
+        from unittest.mock import patch
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {"distance": ValueProto(double_val=0.5)},
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ) as mock_v2:
+            store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                query_string="test query",
+                fusion_strategy="AUTO",
+            )
+            # Verify query_string=None was passed to V2
+            call_kwargs = mock_v2.call_args[1]
+            assert call_kwargs.get("query_string") is None
+
+    def test_include_signal_scores_accepted(
+        self, store, repo_config, feature_view_with_vector
+    ):
+        from unittest.mock import patch
+
+        mock_results = []
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view_with_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                include_signal_scores=False,
+            )
+        assert results == []
+
+
+class TestRetrieveOnlineDocumentsV3ResponseTransform:
+    """Tests for V3 response transformation on Valkey (V2→V3 wrapper)."""
+
+    @pytest.fixture
+    def store(self):
+        return EGValkeyOnlineStore()
+
+    @pytest.fixture
+    def feature_view(self):
+        return FeatureView(
+            name="test_fv",
+            source=FileSource(
+                name="test_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="item_id", value_type=ValueType.INT64)],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="item_id", dtype=Int64),
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=4,
+                    vector_search_metric="COSINE",
+                ),
+                Field(name="title", dtype=String),
+            ],
+        )
+
+    @pytest.fixture
+    def repo_config(self):
+        return RepoConfig(
+            project="test_project",
+            provider="local",
+            registry="test_registry.db",
+            online_store=EGValkeyOnlineStoreConfig(
+                type="eg-valkey",
+                connection_string="localhost:6379",
+            ),
+            entity_key_serialization_version=3,
+        )
+
+    def test_distance_renamed_to_final_score(self, store, repo_config, feature_view):
+        from unittest.mock import patch
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {
+                    "distance": ValueProto(double_val=0.25),
+                    "title": ValueProto(string_val="hello"),
+                },
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        assert len(results) == 1
+        ts, ek, feat_dict = results[0]
+        assert "final_score" in feat_dict
+        assert "distance" not in feat_dict
+        assert feat_dict["final_score"].double_val == pytest.approx(0.25)
+
+    def test_signal_scores_populated(self, store, repo_config, feature_view):
+        from unittest.mock import patch
+
+        from feast.infra.online_stores._signal_scores import decode_signal_scores
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {"distance": ValueProto(double_val=0.5)},
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        feat_dict = results[0][2]
+        assert "signal_scores" in feat_dict
+        scores = decode_signal_scores(feat_dict["signal_scores"])
+        assert "vec_embedding" in scores
+        assert scores["vec_embedding"] == pytest.approx(0.5)
+
+    def test_none_feature_dict_passthrough(self, store, repo_config, feature_view):
+        from unittest.mock import patch
+
+        mock_results = [
+            (datetime(2024, 1, 1), None, None),
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        assert len(results) == 1
+        assert results[0][2] is None
+
+    def test_missing_distance_no_final_score(self, store, repo_config, feature_view):
+        """If V2 returns no distance, signal_scores should be empty."""
+        from unittest.mock import patch
+
+        from feast.infra.online_stores._signal_scores import decode_signal_scores
+
+        mock_results = [
+            (
+                datetime(2024, 1, 1),
+                EntityKeyProto(
+                    join_keys=["item_id"],
+                    entity_values=[ValueProto(int64_val=1)],
+                ),
+                {"title": ValueProto(string_val="test")},
+            )
+        ]
+        with patch.object(
+            store, "retrieve_online_documents_v2", return_value=mock_results
+        ):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        feat_dict = results[0][2]
+        scores = decode_signal_scores(feat_dict["signal_scores"])
+        assert scores == {}
+
+    def test_empty_v2_results(self, store, repo_config, feature_view):
+        from unittest.mock import patch
+
+        with patch.object(store, "retrieve_online_documents_v2", return_value=[]):
+            results = store.retrieve_online_documents_v3(
+                config=repo_config,
+                table=feature_view,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        assert results == []

--- a/sdk/python/tests/unit/online_store/test_elasticsearch_online_store.py
+++ b/sdk/python/tests/unit/online_store/test_elasticsearch_online_store.py
@@ -1,8 +1,17 @@
 import base64
+import json
+import math
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from feast import Entity, FeatureView, RepoConfig
+from feast.field import Field
+from feast.infra.online_stores._signal_scores import decode_signal_scores
 from feast.infra.online_stores.elasticsearch_online_store.elasticsearch import (
+    ElasticSearchOnlineStore,
+    ElasticSearchOnlineStoreConfig,
     _encode_feature_value,
 )
 from feast.protos.feast.types.Value_pb2 import (
@@ -12,6 +21,8 @@ from feast.protos.feast.types.Value_pb2 import (
 from feast.protos.feast.types.Value_pb2 import (
     Value as ValueProto,
 )
+from feast.types import Array, Float32, Int64, String
+from feast.value_type import ValueType
 
 
 class TestEncodeFeatureValue:
@@ -66,3 +77,692 @@ class TestEncodeFeatureValue:
         result = _encode_feature_value(value)
 
         assert "vector_value" not in result
+
+
+def _make_feature_view(
+    name="test_fv",
+    vector_fields=None,
+    extra_fields=None,
+):
+    """Helper to build a FeatureView with optional vector fields."""
+    from feast import FileSource
+
+    schema = [Field(name="item_id", dtype=Int64)]
+    if vector_fields is None:
+        vector_fields = [("embedding", 4)]
+    for fname, dim in vector_fields:
+        schema.append(
+            Field(
+                name=fname,
+                dtype=Array(Float32),
+                vector_index=True,
+                vector_length=dim,
+                vector_search_metric="COSINE",
+            )
+        )
+    for fname, dtype in extra_fields or []:
+        schema.append(Field(name=fname, dtype=dtype))
+
+    return FeatureView(
+        name=name,
+        source=FileSource(
+            name="test_source",
+            path="test.parquet",
+            timestamp_field="event_timestamp",
+        ),
+        entities=[Entity(name="item_id", value_type=ValueType.INT64)],
+        ttl=timedelta(days=1),
+        schema=schema,
+    )
+
+
+_repo_config_counter = 0
+
+
+def _make_repo_config(vector_enabled=True, **overrides):
+    """Helper to build a RepoConfig with ES online store."""
+    global _repo_config_counter
+    _repo_config_counter += 1
+    es_config = ElasticSearchOnlineStoreConfig(
+        type="elasticsearch",
+        host="localhost",
+        port=9200,
+        vector_enabled=vector_enabled,
+        **overrides,
+    )
+    return RepoConfig(
+        project="test_project",
+        provider="local",
+        registry=f"/tmp/test_registry_{_repo_config_counter}.db",
+        online_store=es_config,
+        entity_key_serialization_version=3,
+    )
+
+
+class TestRetrieveOnlineDocumentsV3Validation:
+    """Tests for retrieve_online_documents_v3 input validation."""
+
+    @pytest.fixture
+    def store(self):
+        return ElasticSearchOnlineStore()
+
+    @pytest.fixture
+    def config(self):
+        return _make_repo_config()
+
+    @pytest.fixture
+    def fv_single_vector(self):
+        return _make_feature_view(
+            vector_fields=[("embedding", 4)],
+            extra_fields=[("title", String)],
+        )
+
+    @pytest.fixture
+    def fv_multi_vector(self):
+        return _make_feature_view(
+            vector_fields=[("title_vec", 4), ("body_vec", 4)],
+        )
+
+    @pytest.fixture
+    def fv_no_vector(self):
+        return _make_feature_view(vector_fields=[])
+
+    def test_empty_embeddings_raises(self, store, config, fv_single_vector):
+        with pytest.raises(ValueError, match="at least one embedding"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={},
+                top_k=5,
+            )
+
+    def test_vector_not_enabled_raises(self, store, fv_single_vector):
+        config = _make_repo_config(vector_enabled=False)
+        with pytest.raises(ValueError, match="not enabled"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+    def test_unknown_fusion_strategy_raises(self, store, config, fv_single_vector):
+        with pytest.raises(ValueError, match="Unknown fusion_strategy"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy="INVALID",
+            )
+
+    def test_unknown_embedding_key_raises(self, store, config, fv_single_vector):
+        with pytest.raises(ValueError, match="does not match any vector-indexed"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"nonexistent_field": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+    def test_no_vector_fields_raises(self, store, config, fv_no_vector):
+        with pytest.raises(ValueError, match="no vector-indexed fields"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_no_vector,
+                requested_features=["item_id"],
+                embeddings={"some_field": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+    def test_weighted_linear_missing_weights_raises(
+        self, store, config, fv_multi_vector
+    ):
+        with pytest.raises(ValueError, match="missing weights for signals"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_multi_vector,
+                requested_features=["item_id"],
+                embeddings={
+                    "title_vec": [0.1, 0.2, 0.3, 0.4],
+                    "body_vec": [0.5, 0.6, 0.7, 0.8],
+                },
+                top_k=5,
+                query_string="test",
+                fusion_strategy="WEIGHTED_LINEAR",
+                signal_weights={"title_vec": 0.5},
+            )
+
+    def test_weighted_linear_partial_weights_raises(
+        self, store, config, fv_multi_vector
+    ):
+        """Missing bm25 weight when query_string is present."""
+        with pytest.raises(ValueError, match=r"missing weights for signals.*\bbm25\b"):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_multi_vector,
+                requested_features=["item_id"],
+                embeddings={
+                    "title_vec": [0.1, 0.2, 0.3, 0.4],
+                    "body_vec": [0.5, 0.6, 0.7, 0.8],
+                },
+                top_k=5,
+                query_string="test",
+                fusion_strategy="WEIGHTED_LINEAR",
+                signal_weights={"title_vec": 0.5, "body_vec": 0.3},
+            )
+
+    def test_vector_only_nullifies_query_string(self, store, config, fv_single_vector):
+        """VECTOR_ONLY should drop query_string before building retrievers."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                query_string="should be dropped",
+                fusion_strategy="VECTOR_ONLY",
+            )
+
+        call_body = mock_client.search.call_args[1]["body"]
+        retriever = call_body["retriever"]
+        assert "knn" in retriever, "VECTOR_ONLY should produce a knn retriever"
+        assert "standard" not in json.dumps(retriever)
+        assert "rrf" not in retriever
+
+    def test_empty_query_string_treated_as_none(self, store, config, fv_single_vector):
+        """Whitespace-only query_string should not create a BM25 retriever."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                query_string="   ",
+            )
+
+        call_body = mock_client.search.call_args[1]["body"]
+        retriever = call_body["retriever"]
+        assert "knn" in retriever
+        assert "standard" not in json.dumps(retriever)
+
+    @pytest.mark.parametrize(
+        "strategy", ["auto", "Auto", "AUTO", "rrf", "Rrf", "vector_only"]
+    )
+    def test_strategy_case_insensitive(self, store, config, fv_single_vector, strategy):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                fusion_strategy=strategy,
+            )
+        mock_client.search.assert_called_once()
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_include_signal_scores_accepted_but_ignored(
+        self, store, config, fv_single_vector, flag
+    ):
+        """include_signal_scores is a reserved param; should not raise for True or False."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            store.retrieve_online_documents_v3(
+                config=config,
+                table=fv_single_vector,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+                include_signal_scores=flag,
+            )
+
+
+class TestRetrieveOnlineDocumentsV3QueryBuilding:
+    """Tests for the ES query body construction."""
+
+    @pytest.fixture
+    def store(self):
+        return ElasticSearchOnlineStore()
+
+    @pytest.fixture
+    def config(self):
+        return _make_repo_config()
+
+    @pytest.fixture
+    def fv_single(self):
+        return _make_feature_view(
+            vector_fields=[("embedding", 4)],
+            extra_fields=[("title", String)],
+        )
+
+    @pytest.fixture
+    def fv_multi(self):
+        return _make_feature_view(
+            vector_fields=[("title_vec", 4), ("body_vec", 4)],
+        )
+
+    def _call_and_capture_body(self, store, config, table, **kwargs):
+        mock_client = MagicMock()
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        with patch.object(store, "_get_client", return_value=mock_client):
+            store.retrieve_online_documents_v3(config=config, table=table, **kwargs)
+        return mock_client.search.call_args[1]["body"]
+
+    def test_single_vector_uses_knn_retriever(self, store, config, fv_single):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+        )
+        retriever = body["retriever"]
+        assert "knn" in retriever
+        assert retriever["knn"]["field"] == "embedding.vector_value"
+        assert retriever["knn"]["query_vector"] == [0.1, 0.2, 0.3, 0.4]
+        assert retriever["knn"]["k"] == 5
+        assert body["size"] == 5
+
+    def test_single_vector_knn_k_equals_top_k(self, store, config, fv_single):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=10,
+        )
+        assert body["retriever"]["knn"]["k"] == 10
+
+    def test_multi_vector_uses_rrf_by_default(self, store, config, fv_multi):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_multi,
+            requested_features=["item_id"],
+            embeddings={
+                "title_vec": [0.1, 0.2, 0.3, 0.4],
+                "body_vec": [0.5, 0.6, 0.7, 0.8],
+            },
+            top_k=5,
+        )
+        retriever = body["retriever"]
+        assert "rrf" in retriever
+        assert len(retriever["rrf"]["retrievers"]) == 2
+
+    def test_multi_vector_rrf_has_rank_constant(self, store, config, fv_multi):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_multi,
+            requested_features=["item_id"],
+            embeddings={
+                "title_vec": [0.1, 0.2, 0.3, 0.4],
+                "body_vec": [0.5, 0.6, 0.7, 0.8],
+            },
+            top_k=5,
+            rrf_k=42,
+        )
+        assert body["retriever"]["rrf"]["rank_constant"] == 42
+
+    def test_query_string_adds_bm25_retriever(self, store, config, fv_single):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+            query_string="search term",
+        )
+        retriever = body["retriever"]
+        assert "rrf" in retriever
+        retrievers = retriever["rrf"]["retrievers"]
+        assert len(retrievers) == 2
+        retriever_types = [list(r.keys())[0] for r in retrievers]
+        assert "knn" in retriever_types
+        assert "standard" in retriever_types
+
+    def test_single_vector_plus_bm25_uses_rrf(self, store, config, fv_single):
+        """Single vector + query_string should produce RRF with knn + standard retrievers."""
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+            query_string="search term",
+            fusion_strategy="RRF",
+        )
+        retriever = body["retriever"]
+        assert "rrf" in retriever
+        retrievers = retriever["rrf"]["retrievers"]
+        assert len(retrievers) == 2
+        types = {list(r.keys())[0] for r in retrievers}
+        assert types == {"knn", "standard"}
+        for r in retrievers:
+            if "knn" in r:
+                assert r["knn"]["field"] == "embedding.vector_value"
+            if "standard" in r:
+                assert r["standard"]["query"]["query_string"]["query"] == "search term"
+
+    def test_weighted_linear_uses_linear_retriever(self, store, config, fv_multi):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_multi,
+            requested_features=["item_id"],
+            embeddings={
+                "title_vec": [0.1, 0.2, 0.3, 0.4],
+                "body_vec": [0.5, 0.6, 0.7, 0.8],
+            },
+            top_k=5,
+            fusion_strategy="WEIGHTED_LINEAR",
+            signal_weights={"title_vec": 0.7, "body_vec": 0.3},
+        )
+        retriever = body["retriever"]
+        assert "linear" in retriever
+        weighted = retriever["linear"]["retrievers"]
+        assert len(weighted) == 2
+        weights = [w["weight"] for w in weighted]
+        assert 0.7 in weights
+        assert 0.3 in weights
+
+    def test_multi_signal_inner_k_larger_than_top_k(self, store, config, fv_multi):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_multi,
+            requested_features=["item_id"],
+            embeddings={
+                "title_vec": [0.1, 0.2, 0.3, 0.4],
+                "body_vec": [0.5, 0.6, 0.7, 0.8],
+            },
+            top_k=5,
+        )
+        for r in body["retriever"]["rrf"]["retrievers"]:
+            if "knn" in r:
+                assert r["knn"]["k"] >= 100
+                assert r["knn"]["k"] <= 1000
+
+    def test_num_candidates_uses_math_ceil(self, store, config, fv_single):
+        """Verify math.ceil is applied by using a multiplier that produces a fraction."""
+        object.__setattr__(config.online_store, "knn_num_candidates_multiplier", 1.5)
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=3,
+        )
+        k = body["retriever"]["knn"]["k"]
+        num_candidates = body["retriever"]["knn"]["num_candidates"]
+        # 3 * 1.5 = 4.5 → ceil → 5, proving ceil is used (floor would give 4)
+        assert num_candidates == math.ceil(k * 1.5)
+        assert num_candidates == 5
+        assert num_candidates != int(k * 1.5)
+
+    def test_rrf_single_signal_executes_as_single(self, store, config, fv_single):
+        """RRF with only one signal should still succeed (logged warning, not error)."""
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+            fusion_strategy="RRF",
+        )
+        retriever = body["retriever"]
+        assert "knn" in retriever, "Single signal RRF degrades to single retriever"
+        assert "rrf" not in retriever
+
+    def test_auto_single_signal_uses_direct_knn(self, store, config, fv_single):
+        """AUTO with one vector and no query_string should produce a bare knn retriever."""
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+            fusion_strategy="AUTO",
+        )
+        retriever = body["retriever"]
+        assert "knn" in retriever, "Single signal AUTO should use direct knn"
+        assert "rrf" not in retriever
+        assert "linear" not in retriever
+
+    def test_source_fields_include_metadata(self, store, config, fv_single):
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+        )
+        source = body["_source"]
+        assert "entity_key" in source
+        assert "timestamp" in source
+        assert "title" in source
+
+
+class TestRetrieveOnlineDocumentsV3ResponseParsing:
+    """Tests for parsing ES response into V3 result tuples."""
+
+    @pytest.fixture
+    def store(self):
+        return ElasticSearchOnlineStore()
+
+    @pytest.fixture
+    def config(self):
+        return _make_repo_config()
+
+    @pytest.fixture
+    def fv(self):
+        return _make_feature_view(
+            vector_fields=[("embedding", 4)],
+            extra_fields=[("title", String)],
+        )
+
+    def _mock_es_response(self, hits):
+        return {"hits": {"hits": hits}}
+
+    def _make_hit(self, score, timestamp, features=None):
+        from feast.infra.key_encoding_utils import serialize_entity_key
+        from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+
+        ek = EntityKeyProto(
+            join_keys=["item_id"],
+            entity_values=[ValueProto(int64_val=1)],
+        )
+        ek_bytes = serialize_entity_key(ek, entity_key_serialization_version=3)
+        ek_b64 = base64.b64encode(ek_bytes).decode("utf-8")
+        source = {
+            "entity_key": ek_b64,
+            "timestamp": timestamp,
+        }
+        if features:
+            source.update(features)
+        return {"_source": source, "_score": score}
+
+    def test_single_result_has_final_score(self, store, config, fv):
+        hit = self._make_hit(0.95, "2024-01-01T00:00:00")
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        assert len(results) == 1
+        ts, ek, feat_dict = results[0]
+        assert feat_dict["final_score"].float_val == pytest.approx(0.95)
+
+    def test_single_result_has_signal_scores(self, store, config, fv):
+        hit = self._make_hit(0.95, "2024-01-01T00:00:00")
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        feat_dict = results[0][2]
+        scores = decode_signal_scores(feat_dict["signal_scores"])
+        assert "vec_embedding" in scores
+        assert scores["vec_embedding"] == pytest.approx(0.95)
+
+    def test_signal_scores_is_compact_sorted_json(self, store, config, fv):
+        """signal_scores should be compact JSON with sorted keys."""
+        hit = self._make_hit(0.95, "2024-01-01T00:00:00")
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        raw = results[0][2]["signal_scores"].string_val
+        assert " " not in raw
+        parsed = json.loads(raw)
+        assert list(parsed.keys()) == sorted(parsed.keys())
+
+    def test_multi_signal_signal_scores_are_empty(self, store, config):
+        fv = _make_feature_view(
+            vector_fields=[("title_vec", 4), ("body_vec", 4)],
+        )
+        hit = self._make_hit(0.8, "2024-01-01T00:00:00")
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["item_id"],
+                embeddings={
+                    "title_vec": [0.1, 0.2, 0.3, 0.4],
+                    "body_vec": [0.5, 0.6, 0.7, 0.8],
+                },
+                top_k=5,
+            )
+
+        feat_dict = results[0][2]
+        scores = decode_signal_scores(feat_dict["signal_scores"])
+        assert scores == {}
+
+    def test_empty_results(self, store, config, fv):
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        assert results == []
+
+    def test_timestamp_parsed(self, store, config, fv):
+        hit = self._make_hit(0.9, "2024-06-15T12:30:00")
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        ts = results[0][0]
+        assert isinstance(ts, datetime)
+        assert ts.year == 2024
+        assert ts.month == 6
+
+    def test_top_k_limits_results(self, store, config, fv):
+        """Verify that at most top_k results are returned even if ES returns more."""
+        hits = [self._make_hit(0.9 - i * 0.1, "2024-01-01T00:00:00") for i in range(5)]
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response(hits)
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=3,
+            )
+
+        assert len(results) <= 3
+        body = mock_client.search.call_args[1]["body"]
+        assert body["size"] == 3
+
+    def test_feature_values_included(self, store, config, fv):
+        encoded_val = base64.b64encode(
+            ValueProto(string_val="hello world").SerializeToString()
+        ).decode("utf-8")
+        hit = self._make_hit(
+            0.9,
+            "2024-01-01T00:00:00",
+            features={"title": {"feature_value": encoded_val}},
+        )
+        mock_client = MagicMock()
+        mock_client.search.return_value = self._mock_es_response([hit])
+
+        with patch.object(store, "_get_client", return_value=mock_client):
+            results = store.retrieve_online_documents_v3(
+                config=config,
+                table=fv,
+                requested_features=["title"],
+                embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+                top_k=5,
+            )
+
+        feat_dict = results[0][2]
+        assert "title" in feat_dict
+        assert feat_dict["title"].string_val == "hello world"

--- a/sdk/python/tests/unit/online_store/test_signal_scores.py
+++ b/sdk/python/tests/unit/online_store/test_signal_scores.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from feast.infra.online_stores._signal_scores import (
+    decode_signal_scores,
+    encode_signal_scores,
+)
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+
+
+class TestEncodeSignalScores:
+    def test_single_score(self):
+        result = encode_signal_scores({"vec_embedding": 0.95})
+        assert result.HasField("string_val")
+        parsed = json.loads(result.string_val)
+        assert parsed == {"vec_embedding": 0.95}
+
+    def test_multiple_scores(self):
+        scores = {"vec_title": 0.8, "vec_body": 0.6, "bm25": 12.5}
+        result = encode_signal_scores(scores)
+        parsed = json.loads(result.string_val)
+        assert parsed == scores
+
+    def test_empty_dict(self):
+        result = encode_signal_scores({})
+        assert result.string_val == "{}"
+
+    def test_sort_keys_deterministic(self):
+        result_a = encode_signal_scores({"z_field": 1.0, "a_field": 2.0})
+        result_b = encode_signal_scores({"a_field": 2.0, "z_field": 1.0})
+        assert result_a.string_val == result_b.string_val
+        parsed = json.loads(result_a.string_val)
+        keys = list(parsed.keys())
+        assert keys == sorted(keys)
+
+    def test_compact_json_no_spaces(self):
+        result = encode_signal_scores({"a": 1.0, "b": 2.0})
+        assert " " not in result.string_val
+
+    def test_returns_value_proto(self):
+        result = encode_signal_scores({"x": 1.0})
+        assert isinstance(result, ValueProto)
+
+
+class TestDecodeSignalScores:
+    def test_roundtrip(self):
+        original = {"vec_embedding": 0.95, "bm25": 12.5}
+        encoded = encode_signal_scores(original)
+        decoded = decode_signal_scores(encoded)
+        assert decoded == original
+
+    def test_roundtrip_empty(self):
+        encoded = encode_signal_scores({})
+        decoded = decode_signal_scores(encoded)
+        assert decoded == {}
+
+    def test_empty_string_val(self):
+        val = ValueProto()
+        val.string_val = ""
+        assert decode_signal_scores(val) == {}
+
+    def test_no_string_field(self):
+        val = ValueProto()
+        val.int64_val = 42
+        assert decode_signal_scores(val) == {}
+
+    def test_default_value_proto(self):
+        val = ValueProto()
+        assert decode_signal_scores(val) == {}
+
+    def test_malformed_json_raises(self):
+        val = ValueProto()
+        val.string_val = "not-json"
+        with pytest.raises(json.JSONDecodeError):
+            decode_signal_scores(val)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

Adds `retrieve_online_documents_v3` SDK method supporting multi-vector search, hybrid ranking (vector + BM25), and configurable fusion strategies (RRF, weighted linear). Valkey gets graceful degradation to V2-equivalent single-vector behavior with clear errors for unsupported operations.

Design Doc : [doc](https://expediagroup.atlassian.net/wiki/spaces/~msudhir/pages/1049317725/V3+Proposal+Enhancements+to+Feast+s+Document+Retrieval+with+Multi-Vector+Search+and+Hybrid+Ranking?themeState=dark%3Adark+light%3Alight+spacing%3Aspacing+typography%3Atypography+colorMode%3Alight)


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
