### PR TITLE
fix: Normalize Cassandra column name casing for SortedFeatureView sch…

### DIFF
--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -89,6 +89,20 @@ func base62Encode(data []byte) string {
 	return toBase62(num)
 }
 
+// canonicalColumnName returns the on-disk form of a Cassandra column for a
+// Feast feature. Cassandra/Scylla case-fold unquoted identifiers to lowercase
+// at storage time, and the Python materializer emits column references
+// unquoted (see _build_sorted_table_cql in cassandra_online_store.py), so the
+// canonical on-disk form is always lowercase. Anywhere this reader references
+// a feature column by name in CQL or looks it up in a result map, it must use
+// this canonical form.
+//
+// This helper is NOT used to transform names that flow back to callers in
+// response payloads — those preserve the original case from the FV definition.
+func canonicalColumnName(featureName string) string {
+	return strings.ToLower(featureName)
+}
+
 func parseStringField(config map[string]any, fieldName string, defaultValue string) (string, error) {
 	rawValue, ok := config[fieldName]
 	if !ok {
@@ -719,10 +733,10 @@ func (c *CassandraOnlineStore) executeBatch(
 
 func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (string, []interface{}) {
 	rangeParams := make([]interface{}, 0)
+	sortKeyCol := canonicalColumnName(filter.SortKeyName)
 
-	equality := ""
 	if filter.Equals != nil {
-		equality = fmt.Sprintf(`"%s" = ?`, filter.SortKeyName)
+		equality := fmt.Sprintf(`%s = ?`, sortKeyCol)
 		rangeParams = append(rangeParams, filter.Equals)
 		return equality, rangeParams
 	}
@@ -730,18 +744,18 @@ func (c *CassandraOnlineStore) rangeFilterToCQL(filter *model.SortKeyFilter) (st
 	rangeStart := ""
 	if filter.RangeStart != nil {
 		if filter.StartInclusive {
-			rangeStart = fmt.Sprintf(`"%s" >= ?`, filter.SortKeyName)
+			rangeStart = fmt.Sprintf(`%s >= ?`, sortKeyCol)
 		} else {
-			rangeStart = fmt.Sprintf(`"%s" > ?`, filter.SortKeyName)
+			rangeStart = fmt.Sprintf(`%s > ?`, sortKeyCol)
 		}
 		rangeParams = append(rangeParams, filter.RangeStart)
 	}
 	rangeEnd := ""
 	if filter.RangeEnd != nil {
 		if filter.EndInclusive {
-			rangeEnd = fmt.Sprintf(`"%s" <= ?`, filter.SortKeyName)
+			rangeEnd = fmt.Sprintf(`%s <= ?`, sortKeyCol)
 		} else {
-			rangeEnd = fmt.Sprintf(`"%s" < ?`, filter.SortKeyName)
+			rangeEnd = fmt.Sprintf(`%s < ?`, sortKeyCol)
 		}
 		rangeParams = append(rangeParams, filter.RangeEnd)
 	}
@@ -765,9 +779,13 @@ func (c *CassandraOnlineStore) buildRangeQueryCQL(
 	limit int32,
 	isReverseSortOrder bool,
 ) (string, []interface{}) {
-	quotedFeatures := make([]string, len(featureNames))
+	// Use unquoted, lowercased identifiers to match the on-disk form written
+	// by the Python materializer. Quoting + mixed case would make Cassandra
+	// do a case-sensitive lookup that misses the (always-lowercase) stored
+	// column.
+	columnRefs := make([]string, len(featureNames))
 	for i, name := range featureNames {
-		quotedFeatures[i] = fmt.Sprintf(`"%s"`, name)
+		columnRefs[i] = canonicalColumnName(name)
 	}
 
 	keyPlaceholders := make([]string, numKeys)
@@ -791,7 +809,7 @@ func (c *CassandraOnlineStore) buildRangeQueryCQL(
 			params = append(params, filterParams...)
 			if f.Order != nil {
 				orderBy = append(orderBy,
-					fmt.Sprintf(`"%s" %s`, f.SortKeyName, f.Order.String()))
+					fmt.Sprintf(`%s %s`, canonicalColumnName(f.SortKeyName), f.Order.String()))
 			}
 		}
 
@@ -813,14 +831,14 @@ func (c *CassandraOnlineStore) buildRangeQueryCQL(
 
 	var keyCondition string
 	if numKeys == 1 {
-		keyCondition = `"entity_key" = ?`
+		keyCondition = `entity_key = ?`
 	} else {
-		keyCondition = fmt.Sprintf(`"entity_key" IN (%s)`, strings.Join(keyPlaceholders, ", "))
+		keyCondition = fmt.Sprintf(`entity_key IN (%s)`, strings.Join(keyPlaceholders, ", "))
 	}
 
 	cql := fmt.Sprintf(
-		`SELECT "entity_key", "event_ts", %s FROM %s WHERE %s%s%s%s`,
-		strings.Join(quotedFeatures, ", "),
+		`SELECT entity_key, event_ts, %s FROM %s WHERE %s%s%s%s`,
+		strings.Join(columnRefs, ", "),
 		tableName,
 		keyCondition,
 		whereClause,
@@ -929,12 +947,17 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 
 				for _, featName := range groupedRefs.FeatureNames {
 					idx := prepCtx.featureNamesToIdx[featName]
+					// gocql MapScan returns map keys in the case Cassandra stored them in
+					// (lowercase, since the Python writer emits unquoted DDL). Look up the
+					// value by canonical (lowercase) name. featName itself stays
+					// original-case for use in the response payload below.
+					canonicalFeat := canonicalColumnName(featName)
 					var val interface{}
 					var status serving.FieldStatus
 
 					if _, isSortKey := groupedRefs.SortKeyNames[featName]; isSortKey {
 						var exists bool
-						val, exists = readValues[featName]
+						val, exists = readValues[canonicalFeat]
 						if !exists {
 							status = serving.FieldStatus_NOT_FOUND
 							val = nil
@@ -944,7 +967,7 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 							status = serving.FieldStatus_PRESENT
 						}
 					} else {
-						if valueStr, ok := readValues[featName]; ok {
+						if valueStr, ok := readValues[canonicalFeat]; ok {
 							val, status, err = utils.UnmarshalStoredProto(valueStr.([]byte))
 							if err != nil {
 								errorsChannel <- err
@@ -956,6 +979,8 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 						}
 					}
 
+					// featName (original case) is passed to appendRangeFeature so the
+					// response payload preserves the case the user defined in the FV.
 					appendRangeFeature(&rowData[idx], featName, prepCtx.featureViewName, val, status, eventTs)
 				}
 

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -914,6 +914,13 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 	var waitGroup sync.WaitGroup
 	errorsChannel := make(chan error, nBatches)
 
+	canonicalFeats := make([]string, len(groupedRefs.FeatureNames))
+	isSortKey := make([]bool, len(groupedRefs.FeatureNames))
+	for i, name := range groupedRefs.FeatureNames {
+		canonicalFeats[i] = canonicalColumnName(name)
+		_, isSortKey[i] = groupedRefs.SortKeyNames[name]
+	}
+
 	for i := 0; i < nBatches; i++ {
 		start := i * batchSize
 		end := int(math.Min(float64(start+batchSize), float64(len(prepCtx.serializedEntityKeys))))
@@ -945,42 +952,15 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 
 				rowData := results[rowIdx]
 
-				for _, featName := range groupedRefs.FeatureNames {
+				for i, featName := range groupedRefs.FeatureNames {
 					idx := prepCtx.featureNamesToIdx[featName]
-					// gocql MapScan returns map keys in the case Cassandra stored them in
-					// (lowercase, since the Python writer emits unquoted DDL). Look up the
-					// value by canonical (lowercase) name. featName itself stays
-					// original-case for use in the response payload below.
-					canonicalFeat := canonicalColumnName(featName)
-					var val interface{}
-					var status serving.FieldStatus
 
-					if _, isSortKey := groupedRefs.SortKeyNames[featName]; isSortKey {
-						var exists bool
-						val, exists = readValues[canonicalFeat]
-						if !exists {
-							status = serving.FieldStatus_NOT_FOUND
-							val = nil
-						} else if val == nil {
-							status = serving.FieldStatus_NULL_VALUE
-						} else {
-							status = serving.FieldStatus_PRESENT
-						}
-					} else {
-						if valueStr, ok := readValues[canonicalFeat]; ok {
-							val, status, err = utils.UnmarshalStoredProto(valueStr.([]byte))
-							if err != nil {
-								errorsChannel <- err
-								return
-							}
-						} else {
-							val = nil
-							status = serving.FieldStatus_NOT_FOUND
-						}
+					val, status, resolveErr := resolveFeatureValue(readValues, canonicalFeats[i], isSortKey[i])
+					if resolveErr != nil {
+						errorsChannel <- resolveErr
+						return
 					}
 
-					// featName (original case) is passed to appendRangeFeature so the
-					// response payload preserves the case the user defined in the FV.
 					appendRangeFeature(&rowData[idx], featName, prepCtx.featureViewName, val, status, eventTs)
 				}
 
@@ -1032,6 +1012,37 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 	}
 
 	return results, nil
+}
+
+// resolveFeatureValue looks up a single feature's value from a MapScan-populated
+// row. readValues keys are lowercase (Cassandra's on-disk form).
+// canonicalFeat is the pre-computed lowercase form of the feature name.
+// isSortKey indicates whether this feature is a sort key.
+func resolveFeatureValue(
+	readValues map[string]interface{},
+	canonicalFeat string,
+	isSortKey bool,
+) (val interface{}, status serving.FieldStatus, err error) {
+	if isSortKey {
+		v, exists := readValues[canonicalFeat]
+		if !exists {
+			return nil, serving.FieldStatus_NOT_FOUND, nil
+		}
+		if v == nil {
+			return nil, serving.FieldStatus_NULL_VALUE, nil
+		}
+		return v, serving.FieldStatus_PRESENT, nil
+	}
+
+	valueStr, ok := readValues[canonicalFeat]
+	if !ok {
+		return nil, serving.FieldStatus_NOT_FOUND, nil
+	}
+	v, status, err := utils.UnmarshalStoredProto(valueStr.([]byte))
+	if err != nil {
+		return nil, status, err
+	}
+	return v, status, nil
 }
 
 func appendRangeFeature(row *RangeFeatureData, featName, view string, val interface{}, status serving.FieldStatus, ts time.Time) {

--- a/go/internal/feast/onlinestore/cassandraonlinestore_test.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore_test.go
@@ -255,7 +255,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_singleFilter(t *testing.T) {
 
 	cqlStatement, params := store.buildRangeQueryCQL(fqTableName, []string{"feat1", "feat2"}, 1, []*model.SortKeyFilter{&sortFilter1}, 5, false)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" >= ? AND "sort1" <= ? PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? AND sort1 >= ? AND sort1 <= ? PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 	assert.ElementsMatch(t, []interface{}{4, 12, int32(5)}, params)
@@ -273,7 +273,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_withoutLimit(t *testing.T) {
 
 	cqlStatement, params := store.buildRangeQueryCQL(fqTableName, []string{"feat1", "feat2"}, 1, []*model.SortKeyFilter{&sortFilter1}, 0, false)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" <= ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? AND sort1 <= ?`,
 		cqlStatement,
 	)
 	assert.ElementsMatch(t, []interface{}{12}, params)
@@ -296,7 +296,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_multipleFilters(t *testing.T) {
 
 	cqlStatement, params := store.buildRangeQueryCQL(fqTableName, []string{"feat1", "feat2"}, 1, []*model.SortKeyFilter{&sortFilter1, &sortFilter2}, 5, false)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" = ? AND "sort2" >= ? PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? AND sort1 = ? AND sort2 >= ? PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 	assert.ElementsMatch(t, []interface{}{4, 10, int32(5)}, params)
@@ -328,7 +328,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_multipleFiltersWithMixOfRanges(
 
 	cqlStatement, params := store.buildRangeQueryCQL(fqTableName, []string{"feat1", "feat2"}, 1, []*model.SortKeyFilter{&sortFilter1, &sortFilter2, &sortFilter3}, 5, false)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" >= ? AND "sort1" < ? AND "sort2" > ? AND "sort2" <= ? PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? AND sort1 >= ? AND sort1 < ? AND sort2 > ? AND sort2 <= ? PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 	assert.ElementsMatch(t, []interface{}{4, 12, 10, 20, int32(5)}, params)
@@ -340,7 +340,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_noFilters(t *testing.T) {
 
 	cqlStatement, params := store.buildRangeQueryCQL(fqTableName, []string{"feat1", "feat2"}, 1, []*model.SortKeyFilter{}, 5, false)
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 	assert.ElementsMatch(t, []interface{}{int32(5)}, params)
@@ -366,7 +366,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_reverseSortOrder(t *testing.T) 
 	)
 
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" = ? AND "sort1" >= ? ORDER BY "sort1" DESC PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key = ? AND sort1 >= ? ORDER BY sort1 DESC PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 
@@ -387,7 +387,7 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_batchedKeysWithoutFilters(t *te
 	)
 
 	assert.Equal(t,
-		`SELECT "entity_key", "event_ts", "feat1", "feat2" FROM "scylladb"."dummy_project_dummy_fv" WHERE "entity_key" IN (?, ?) PER PARTITION LIMIT ?`,
+		`SELECT entity_key, event_ts, feat1, feat2 FROM "scylladb"."dummy_project_dummy_fv" WHERE entity_key IN (?, ?) PER PARTITION LIMIT ?`,
 		cqlStatement,
 	)
 
@@ -415,11 +415,40 @@ func TestCassandraOnlineStore_buildRangeQueryCQL_orderNil_skipsOrderBy(t *testin
 	)
 
 	expectedCQL :=
-		`SELECT "entity_key", "event_ts", "feat1" ` +
+		`SELECT entity_key, event_ts, feat1 ` +
 			`FROM "scylladb"."dummy_project_dummy_fv" ` +
-			`WHERE "entity_key" = ? AND "sort1" = ?`
+			`WHERE entity_key = ? AND sort1 = ?`
 
 	assert.Equal(t, expectedCQL, cql)
 	assert.ElementsMatch(t, []interface{}{42}, params)
 	assert.NotContains(t, cql, "ORDER BY", "ORDER BY should be omitted when all SortKeyFilters have Order == nil")
+}
+
+func TestBuildRangeQueryCQL_UsesLowercaseUnquotedIdentifiers(t *testing.T) {
+	store := CassandraOnlineStore{}
+	fqTableName := `"scylladb"."dummy_project_dummy_fv"`
+
+	cql, _ := store.buildRangeQueryCQL(
+		fqTableName,
+		[]string{"featureX", "FeatureY"},
+		2,
+		nil,
+		0,
+		false,
+	)
+	// Feature columns must appear lowercase and unquoted in projection.
+	assert.Contains(t, cql, "featurex")
+	assert.Contains(t, cql, "featurey")
+	assert.NotContains(t, cql, `"featureX"`)
+	assert.NotContains(t, cql, `"FeatureY"`)
+	// entity_key and event_ts also unquoted.
+	assert.Contains(t, cql, "entity_key")
+	assert.NotContains(t, cql, `"entity_key"`)
+}
+
+func TestCanonicalColumnName(t *testing.T) {
+	assert.Equal(t, "featurex", canonicalColumnName("featureX"))
+	assert.Equal(t, "feature", canonicalColumnName("FEATURE"))
+	assert.Equal(t, "already_lower", canonicalColumnName("already_lower"))
+	assert.Equal(t, "", canonicalColumnName(""))
 }

--- a/go/internal/feast/onlinestore/cassandraonlinestore_test.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore_test.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/protos/feast/core"
+	"github.com/feast-dev/feast/go/protos/feast/serving"
+	"github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestExtractCassandraConfig_CorrectDefaults(t *testing.T) {
@@ -451,4 +454,88 @@ func TestCanonicalColumnName(t *testing.T) {
 	assert.Equal(t, "feature", canonicalColumnName("FEATURE"))
 	assert.Equal(t, "already_lower", canonicalColumnName("already_lower"))
 	assert.Equal(t, "", canonicalColumnName(""))
+}
+
+func mustMarshalValueProto(t *testing.T, val *types.Value) []byte {
+	t.Helper()
+	b, err := proto.Marshal(val)
+	if err != nil {
+		t.Fatalf("failed to marshal value proto: %v", err)
+	}
+	return b
+}
+
+func TestResolveFeatureValue_MixedCaseNonSortKey(t *testing.T) {
+	// Regression: gocql MapScan returns row keys in the case Cassandra stored
+	// them (lowercase, since the Python writer emits unquoted DDL). FV feature
+	// names from the registry preserve their original case. The caller must
+	// canonicalize the FV name before passing it here.
+	testVal := &types.Value{Val: &types.Value_Int64Val{Int64Val: 99}}
+	serialized := mustMarshalValueProto(t, testVal)
+
+	readValues := map[string]interface{}{
+		"sumclicksxdestinationgeoid": serialized,
+	}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("sumClicksXDestinationGeoId"), false)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_PRESENT, status)
+	assert.NotNil(t, val)
+	assert.Equal(t, int64(99), val.(*types.Value).GetInt64Val())
+}
+
+func TestResolveFeatureValue_MixedCaseSortKey(t *testing.T) {
+	readValues := map[string]interface{}{
+		"eventoriginationtimestamp": int64(1714500000),
+	}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("EventOriginationTimestamp"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_PRESENT, status)
+	assert.Equal(t, int64(1714500000), val)
+}
+
+func TestResolveFeatureValue_SortKeyNullValue(t *testing.T) {
+	readValues := map[string]interface{}{
+		"sortkey": nil,
+	}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("SortKey"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_NULL_VALUE, status)
+	assert.Nil(t, val)
+}
+
+func TestResolveFeatureValue_FeatureMissingFromRow(t *testing.T) {
+	readValues := map[string]interface{}{
+		"entity_key": "abc",
+	}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("MissingFeature"), false)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_NOT_FOUND, status)
+	assert.Nil(t, val)
+}
+
+func TestResolveFeatureValue_SortKeyMissingFromRow(t *testing.T) {
+	readValues := map[string]interface{}{}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("SortKey"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_NOT_FOUND, status)
+	assert.Nil(t, val)
+}
+
+func TestResolveFeatureValue_AlreadyLowercaseFeature(t *testing.T) {
+	testVal := &types.Value{Val: &types.Value_StringVal{StringVal: "hello"}}
+	serialized := mustMarshalValueProto(t, testVal)
+
+	readValues := map[string]interface{}{
+		"already_lower": serialized,
+	}
+
+	val, status, err := resolveFeatureValue(readValues, canonicalColumnName("already_lower"), false)
+	assert.NoError(t, err)
+	assert.Equal(t, serving.FieldStatus_PRESENT, status)
+	assert.Equal(t, "hello", val.(*types.Value).GetStringVal())
 }

--- a/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
@@ -994,9 +994,7 @@ class CassandraOnlineStore(OnlineStore):
         col_defs = ", ".join(col_defs_parts)
         alter_cql = f"ALTER TABLE {fqtable} ADD ({col_defs})"
         session.execute(alter_cql)
-        logger.info(
-            f"Added columns [{', '.join(new_col_names)}] to table: {fqtable}"
-        )
+        logger.info(f"Added columns [{', '.join(new_col_names)}] to table: {fqtable}")
 
     def _build_sorted_table_cql(
         self, project: str, table: SortedFeatureView, fqtable: str

--- a/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
@@ -894,6 +894,23 @@ class CassandraOnlineStore(OnlineStore):
         logger.info(f"Deleting table {fqtable}.")
         session.execute(drop_cql)
 
+    @staticmethod
+    def _check_no_case_collisions(table: FeatureView) -> None:
+        """Cassandra/Scylla case-fold unquoted column identifiers. Refuse to
+        create tables where two features would collapse to the same column."""
+        seen: dict[str, str] = {}
+        for f in table.features:
+            canonical = f.name.lower()
+            if canonical in seen:
+                raise CassandraInvalidConfig(
+                    f"FeatureView '{table.name}' has features '{f.name}' and "
+                    f"'{seen[canonical]}' that differ only in case. On "
+                    f"Cassandra/Scylla, unquoted column identifiers are stored "
+                    f"lowercase, so these would collide as column '{canonical}'. "
+                    f"Rename one of them."
+                )
+            seen[canonical] = f.name
+
     def _create_table(
         self,
         config: RepoConfig,
@@ -901,6 +918,7 @@ class CassandraOnlineStore(OnlineStore):
         table: Union[FeatureView, SortedFeatureView],
     ):
         """Handle the CQL (low-level) creation of a table."""
+        self._check_no_case_collisions(table)
         session: Session = self._get_session(config)
         keyspace: str = self._keyspace
         table_name_version = config.online_store.table_name_format_version
@@ -950,6 +968,7 @@ class CassandraOnlineStore(OnlineStore):
         return plain_table_name in ks_meta.tables
 
     def _alter_table(self, config: RepoConfig, project: str, table: FeatureView):
+        self._check_no_case_collisions(table)
         session = self._get_session(config)
         fqtable, plain_table_name = self._resolve_table_names(config, project, table)
 

--- a/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
@@ -122,6 +122,24 @@ CQL_TEMPLATE_MAP = {
 
 V2_TABLE_NAME_FORMAT_MAX_LENGTH = 48
 
+
+def _canonical_column_name(feature_name: str) -> str:
+    """
+    Return the on-disk form of a Cassandra column for a Feast feature.
+
+    Cassandra and Scylla case-fold unquoted identifiers to lowercase at
+    storage time. The plugin emits all column references unquoted, so the
+    canonical on-disk form for any feature column is lowercase. Anywhere
+    this plugin compares or looks up a column name against Cassandra
+    metadata, this helper must be used to match the stored form.
+
+    This helper is NOT used to transform feature names that flow back to
+    callers via API responses — those preserve the original case from the
+    FeatureView definition.
+    """
+    return feature_name.lower()
+
+
 # Logger
 logger = logging.getLogger(__name__)
 
@@ -936,18 +954,49 @@ class CassandraOnlineStore(OnlineStore):
         fqtable, plain_table_name = self._resolve_table_names(config, project, table)
 
         ks_meta = self._cluster.metadata.keyspaces[self._keyspace]
-        existing_cols = set(ks_meta.tables[plain_table_name].columns.keys())
+        # Cassandra/Scylla lowercase unquoted identifiers at storage time. The
+        # plugin emits column references unquoted (see _build_sorted_table_cql
+        # and the INSERT templates), so the canonical on-disk form for any
+        # feature column is lowercase. Both sides of the diff must be normalized.
+        existing_cols = {
+            _canonical_column_name(c)
+            for c in ks_meta.tables[plain_table_name].columns.keys()
+        }
 
-        desired_cols = {f.name for f in table.features}
-        new_cols = desired_cols - existing_cols
-        if new_cols:
-            cql_type = "BLOB"  # Default type for features
-            col_defs = ", ".join(f"{col} {cql_type}" for col in new_cols)
-            alter_cql = f"ALTER TABLE {fqtable} ADD ({col_defs})"
-            session.execute(alter_cql)
-            logger.info(
-                f"Added columns [{', '.join(sorted(new_cols))}] to table: {fqtable}"
+        # Map canonical (lowercased) name -> original Field, so we can pick the
+        # correct CQL type per column and report original-case names in logs.
+        desired = {_canonical_column_name(f.name): f for f in table.features}
+        missing_canonical = set(desired.keys()) - existing_cols
+        if not missing_canonical:
+            return
+
+        # Sort-key columns on a SortedFeatureView need typed CQL columns
+        # (BIGINT, TIMESTAMP, etc.) for clustering order. Non-sort-key features
+        # are stored as BLOB. Mirrors _build_sorted_table_cql.
+        sort_key_names_canonical = (
+            {_canonical_column_name(sk.name) for sk in table.sort_keys}
+            if isinstance(table, SortedFeatureView)
+            else set()
+        )
+
+        col_defs_parts = []
+        new_col_names = []
+        for canonical in sorted(missing_canonical):
+            feature = desired[canonical]
+            cql_type = (
+                self._get_cql_type(feature.dtype)
+                if canonical in sort_key_names_canonical
+                else "BLOB"
             )
+            col_defs_parts.append(f"{feature.name} {cql_type}")
+            new_col_names.append(feature.name)
+
+        col_defs = ", ".join(col_defs_parts)
+        alter_cql = f"ALTER TABLE {fqtable} ADD ({col_defs})"
+        session.execute(alter_cql)
+        logger.info(
+            f"Added columns [{', '.join(new_col_names)}] to table: {fqtable}"
+        )
 
     def _build_sorted_table_cql(
         self, project: str, table: SortedFeatureView, fqtable: str

--- a/sdk/python/feast/sorted_feature_view.py
+++ b/sdk/python/feast/sorted_feature_view.py
@@ -122,16 +122,18 @@ class SortedFeatureView(FeatureView):
                 raise ValueError(
                     f"For SortedFeatureView: {self.name}: Duplicate feature name found: '{field.name}'."
                 )
-            # On Cassandra/Scylla, unquoted column identifiers are case-folded
-            # to lowercase. Two features that differ only in case would silently
-            # collapse to the same column, causing data loss.
             canonical = field.name.lower()
             if canonical in canonical_to_original:
-                raise ValueError(
-                    f"For SortedFeatureView '{self.name}': features '{field.name}' and "
-                    f"'{canonical_to_original[canonical]}' differ only in case and would "
-                    f"collide on Cassandra/Scylla online stores (both stored as "
-                    f"'{canonical}'). Rename one of them to use a distinct lowercase form."
+                logger.warning(
+                    "SortedFeatureView '%s': features '%s' and '%s' differ only in case. "
+                    "This works on case-preserving online stores (Valkey, DynamoDB) "
+                    "but will collide on Cassandra/Scylla (both stored as '%s'). "
+                    "If you target multiple online stores or may switch in the future, "
+                    "use distinct lowercase names.",
+                    self.name,
+                    field.name,
+                    canonical_to_original[canonical],
+                    canonical,
                 )
             feature_map[field.name] = field
             canonical_to_original[canonical] = field.name

--- a/sdk/python/feast/sorted_feature_view.py
+++ b/sdk/python/feast/sorted_feature_view.py
@@ -105,6 +105,7 @@ class SortedFeatureView(FeatureView):
 
         reserved_columns = {"event_ts", "created_ts", "entity_key"}
         feature_map = {}
+        canonical_to_original: dict[str, str] = {}
 
         for field in self.features:
             if field.name in reserved_columns:
@@ -121,29 +122,19 @@ class SortedFeatureView(FeatureView):
                 raise ValueError(
                     f"For SortedFeatureView: {self.name}: Duplicate feature name found: '{field.name}'."
                 )
-            # Case-insensitive collision check. On Cassandra/Scylla online stores,
-            # unquoted column identifiers are case-folded to lowercase at storage time.
-            # Two features whose names differ only in case (e.g., "featureX" and
-            # "featurex") would silently collapse to the same column on those backends,
-            # causing data loss. Reject at registration time.
+            # On Cassandra/Scylla, unquoted column identifiers are case-folded
+            # to lowercase. Two features that differ only in case would silently
+            # collapse to the same column, causing data loss.
             canonical = field.name.lower()
-            existing_with_same_canonical = next(
-                (
-                    existing_name
-                    for existing_name in feature_map
-                    if existing_name != field.name
-                    and existing_name.lower() == canonical
-                ),
-                None,
-            )
-            if existing_with_same_canonical is not None:
+            if canonical in canonical_to_original:
                 raise ValueError(
-                    f"For SortedFeatureView: {self.name}: features '{field.name}' and "
-                    f"'{existing_with_same_canonical}' differ only in case. On "
-                    f"Cassandra/Scylla online stores these would collide (both stored "
-                    f"as '{canonical}'). Rename one of them to avoid silent data loss."
+                    f"For SortedFeatureView '{self.name}': features '{field.name}' and "
+                    f"'{canonical_to_original[canonical]}' differ only in case and would "
+                    f"collide on Cassandra/Scylla online stores (both stored as "
+                    f"'{canonical}'). Rename one of them to use a distinct lowercase form."
                 )
             feature_map[field.name] = field
+            canonical_to_original[canonical] = field.name
 
         valid_feature_names = list(feature_map.keys())
 

--- a/sdk/python/feast/sorted_feature_view.py
+++ b/sdk/python/feast/sorted_feature_view.py
@@ -121,6 +121,28 @@ class SortedFeatureView(FeatureView):
                 raise ValueError(
                     f"For SortedFeatureView: {self.name}: Duplicate feature name found: '{field.name}'."
                 )
+            # Case-insensitive collision check. On Cassandra/Scylla online stores,
+            # unquoted column identifiers are case-folded to lowercase at storage time.
+            # Two features whose names differ only in case (e.g., "featureX" and
+            # "featurex") would silently collapse to the same column on those backends,
+            # causing data loss. Reject at registration time.
+            canonical = field.name.lower()
+            existing_with_same_canonical = next(
+                (
+                    existing_name
+                    for existing_name in feature_map
+                    if existing_name != field.name
+                    and existing_name.lower() == canonical
+                ),
+                None,
+            )
+            if existing_with_same_canonical is not None:
+                raise ValueError(
+                    f"For SortedFeatureView: {self.name}: features '{field.name}' and "
+                    f"'{existing_with_same_canonical}' differ only in case. On "
+                    f"Cassandra/Scylla online stores these would collide (both stored "
+                    f"as '{canonical}'). Rename one of them to avoid silent data loss."
+                )
             feature_map[field.name] = field
 
         valid_feature_names = list(feature_map.keys())

--- a/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
@@ -254,3 +254,14 @@ def test_get_cql_type():
     assert store._get_cql_type(Array(Float32)) == "LIST<FLOAT>"
     assert store._get_cql_type(Array(Float64)) == "LIST<DOUBLE>"
     assert store._get_cql_type(Array(Bool)) == "LIST<BOOLEAN>"
+
+
+def test_canonical_column_name():
+    from feast.infra.online_stores.cassandra_online_store.cassandra_online_store import (
+        _canonical_column_name,
+    )
+
+    assert _canonical_column_name("featureX") == "featurex"
+    assert _canonical_column_name("FEATURE") == "feature"
+    assert _canonical_column_name("already_lower") == "already_lower"
+    assert _canonical_column_name("") == ""

--- a/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_cassandra_online_store.py
@@ -265,3 +265,32 @@ def test_canonical_column_name():
     assert _canonical_column_name("FEATURE") == "feature"
     assert _canonical_column_name("already_lower") == "already_lower"
     assert _canonical_column_name("") == ""
+
+
+def test_check_no_case_collisions_raises(file_source):
+    from feast.infra.online_stores.cassandra_online_store.cassandra_online_store import (
+        CassandraInvalidConfig,
+    )
+
+    fv = FeatureView(
+        name="collision_view",
+        source=file_source,
+        schema=[
+            Field(name="featureX", dtype=Int64),
+            Field(name="featurex", dtype=Int64),
+        ],
+    )
+    with pytest.raises(CassandraInvalidConfig, match="differ only in case"):
+        CassandraOnlineStore._check_no_case_collisions(fv)
+
+
+def test_check_no_case_collisions_passes(file_source):
+    fv = FeatureView(
+        name="good_view",
+        source=file_source,
+        schema=[
+            Field(name="featureX", dtype=Int64),
+            Field(name="featureY", dtype=Int64),
+        ],
+    )
+    CassandraOnlineStore._check_no_case_collisions(fv)

--- a/sdk/python/tests/unit/test_sorted_feature_view.py
+++ b/sdk/python/tests/unit/test_sorted_feature_view.py
@@ -491,13 +491,15 @@ def test_sorted_feature_view_invalid_sort_key_order_int():
         )
 
 
-def test_case_collision_features_raises_at_validation():
-    """Two features whose names differ only in case must be rejected,
-    because they would collide on Cassandra/Scylla storage."""
+def test_case_collision_features_warns_at_validation(caplog):
+    """Two features whose names differ only in case emit a warning
+    (the hard error lives in the Cassandra plugin, not the FV layer)."""
     source = FileSource(path="some path")
     entity = Entity(name="entity1", join_keys=["entity1_id"])
 
-    with pytest.raises(ValueError, match="differ only in case"):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="feast.sorted_feature_view"):
         SortedFeatureView(
             name="bad_view",
             entities=[entity],
@@ -515,14 +517,17 @@ def test_case_collision_features_raises_at_validation():
                 Field(name="featurex", dtype=Int64),
             ],
         )
+    assert "differ only in case" in caplog.text
 
 
-def test_case_collision_features_uppercase_raises():
-    """Features featureX and FEATUREX must also be rejected."""
+def test_case_collision_features_uppercase_warns(caplog):
+    """Features featureX and FEATUREX also trigger a warning."""
     source = FileSource(path="some path")
     entity = Entity(name="entity1", join_keys=["entity1_id"])
 
-    with pytest.raises(ValueError, match="differ only in case"):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="feast.sorted_feature_view"):
         SortedFeatureView(
             name="bad_view",
             entities=[entity],
@@ -540,6 +545,7 @@ def test_case_collision_features_uppercase_raises():
                 Field(name="FEATUREX", dtype=Int64),
             ],
         )
+    assert "differ only in case" in caplog.text
 
 
 def test_case_distinct_features_pass_validation():

--- a/sdk/python/tests/unit/test_sorted_feature_view.py
+++ b/sdk/python/tests/unit/test_sorted_feature_view.py
@@ -491,6 +491,105 @@ def test_sorted_feature_view_invalid_sort_key_order_int():
         )
 
 
+def test_case_collision_features_raises_at_validation():
+    """Two features whose names differ only in case must be rejected,
+    because they would collide on Cassandra/Scylla storage."""
+    source = FileSource(path="some path")
+    entity = Entity(name="entity1", join_keys=["entity1_id"])
+
+    with pytest.raises(ValueError, match="differ only in case"):
+        SortedFeatureView(
+            name="bad_view",
+            entities=[entity],
+            sort_keys=[
+                SortKey(
+                    name="sortKey",
+                    value_type=ValueType.INT64,
+                    default_sort_order=SortOrder.ASC,
+                )
+            ],
+            source=source,
+            schema=[
+                Field(name="sortKey", dtype=Int64),
+                Field(name="featureX", dtype=Int64),
+                Field(name="featurex", dtype=Int64),
+            ],
+        )
+
+
+def test_case_collision_features_uppercase_raises():
+    """Features featureX and FEATUREX must also be rejected."""
+    source = FileSource(path="some path")
+    entity = Entity(name="entity1", join_keys=["entity1_id"])
+
+    with pytest.raises(ValueError, match="differ only in case"):
+        SortedFeatureView(
+            name="bad_view",
+            entities=[entity],
+            sort_keys=[
+                SortKey(
+                    name="sortKey",
+                    value_type=ValueType.INT64,
+                    default_sort_order=SortOrder.ASC,
+                )
+            ],
+            source=source,
+            schema=[
+                Field(name="sortKey", dtype=Int64),
+                Field(name="featureX", dtype=Int64),
+                Field(name="FEATUREX", dtype=Int64),
+            ],
+        )
+
+
+def test_case_distinct_features_pass_validation():
+    """Features that differ in more than just case are allowed."""
+    source = FileSource(path="some path")
+    entity = Entity(name="entity1", join_keys=["entity1_id"])
+
+    fv = SortedFeatureView(
+        name="good_view",
+        entities=[entity],
+        sort_keys=[
+            SortKey(
+                name="sortKey",
+                value_type=ValueType.INT64,
+                default_sort_order=SortOrder.ASC,
+            )
+        ],
+        source=source,
+        schema=[
+            Field(name="sortKey", dtype=Int64),
+            Field(name="featureX", dtype=Int64),
+            Field(name="featureY", dtype=Int64),
+        ],
+    )
+    fv.ensure_valid()
+
+
+def test_single_feature_passes_case_validation():
+    """A SortedFeatureView with a single feature passes validation."""
+    source = FileSource(path="some path")
+    entity = Entity(name="entity1", join_keys=["entity1_id"])
+
+    fv = SortedFeatureView(
+        name="single_feat_view",
+        entities=[entity],
+        sort_keys=[
+            SortKey(
+                name="featureX",
+                value_type=ValueType.INT64,
+                default_sort_order=SortOrder.ASC,
+            )
+        ],
+        source=source,
+        schema=[
+            Field(name="featureX", dtype=Int64),
+        ],
+    )
+    fv.ensure_valid()
+
+
 def test_sfv_compatibility_same():
     """
     Two identical SortedFeatureViews should be compatible with no reasons.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
  - Fix Cassandra _alter_table failing with "Column already exists" on re-materialization of SortedFeatureViews with mixed-case feature names                                                                                                             
  - Fix Go OnlineReadRange producing "Undefined column name" errors when reading those same features                                                                                                                                                                                                                
  - Add registration-time validation to reject SortedFeatureView features that differ only in case, preventing silent data loss on Cassandra/Scylla                                                                                                                                                                 
                                                                                                                                                        

# Which issue(s) this PR fixes:

 Cassandra and Scylla case-fold unquoted column identifiers to lowercase at storage time. A feature named pct_filter_bookings_adult_countXdestination_geo_id_2w is stored as pct_filter_bookings_adult_countxdestination_geo_id_2w on disk.                                                                        
                                                            
 Python materialization path: _alter_table compared desired_cols (original case from FV definition) against existing_cols (lowercase from Cassandra metadata) using a case-sensitive set difference. On every materialization after the initial table creation, it concluded the column was "new" and attempted    
  ALTER TABLE ADD, which Cassandra rejected because the lowercase column already existed.
                                                                                                                                                                                                                                                                                                                    
Go read path: buildRangeQueryCQL and rangeFilterToCQL wrapped column identifiers in double quotes ("featureX"), making Cassandra perform a case-sensitive lookup against the always-lowercase stored column — resulting in "Undefined column name" errors.                                                        
   

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
