### PR TITLE
fix: Apply rescore_oversample to V3 ES kNN retrievers

### DIFF
--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -834,10 +834,15 @@ class ElasticSearchOnlineStore(OnlineStore):
             inner_k = min(max(top_k * 10, 100), 1000)
         num_candidates = max(inner_k, math.ceil(inner_k * multiplier))
 
+        rescore_oversample = config.online_store.rescore_oversample
         for _, retriever in retrievers_with_names:
             if "knn" in retriever:
                 retriever["knn"]["k"] = inner_k
                 retriever["knn"]["num_candidates"] = num_candidates
+                if rescore_oversample is not None:
+                    retriever["knn"]["rescore_vector"] = {
+                        "oversample": rescore_oversample
+                    }
 
         # Resolve execution mode
         if is_single_signal:

--- a/sdk/python/tests/unit/online_store/test_elasticsearch_online_store.py
+++ b/sdk/python/tests/unit/online_store/test_elasticsearch_online_store.py
@@ -569,6 +569,60 @@ class TestRetrieveOnlineDocumentsV3QueryBuilding:
         assert "timestamp" in source
         assert "title" in source
 
+    def test_rescore_oversample_applied_to_single_knn(self, store, fv_single):
+        """When rescore_oversample is configured on a quantized index, the V3
+        kNN retriever should include a rescore_vector clause."""
+        config = _make_repo_config(
+            vector_index_type="int8_hnsw", rescore_oversample=3.0
+        )
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+        )
+        knn = body["retriever"]["knn"]
+        assert knn["rescore_vector"] == {"oversample": 3.0}
+
+    def test_rescore_oversample_applied_to_all_multi_vector_knns(self, store, fv_multi):
+        """Multi-vector V3 queries should apply rescore_vector to every kNN
+        retriever, not just the first one."""
+        config = _make_repo_config(
+            vector_index_type="int4_hnsw", rescore_oversample=2.5
+        )
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_multi,
+            requested_features=["item_id"],
+            embeddings={
+                "title_vec": [0.1, 0.2, 0.3, 0.4],
+                "body_vec": [0.5, 0.6, 0.7, 0.8],
+            },
+            top_k=5,
+        )
+        retrievers = body["retriever"]["rrf"]["retrievers"]
+        assert len(retrievers) == 2
+        for r in retrievers:
+            assert r["knn"]["rescore_vector"] == {"oversample": 2.5}
+
+    def test_rescore_oversample_absent_when_not_configured(
+        self, store, config, fv_single
+    ):
+        """Default config has no rescore_oversample; the kNN clause should not
+        include rescore_vector."""
+        body = self._call_and_capture_body(
+            store,
+            config,
+            fv_single,
+            requested_features=["title"],
+            embeddings={"embedding": [0.1, 0.2, 0.3, 0.4]},
+            top_k=5,
+        )
+        assert "rescore_vector" not in body["retriever"]["knn"]
+
 
 class TestRetrieveOnlineDocumentsV3ResponseParsing:
     """Tests for parsing ES response into V3 result tuples."""


### PR DESCRIPTION
# What this PR does / why we need it:

V3's retriever construction was silently ignoring rescore_oversample. V2 honored it (lines 483-486, 617-620) but V3 never added rescore_vector to its kNN clauses. On quantized indices (int8_hnsw / int4_hnsw / bbq_hnsw), this meant V3 queries returned lower recall than the config promised, with no error or warning.

Wire rescore_oversample into each kNN retriever the same way V2 does. Covers single-vector and multi-vector V3 queries; BM25 retrievers skip the branch since they lack a "knn" key.

Existing config validation (lines 102-127) already prevents rescore on non-quantized indices, so no new validation needed.

Added three unit tests in TestRetrieveOnlineDocumentsV3QueryBuilding:
- rescore_vector appears in single-vector query body when configured
- rescore_vector appears on every kNN retriever in multi-vector query
- rescore_vector absent when rescore_oversample is None

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
