### PR TITLE
feat: Add per-feature-view metrics for online read path

### DIFF
--- a/go/internal/feast/errors/grpc_error.go
+++ b/go/internal/feast/errors/grpc_error.go
@@ -3,8 +3,8 @@ package errors
 import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"net/http"
 	"strings"
-    "net/http"
 )
 
 func GrpcErrorf(code codes.Code, format string, args ...interface{}) error {
@@ -31,16 +31,16 @@ func GrpcNotFoundErrorf(format string, args ...interface{}) error {
 }
 
 func IsGrpcNotFoundError(err error) bool {
-    if err == nil {
-        return false
-    }
-    s, ok := status.FromError(err)
-    return ok && s.Code() == codes.NotFound
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	return ok && s.Code() == codes.NotFound
 }
 
 func IsHTTPNotFoundError(err error) bool {
-    if err == nil {
-        return false
-    }
-    return strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), http.StatusText(http.StatusNotFound))
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), http.StatusText(http.StatusNotFound))
 }

--- a/go/internal/feast/metrics/client.go
+++ b/go/internal/feast/metrics/client.go
@@ -4,9 +4,11 @@ package metrics
 // The real github.com/DataDog/datadog-go/v5/statsd.Client satisfies this interface.
 type StatsdClient interface {
 	Count(name string, value int64, tags []string, rate float64) error
+	Distribution(name string, value float64, tags []string, rate float64) error
 }
 
 // NoOpStatsdClient does nothing when metrics are disabled.
 type NoOpStatsdClient struct{}
 
-func (n *NoOpStatsdClient) Count(string, int64, []string, float64) error { return nil }
+func (n *NoOpStatsdClient) Count(string, int64, []string, float64) error        { return nil }
+func (n *NoOpStatsdClient) Distribution(string, float64, []string, float64) error { return nil }

--- a/go/internal/feast/metrics/client.go
+++ b/go/internal/feast/metrics/client.go
@@ -10,5 +10,5 @@ type StatsdClient interface {
 // NoOpStatsdClient does nothing when metrics are disabled.
 type NoOpStatsdClient struct{}
 
-func (n *NoOpStatsdClient) Count(string, int64, []string, float64) error        { return nil }
+func (n *NoOpStatsdClient) Count(string, int64, []string, float64) error          { return nil }
 func (n *NoOpStatsdClient) Distribution(string, float64, []string, float64) error { return nil }

--- a/go/internal/feast/metrics/config.go
+++ b/go/internal/feast/metrics/config.go
@@ -3,10 +3,13 @@ package metrics
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 )
+
+const DefaultSampleRate = 0.01
 
 func IsMissingKeyMetricsEnabled() bool {
 	return strings.ToLower(os.Getenv("ENABLE_MISSING_KEY_METRICS")) == "true"
@@ -22,6 +25,20 @@ func GetOnlineStoreType(config *registry.RepoConfig) string {
 		return fmt.Sprintf("%v", storeType)
 	}
 	return "unknown"
+}
+
+// ParseSampleRate reads FEAST_METRICS_SAMPLE_RATE from the environment once.
+// Returns DefaultSampleRate (0.01) if unset or invalid.
+func ParseSampleRate() float64 {
+	rateStr := os.Getenv("FEAST_METRICS_SAMPLE_RATE")
+	if rateStr == "" {
+		return DefaultSampleRate
+	}
+	rate, err := strconv.ParseFloat(rateStr, 64)
+	if err != nil || rate <= 0 || rate > 1.0 {
+		return DefaultSampleRate
+	}
+	return rate
 }
 
 // GetStatsDAddress returns the DogStatsD address from environment variables.

--- a/go/internal/feast/metrics/config.go
+++ b/go/internal/feast/metrics/config.go
@@ -22,8 +22,7 @@ func IsFVMetricsEnabled() bool {
 	return strings.ToLower(os.Getenv("ENABLE_FV_LEVEL_METRICS")) == "true"
 }
 
-// IsMetricsClientEnabled returns true if any metrics feature is enabled.
-// Use this in main.go to gate statsd client construction.
+// IsMetricsClientEnabled returns true if any metrics feature flag is enabled.
 func IsMetricsClientEnabled() bool {
 	return IsFVMetricsEnabled() || IsMissingKeyMetricsEnabled()
 }
@@ -35,14 +34,12 @@ func GetOnlineStoreType(config *registry.RepoConfig) string {
 	return "unknown"
 }
 
-// ParseSampleRate reads FEAST_METRICS_SAMPLE_RATE for lookup metrics.
-// Returns DefaultLookupSampleRate (1.0) if unset or invalid.
-func ParseSampleRate() float64 {
+// ParseLookupSampleRate reads FEAST_METRICS_SAMPLE_RATE for lookup metrics.
+func ParseLookupSampleRate() float64 {
 	return parseRate(os.Getenv("FEAST_METRICS_SAMPLE_RATE"), DefaultLookupSampleRate)
 }
 
 // ParseFVSampleRate reads FEAST_FV_METRICS_SAMPLE_RATE for feature-view read metrics.
-// Returns DefaultFVSampleRate (0.01) if unset or invalid.
 func ParseFVSampleRate() float64 {
 	return parseRate(os.Getenv("FEAST_FV_METRICS_SAMPLE_RATE"), DefaultFVSampleRate)
 }

--- a/go/internal/feast/metrics/config.go
+++ b/go/internal/feast/metrics/config.go
@@ -12,6 +12,11 @@ func IsMissingKeyMetricsEnabled() bool {
 	return strings.ToLower(os.Getenv("ENABLE_MISSING_KEY_METRICS")) == "true"
 }
 
+func IsFVMetricsEnabled() bool {
+	return strings.ToLower(os.Getenv("ENABLE_FV_LEVEL_METRICS")) == "true" ||
+		IsMissingKeyMetricsEnabled()
+}
+
 func GetOnlineStoreType(config *registry.RepoConfig) string {
 	if storeType, ok := config.OnlineStore["type"]; ok {
 		return fmt.Sprintf("%v", storeType)

--- a/go/internal/feast/metrics/config.go
+++ b/go/internal/feast/metrics/config.go
@@ -9,15 +9,23 @@ import (
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 )
 
-const DefaultSampleRate = 0.01
+const (
+	DefaultLookupSampleRate = 1.0
+	DefaultFVSampleRate     = 0.01
+)
 
 func IsMissingKeyMetricsEnabled() bool {
 	return strings.ToLower(os.Getenv("ENABLE_MISSING_KEY_METRICS")) == "true"
 }
 
 func IsFVMetricsEnabled() bool {
-	return strings.ToLower(os.Getenv("ENABLE_FV_LEVEL_METRICS")) == "true" ||
-		IsMissingKeyMetricsEnabled()
+	return strings.ToLower(os.Getenv("ENABLE_FV_LEVEL_METRICS")) == "true"
+}
+
+// IsMetricsClientEnabled returns true if any metrics feature is enabled.
+// Use this in main.go to gate statsd client construction.
+func IsMetricsClientEnabled() bool {
+	return IsFVMetricsEnabled() || IsMissingKeyMetricsEnabled()
 }
 
 func GetOnlineStoreType(config *registry.RepoConfig) string {
@@ -27,16 +35,25 @@ func GetOnlineStoreType(config *registry.RepoConfig) string {
 	return "unknown"
 }
 
-// ParseSampleRate reads FEAST_METRICS_SAMPLE_RATE from the environment once.
-// Returns DefaultSampleRate (0.01) if unset or invalid.
+// ParseSampleRate reads FEAST_METRICS_SAMPLE_RATE for lookup metrics.
+// Returns DefaultLookupSampleRate (1.0) if unset or invalid.
 func ParseSampleRate() float64 {
-	rateStr := os.Getenv("FEAST_METRICS_SAMPLE_RATE")
+	return parseRate(os.Getenv("FEAST_METRICS_SAMPLE_RATE"), DefaultLookupSampleRate)
+}
+
+// ParseFVSampleRate reads FEAST_FV_METRICS_SAMPLE_RATE for feature-view read metrics.
+// Returns DefaultFVSampleRate (0.01) if unset or invalid.
+func ParseFVSampleRate() float64 {
+	return parseRate(os.Getenv("FEAST_FV_METRICS_SAMPLE_RATE"), DefaultFVSampleRate)
+}
+
+func parseRate(rateStr string, defaultRate float64) float64 {
 	if rateStr == "" {
-		return DefaultSampleRate
+		return defaultRate
 	}
 	rate, err := strconv.ParseFloat(rateStr, 64)
 	if err != nil || rate <= 0 || rate > 1.0 {
-		return DefaultSampleRate
+		return defaultRate
 	}
 	return rate
 }

--- a/go/internal/feast/metrics/config_test.go
+++ b/go/internal/feast/metrics/config_test.go
@@ -7,6 +7,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseFVSampleRate_Default(t *testing.T) {
+	os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
+	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
+	assert.Equal(t, DefaultFVSampleRate, ParseFVSampleRate())
+}
+
+func TestParseFVSampleRate_FVSpecificEnvVar(t *testing.T) {
+	os.Setenv("FEAST_FV_METRICS_SAMPLE_RATE", "0.2")
+	defer os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
+	assert.Equal(t, 0.2, ParseFVSampleRate())
+}
+
+func TestParseFVSampleRate_IndependentOfLookupEnvVar(t *testing.T) {
+	os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
+	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.3")
+	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
+	// FV rate should not pick up the lookup env var — uses its own default.
+	assert.Equal(t, DefaultFVSampleRate, ParseFVSampleRate())
+}
+
+func TestParseSampleRate_IndependentOfFVEnvVar(t *testing.T) {
+	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
+	os.Setenv("FEAST_FV_METRICS_SAMPLE_RATE", "0.2")
+	defer os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
+	// Lookup rate should not pick up the FV env var — uses its own default.
+	assert.Equal(t, DefaultLookupSampleRate, ParseSampleRate())
+}
+
+func TestIsMetricsClientEnabled(t *testing.T) {
+	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+	assert.False(t, IsMetricsClientEnabled())
+
+	os.Setenv("ENABLE_FV_LEVEL_METRICS", "true")
+	assert.True(t, IsMetricsClientEnabled())
+	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+
+	os.Setenv("ENABLE_MISSING_KEY_METRICS", "true")
+	assert.True(t, IsMetricsClientEnabled())
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+}
+
 func TestGetStatsDAddress(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/go/internal/feast/metrics/config_test.go
+++ b/go/internal/feast/metrics/config_test.go
@@ -19,22 +19,6 @@ func TestParseFVSampleRate_FVSpecificEnvVar(t *testing.T) {
 	assert.Equal(t, 0.2, ParseFVSampleRate())
 }
 
-func TestParseFVSampleRate_IndependentOfLookupEnvVar(t *testing.T) {
-	os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
-	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.3")
-	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-	// FV rate should not pick up the lookup env var — uses its own default.
-	assert.Equal(t, DefaultFVSampleRate, ParseFVSampleRate())
-}
-
-func TestParseSampleRate_IndependentOfFVEnvVar(t *testing.T) {
-	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-	os.Setenv("FEAST_FV_METRICS_SAMPLE_RATE", "0.2")
-	defer os.Unsetenv("FEAST_FV_METRICS_SAMPLE_RATE")
-	// Lookup rate should not pick up the FV env var — uses its own default.
-	assert.Equal(t, DefaultLookupSampleRate, ParseSampleRate())
-}
-
 func TestIsMetricsClientEnabled(t *testing.T) {
 	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
 	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -2,8 +2,6 @@ package metrics
 
 import (
 	"math/rand"
-	"os"
-	"strconv"
 )
 
 const (
@@ -12,32 +10,29 @@ const (
 	FVReadErrorsMetric   = "mlpfs.featureserver.fv_read_errors"
 )
 
+// FeatureViewReadMetrics is a singleton that emits per-feature-view read metrics.
+// Create once at server startup via NewFeatureViewReadMetrics and reuse across requests.
 type FeatureViewReadMetrics struct {
-	project     string
-	onlineStore string
-	client      StatsdClient
-	sampleRate  float64
+	baseTags   []string
+	client     StatsdClient
+	sampleRate float64
 }
 
-func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient) *FeatureViewReadMetrics {
+// NewFeatureViewReadMetrics creates a reusable metrics emitter. The sampleRate
+// is parsed once at startup (see ParseSampleRate) rather than reading the
+// environment on every request.
+func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient, sampleRate float64) *FeatureViewReadMetrics {
 	if client == nil {
 		return nil
 	}
 
-	sampleRate := 1.0
-	if rateStr := os.Getenv("FEAST_METRICS_SAMPLE_RATE"); rateStr != "" {
-		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
-			if rate > 0 && rate <= 1.0 {
-				sampleRate = rate
-			}
-		}
-	}
-
 	return &FeatureViewReadMetrics{
-		project:     project,
-		onlineStore: onlineStore,
-		client:      client,
-		sampleRate:  sampleRate,
+		baseTags: []string{
+			"project:" + project,
+			"online_store_type:" + onlineStore,
+		},
+		client:     client,
+		sampleRate: sampleRate,
 	}
 }
 
@@ -51,15 +46,10 @@ func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float
 		return
 	}
 
-	baseTags := []string{
-		"project:" + m.project,
-		"online_store_type:" + m.onlineStore,
-	}
-
 	for _, fvName := range featureViewNames {
-		tags := make([]string, len(baseTags)+1)
-		copy(tags, baseTags)
-		tags[len(baseTags)] = "feature_view:" + fvName
+		tags := make([]string, len(m.baseTags)+1)
+		copy(tags, m.baseTags)
+		tags[len(m.baseTags)] = "feature_view:" + fvName
 
 		m.client.Distribution(FVReadLatencyMetric, latencyMs, tags, 1.0)
 		m.client.Count(FVReadRequestsMetric, 1, tags, 1.0)

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -6,6 +6,12 @@ import (
 	"strconv"
 )
 
+const (
+	FVReadLatencyMetric  = "mlpfs.featureserver.fv_read_latency_ms"
+	FVReadRequestsMetric = "mlpfs.featureserver.fv_read_requests"
+	FVReadErrorsMetric   = "mlpfs.featureserver.fv_read_errors"
+)
+
 type FeatureViewReadMetrics struct {
 	project     string
 	onlineStore string
@@ -55,11 +61,11 @@ func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float
 		copy(tags, baseTags)
 		tags[len(baseTags)] = "feature_view:" + fvName
 
-		m.client.Distribution("mlpfs.featureserver.fv_read_latency_ms", latencyMs, tags, 1.0)
-		m.client.Count("mlpfs.featureserver.fv_read_requests", 1, tags, 1.0)
+		m.client.Distribution(FVReadLatencyMetric, latencyMs, tags, 1.0)
+		m.client.Count(FVReadRequestsMetric, 1, tags, 1.0)
 
 		if hasError {
-			m.client.Count("mlpfs.featureserver.fv_read_errors", 1, tags, 1.0)
+			m.client.Count(FVReadErrorsMetric, 1, tags, 1.0)
 		}
 	}
 }

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -28,19 +28,22 @@ func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient,
 	}
 }
 
+func (m *FeatureViewReadMetrics) fvTags(fvName string) []string {
+	tags := make([]string, len(m.baseTags)+1)
+	copy(tags, m.baseTags)
+	tags[len(m.baseTags)] = "feature_view:" + fvName
+	return tags
+}
+
 func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float64, hasError bool) {
 	if m == nil || m.client == nil {
 		return
 	}
 
 	for _, fvName := range featureViewNames {
-		tags := make([]string, len(m.baseTags)+1)
-		copy(tags, m.baseTags)
-		tags[len(m.baseTags)] = "feature_view:" + fvName
-
+		tags := m.fvTags(fvName)
 		m.client.Distribution(FVReadLatencyMetric, latencyMs, tags, m.sampleRate)
 		m.client.Count(FVReadRequestsMetric, 1, tags, m.sampleRate)
-
 		if hasError {
 			m.client.Count(FVReadErrorsMetric, 1, tags, m.sampleRate)
 		}

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+)
+
+type FeatureViewReadMetrics struct {
+	project     string
+	onlineStore string
+	client      StatsdClient
+	sampleRate  float64
+}
+
+func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient) *FeatureViewReadMetrics {
+	if client == nil {
+		return nil
+	}
+
+	sampleRate := 1.0
+	if rateStr := os.Getenv("FEAST_METRICS_SAMPLE_RATE"); rateStr != "" {
+		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
+			if rate > 0 && rate <= 1.0 {
+				sampleRate = rate
+			}
+		}
+	}
+
+	return &FeatureViewReadMetrics{
+		project:     project,
+		onlineStore: onlineStore,
+		client:      client,
+		sampleRate:  sampleRate,
+	}
+}
+
+// Emit emits latency, request count, and optionally errors for each feature view.
+func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float64, hasError bool) {
+	if m == nil || m.client == nil {
+		return
+	}
+
+	if m.sampleRate < 1.0 && rand.Float64() > m.sampleRate {
+		return
+	}
+
+	baseTags := []string{
+		"project:" + m.project,
+		"online_store_type:" + m.onlineStore,
+	}
+
+	for _, fvName := range featureViewNames {
+		tags := make([]string, len(baseTags)+1)
+		copy(tags, baseTags)
+		tags[len(baseTags)] = "feature_view:" + fvName
+
+		m.client.Distribution("mlpfs.featureserver.fv_read_latency_ms", latencyMs, tags, 1.0)
+		m.client.Count("mlpfs.featureserver.fv_read_requests", 1, tags, 1.0)
+
+		if hasError {
+			m.client.Count("mlpfs.featureserver.fv_read_errors", 1, tags, 1.0)
+		}
+	}
+}

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -6,17 +6,13 @@ const (
 	FVReadErrorsMetric   = "mlpfs.featureserver.fv_read_errors"
 )
 
-// FeatureViewReadMetrics is a singleton that emits per-feature-view read metrics.
-// Create once at server startup via NewFeatureViewReadMetrics and reuse across requests.
+// FeatureViewReadMetrics emits per-feature-view read metrics (latency, requests, errors).
 type FeatureViewReadMetrics struct {
 	baseTags   []string
 	client     StatsdClient
 	sampleRate float64
 }
 
-// NewFeatureViewReadMetrics creates a reusable metrics emitter. The sampleRate
-// is parsed once at startup (see ParseSampleRate) rather than reading the
-// environment on every request.
 func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient, sampleRate float64) *FeatureViewReadMetrics {
 	if client == nil {
 		return nil
@@ -32,7 +28,6 @@ func NewFeatureViewReadMetrics(project, onlineStore string, client StatsdClient,
 	}
 }
 
-// Emit emits latency, request count, and optionally errors for each feature view.
 func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float64, hasError bool) {
 	if m == nil || m.client == nil {
 		return

--- a/go/internal/feast/metrics/fv_read_metrics.go
+++ b/go/internal/feast/metrics/fv_read_metrics.go
@@ -1,9 +1,5 @@
 package metrics
 
-import (
-	"math/rand"
-)
-
 const (
 	FVReadLatencyMetric  = "mlpfs.featureserver.fv_read_latency_ms"
 	FVReadRequestsMetric = "mlpfs.featureserver.fv_read_requests"
@@ -42,20 +38,16 @@ func (m *FeatureViewReadMetrics) Emit(featureViewNames []string, latencyMs float
 		return
 	}
 
-	if m.sampleRate < 1.0 && rand.Float64() > m.sampleRate {
-		return
-	}
-
 	for _, fvName := range featureViewNames {
 		tags := make([]string, len(m.baseTags)+1)
 		copy(tags, m.baseTags)
 		tags[len(m.baseTags)] = "feature_view:" + fvName
 
-		m.client.Distribution(FVReadLatencyMetric, latencyMs, tags, 1.0)
-		m.client.Count(FVReadRequestsMetric, 1, tags, 1.0)
+		m.client.Distribution(FVReadLatencyMetric, latencyMs, tags, m.sampleRate)
+		m.client.Count(FVReadRequestsMetric, 1, tags, m.sampleRate)
 
 		if hasError {
-			m.client.Count(FVReadErrorsMetric, 1, tags, 1.0)
+			m.client.Count(FVReadErrorsMetric, 1, tags, m.sampleRate)
 		}
 	}
 }

--- a/go/internal/feast/metrics/fv_read_metrics_test.go
+++ b/go/internal/feast/metrics/fv_read_metrics_test.go
@@ -14,7 +14,7 @@ func TestFVMetrics_EmitLatencyDistribution(t *testing.T) {
 	m.Emit([]string{"hotel_fv"}, 42.5, false)
 
 	assert.Len(t, fake.distCalls, 1)
-	assert.Equal(t, "mlpfs.featureserver.fv_read_latency_ms", fake.distCalls[0].name)
+	assert.Equal(t, FVReadLatencyMetric, fake.distCalls[0].name)
 	assert.Equal(t, 42.5, fake.distCalls[0].value)
 	assert.Contains(t, fake.distCalls[0].tags, "project:proj")
 	assert.Contains(t, fake.distCalls[0].tags, "online_store_type:redis")
@@ -27,7 +27,7 @@ func TestFVMetrics_EmitRequestsCount(t *testing.T) {
 
 	m.Emit([]string{"hotel_fv"}, 10.0, false)
 
-	requestCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_requests")
+	requestCalls := filterCalls(fake.calls, FVReadRequestsMetric)
 	assert.Len(t, requestCalls, 1)
 	assert.Equal(t, int64(1), requestCalls[0].value)
 	assert.Contains(t, requestCalls[0].tags, "feature_view:hotel_fv")
@@ -39,7 +39,7 @@ func TestFVMetrics_EmitErrors(t *testing.T) {
 
 	m.Emit([]string{"hotel_fv"}, 100.0, true)
 
-	errorCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_errors")
+	errorCalls := filterCalls(fake.calls, FVReadErrorsMetric)
 	assert.Len(t, errorCalls, 1)
 	assert.Equal(t, int64(1), errorCalls[0].value)
 	assert.Contains(t, errorCalls[0].tags, "feature_view:hotel_fv")
@@ -51,7 +51,7 @@ func TestFVMetrics_NoErrorsWhenSuccess(t *testing.T) {
 
 	m.Emit([]string{"hotel_fv"}, 50.0, false)
 
-	errorCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_errors")
+	errorCalls := filterCalls(fake.calls, FVReadErrorsMetric)
 	assert.Len(t, errorCalls, 0)
 }
 
@@ -65,7 +65,7 @@ func TestFVMetrics_MultipleFeatureViews(t *testing.T) {
 	assert.Len(t, fake.distCalls, 3)
 
 	// 3 request counts
-	requestCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_requests")
+	requestCalls := filterCalls(fake.calls, FVReadRequestsMetric)
 	assert.Len(t, requestCalls, 3)
 
 	// All have same latency

--- a/go/internal/feast/metrics/fv_read_metrics_test.go
+++ b/go/internal/feast/metrics/fv_read_metrics_test.go
@@ -1,0 +1,132 @@
+package metrics
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFVMetrics_EmitLatencyDistribution(t *testing.T) {
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+
+	m.Emit([]string{"hotel_fv"}, 42.5, false)
+
+	assert.Len(t, fake.distCalls, 1)
+	assert.Equal(t, "mlpfs.featureserver.fv_read_latency_ms", fake.distCalls[0].name)
+	assert.Equal(t, 42.5, fake.distCalls[0].value)
+	assert.Contains(t, fake.distCalls[0].tags, "project:proj")
+	assert.Contains(t, fake.distCalls[0].tags, "online_store_type:redis")
+	assert.Contains(t, fake.distCalls[0].tags, "feature_view:hotel_fv")
+}
+
+func TestFVMetrics_EmitRequestsCount(t *testing.T) {
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+
+	m.Emit([]string{"hotel_fv"}, 10.0, false)
+
+	requestCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_requests")
+	assert.Len(t, requestCalls, 1)
+	assert.Equal(t, int64(1), requestCalls[0].value)
+	assert.Contains(t, requestCalls[0].tags, "feature_view:hotel_fv")
+}
+
+func TestFVMetrics_EmitErrors(t *testing.T) {
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+
+	m.Emit([]string{"hotel_fv"}, 100.0, true)
+
+	errorCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_errors")
+	assert.Len(t, errorCalls, 1)
+	assert.Equal(t, int64(1), errorCalls[0].value)
+	assert.Contains(t, errorCalls[0].tags, "feature_view:hotel_fv")
+}
+
+func TestFVMetrics_NoErrorsWhenSuccess(t *testing.T) {
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+
+	m.Emit([]string{"hotel_fv"}, 50.0, false)
+
+	errorCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_errors")
+	assert.Len(t, errorCalls, 0)
+}
+
+func TestFVMetrics_MultipleFeatureViews(t *testing.T) {
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "valkey", fake)
+
+	m.Emit([]string{"hotel_fv", "user_fv", "booking_fv"}, 75.0, false)
+
+	// 3 latency distributions
+	assert.Len(t, fake.distCalls, 3)
+
+	// 3 request counts
+	requestCalls := filterCalls(fake.calls, "mlpfs.featureserver.fv_read_requests")
+	assert.Len(t, requestCalls, 3)
+
+	// All have same latency
+	for _, dc := range fake.distCalls {
+		assert.Equal(t, 75.0, dc.value)
+	}
+
+	// Check each FV is tagged
+	fvTags := make(map[string]bool)
+	for _, dc := range fake.distCalls {
+		fvTags[findTag(dc.tags, "feature_view:")] = true
+	}
+	assert.True(t, fvTags["hotel_fv"])
+	assert.True(t, fvTags["user_fv"])
+	assert.True(t, fvTags["booking_fv"])
+}
+
+func TestFVMetrics_NilClient(t *testing.T) {
+	m := NewFeatureViewReadMetrics("proj", "redis", nil)
+	assert.Nil(t, m)
+}
+
+func TestFVMetrics_NilSafe(t *testing.T) {
+	var m *FeatureViewReadMetrics
+	m.Emit([]string{"fv"}, 10.0, false) // should not panic
+}
+
+func TestFVMetrics_Sampling(t *testing.T) {
+	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.5")
+	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
+
+	fake := &fakeStatsdClient{}
+	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+
+	assert.Equal(t, 0.5, m.sampleRate)
+
+	// Emit many times — should skip roughly half
+	emitted := 0
+	for i := 0; i < 100; i++ {
+		fake.distCalls = nil
+		m.Emit([]string{"fv"}, 10.0, false)
+		if len(fake.distCalls) > 0 {
+			emitted++
+		}
+	}
+
+	// With 50% sampling, should emit roughly 50 times (allow wide margin)
+	assert.Greater(t, emitted, 20)
+	assert.Less(t, emitted, 80)
+}
+
+func TestIsFVMetricsEnabled(t *testing.T) {
+	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+	assert.False(t, IsFVMetricsEnabled())
+
+	os.Setenv("ENABLE_FV_LEVEL_METRICS", "true")
+	assert.True(t, IsFVMetricsEnabled())
+	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+
+	os.Setenv("ENABLE_MISSING_KEY_METRICS", "true")
+	assert.True(t, IsFVMetricsEnabled())
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+}

--- a/go/internal/feast/metrics/fv_read_metrics_test.go
+++ b/go/internal/feast/metrics/fv_read_metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFVMetrics_EmitLatencyDistribution(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+	m := NewFeatureViewReadMetrics("proj", "redis", fake, 1.0)
 
 	m.Emit([]string{"hotel_fv"}, 42.5, false)
 
@@ -23,7 +23,7 @@ func TestFVMetrics_EmitLatencyDistribution(t *testing.T) {
 
 func TestFVMetrics_EmitRequestsCount(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+	m := NewFeatureViewReadMetrics("proj", "redis", fake, 1.0)
 
 	m.Emit([]string{"hotel_fv"}, 10.0, false)
 
@@ -35,7 +35,7 @@ func TestFVMetrics_EmitRequestsCount(t *testing.T) {
 
 func TestFVMetrics_EmitErrors(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+	m := NewFeatureViewReadMetrics("proj", "redis", fake, 1.0)
 
 	m.Emit([]string{"hotel_fv"}, 100.0, true)
 
@@ -47,7 +47,7 @@ func TestFVMetrics_EmitErrors(t *testing.T) {
 
 func TestFVMetrics_NoErrorsWhenSuccess(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+	m := NewFeatureViewReadMetrics("proj", "redis", fake, 1.0)
 
 	m.Emit([]string{"hotel_fv"}, 50.0, false)
 
@@ -57,7 +57,7 @@ func TestFVMetrics_NoErrorsWhenSuccess(t *testing.T) {
 
 func TestFVMetrics_MultipleFeatureViews(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "valkey", fake)
+	m := NewFeatureViewReadMetrics("proj", "valkey", fake, 1.0)
 
 	m.Emit([]string{"hotel_fv", "user_fv", "booking_fv"}, 75.0, false)
 
@@ -84,7 +84,7 @@ func TestFVMetrics_MultipleFeatureViews(t *testing.T) {
 }
 
 func TestFVMetrics_NilClient(t *testing.T) {
-	m := NewFeatureViewReadMetrics("proj", "redis", nil)
+	m := NewFeatureViewReadMetrics("proj", "redis", nil, 1.0)
 	assert.Nil(t, m)
 }
 
@@ -94,11 +94,8 @@ func TestFVMetrics_NilSafe(t *testing.T) {
 }
 
 func TestFVMetrics_Sampling(t *testing.T) {
-	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.5")
-	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-
 	fake := &fakeStatsdClient{}
-	m := NewFeatureViewReadMetrics("proj", "redis", fake)
+	m := NewFeatureViewReadMetrics("proj", "redis", fake, 0.5)
 
 	assert.Equal(t, 0.5, m.sampleRate)
 

--- a/go/internal/feast/metrics/fv_read_metrics_test.go
+++ b/go/internal/feast/metrics/fv_read_metrics_test.go
@@ -99,19 +99,13 @@ func TestFVMetrics_Sampling(t *testing.T) {
 
 	assert.Equal(t, 0.5, m.sampleRate)
 
-	// Emit many times — should skip roughly half
-	emitted := 0
-	for i := 0; i < 100; i++ {
-		fake.distCalls = nil
-		m.Emit([]string{"fv"}, 10.0, false)
-		if len(fake.distCalls) > 0 {
-			emitted++
-		}
-	}
+	m.Emit([]string{"fv"}, 10.0, false)
 
-	// With 50% sampling, should emit roughly 50 times (allow wide margin)
-	assert.Greater(t, emitted, 20)
-	assert.Less(t, emitted, 80)
+	// Always emits; sample rate is passed to the statsd client, not used as a local guard.
+	assert.Len(t, fake.distCalls, 1)
+	assert.Equal(t, float64(0.5), fake.distCalls[0].rate)
+	assert.Len(t, fake.calls, 1)
+	assert.Equal(t, float64(0.5), fake.calls[0].rate)
 }
 
 func TestIsFVMetricsEnabled(t *testing.T) {
@@ -123,7 +117,9 @@ func TestIsFVMetricsEnabled(t *testing.T) {
 	assert.True(t, IsFVMetricsEnabled())
 	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
 
+	// ENABLE_MISSING_KEY_METRICS no longer implies IsFVMetricsEnabled.
 	os.Setenv("ENABLE_MISSING_KEY_METRICS", "true")
-	assert.True(t, IsFVMetricsEnabled())
+	assert.False(t, IsFVMetricsEnabled())
+	assert.True(t, IsMetricsClientEnabled())
 	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
 }

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"math/rand"
 	"strings"
 
 	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
@@ -103,44 +102,35 @@ func (m *LookupMetricsAggregator) Emit() {
 		return
 	}
 
-	if m.sampleRate < 1.0 && rand.Float64() > m.sampleRate {
-		return
-	}
-
-	multiplier := 1.0 / m.sampleRate
-
 	for featureID, count := range m.notFound {
 		if count == 0 {
 			continue
 		}
-		adjustedCount := int64(float64(count) * multiplier)
 		tags := make([]string, len(m.baseTags)+2)
 		copy(tags, m.baseTags)
 		tags[len(m.baseTags)] = "feature:" + featureID
 		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count(LookupNotFoundMetric, adjustedCount, tags, 1.0)
+		m.client.Count(LookupNotFoundMetric, count, tags, m.sampleRate)
 	}
 
 	for featureID, count := range m.nullOrExpired {
 		if count == 0 {
 			continue
 		}
-		adjustedCount := int64(float64(count) * multiplier)
 		tags := make([]string, len(m.baseTags)+2)
 		copy(tags, m.baseTags)
 		tags[len(m.baseTags)] = "feature:" + featureID
 		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count(LookupNullOrExpiredMetric, adjustedCount, tags, 1.0)
+		m.client.Count(LookupNullOrExpiredMetric, count, tags, m.sampleRate)
 	}
 
 	for fvName, count := range m.totalByFV {
 		if count == 0 {
 			continue
 		}
-		adjustedCount := int64(float64(count) * multiplier)
 		tags := make([]string, len(m.baseTags)+1)
 		copy(tags, m.baseTags)
 		tags[len(m.baseTags)] = "feature_view:" + fvName
-		m.client.Count(LookupRequestsMetric, adjustedCount, tags, 1.0)
+		m.client.Count(LookupRequestsMetric, count, tags, m.sampleRate)
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -28,7 +28,7 @@ func extractFeatureView(featureName string) string {
 type LookupMetricsAggregator struct {
 	notFound      map[string]int64
 	nullOrExpired map[string]int64
-	totalByFV     map[string]int64
+	total         map[string]int64
 	baseTags      []string
 	client        StatsdClient
 	sampleRate    float64
@@ -46,7 +46,7 @@ func NewLookupMetricsAggregator(
 	return &LookupMetricsAggregator{
 		notFound:      make(map[string]int64),
 		nullOrExpired: make(map[string]int64),
-		totalByFV:     make(map[string]int64),
+		total:         make(map[string]int64),
 		baseTags: []string{
 			"project:" + project,
 			"online_store_type:" + onlineStore,
@@ -60,7 +60,7 @@ func (m *LookupMetricsAggregator) Record(featureID string, status serving.FieldS
 	if m == nil {
 		return
 	}
-	m.totalByFV[extractFeatureView(featureID)]++
+	m.total[featureID]++
 	switch status {
 	case serving.FieldStatus_NOT_FOUND:
 		m.notFound[featureID]++
@@ -93,40 +93,32 @@ func (m *LookupMetricsAggregator) RecordFromRangeFeatureVectors(vectors []*onlin
 	}
 }
 
+func (m *LookupMetricsAggregator) featureTags(featureID string) []string {
+	tags := make([]string, len(m.baseTags)+2)
+	copy(tags, m.baseTags)
+	tags[len(m.baseTags)] = "feature:" + featureID
+	tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
+	return tags
+}
+
 func (m *LookupMetricsAggregator) Emit() {
 	if m == nil || m.client == nil {
 		return
 	}
 
 	for featureID, count := range m.notFound {
-		if count == 0 {
-			continue
+		if count > 0 {
+			m.client.Count(LookupNotFoundMetric, count, m.featureTags(featureID), m.sampleRate)
 		}
-		tags := make([]string, len(m.baseTags)+2)
-		copy(tags, m.baseTags)
-		tags[len(m.baseTags)] = "feature:" + featureID
-		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count(LookupNotFoundMetric, count, tags, m.sampleRate)
 	}
-
 	for featureID, count := range m.nullOrExpired {
-		if count == 0 {
-			continue
+		if count > 0 {
+			m.client.Count(LookupNullOrExpiredMetric, count, m.featureTags(featureID), m.sampleRate)
 		}
-		tags := make([]string, len(m.baseTags)+2)
-		copy(tags, m.baseTags)
-		tags[len(m.baseTags)] = "feature:" + featureID
-		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count(LookupNullOrExpiredMetric, count, tags, m.sampleRate)
 	}
-
-	for fvName, count := range m.totalByFV {
-		if count == 0 {
-			continue
+	for featureID, count := range m.total {
+		if count > 0 {
+			m.client.Count(LookupRequestsMetric, count, m.featureTags(featureID), m.sampleRate)
 		}
-		tags := make([]string, len(m.baseTags)+1)
-		copy(tags, m.baseTags)
-		tags[len(m.baseTags)] = "feature_view:" + fvName
-		m.client.Count(LookupRequestsMetric, count, tags, m.sampleRate)
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -24,9 +24,7 @@ func extractFeatureView(featureName string) string {
 	return "unknown"
 }
 
-// LookupMetricsAggregator accumulates per-feature lookup statuses within a single
-// request and emits aggregated counts. A new instance is needed per request (because
-// it accumulates state), but the sampleRate is parsed once at startup.
+// LookupMetricsAggregator accumulates per-feature lookup statuses for a single request and emits aggregated counts.
 type LookupMetricsAggregator struct {
 	notFound      map[string]int64
 	nullOrExpired map[string]int64
@@ -36,8 +34,6 @@ type LookupMetricsAggregator struct {
 	sampleRate    float64
 }
 
-// NewLookupMetricsAggregator creates a per-request aggregator. The sampleRate should
-// come from ParseSampleRate() called once at server startup.
 func NewLookupMetricsAggregator(
 	project, onlineStore string,
 	client StatsdClient,

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -2,8 +2,6 @@ package metrics
 
 import (
 	"math/rand"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
@@ -27,42 +25,39 @@ func extractFeatureView(featureName string) string {
 	return "unknown"
 }
 
+// LookupMetricsAggregator accumulates per-feature lookup statuses within a single
+// request and emits aggregated counts. A new instance is needed per request (because
+// it accumulates state), but the sampleRate is parsed once at startup.
 type LookupMetricsAggregator struct {
 	notFound      map[string]int64
 	nullOrExpired map[string]int64
 	totalByFV     map[string]int64
-	project       string
-	onlineStore   string
+	baseTags      []string
 	client        StatsdClient
 	sampleRate    float64
 }
 
+// NewLookupMetricsAggregator creates a per-request aggregator. The sampleRate should
+// come from ParseSampleRate() called once at server startup.
 func NewLookupMetricsAggregator(
 	project, onlineStore string,
 	client StatsdClient,
+	sampleRate float64,
 ) *LookupMetricsAggregator {
 	if client == nil {
 		return nil
-	}
-
-	// Read sampling rate from environment (default: 1.0 = no sampling)
-	sampleRate := 1.0
-	if rateStr := os.Getenv("FEAST_METRICS_SAMPLE_RATE"); rateStr != "" {
-		if rate, err := strconv.ParseFloat(rateStr, 64); err == nil {
-			if rate > 0 && rate <= 1.0 {
-				sampleRate = rate
-			}
-		}
 	}
 
 	return &LookupMetricsAggregator{
 		notFound:      make(map[string]int64),
 		nullOrExpired: make(map[string]int64),
 		totalByFV:     make(map[string]int64),
-		project:       project,
-		onlineStore:   onlineStore,
-		client:        client,
-		sampleRate:    sampleRate,
+		baseTags: []string{
+			"project:" + project,
+			"online_store_type:" + onlineStore,
+		},
+		client:     client,
+		sampleRate: sampleRate,
 	}
 }
 
@@ -108,30 +103,21 @@ func (m *LookupMetricsAggregator) Emit() {
 		return
 	}
 
-	// Probabilistic sampling: skip this request's metrics based on sample_rate
 	if m.sampleRate < 1.0 && rand.Float64() > m.sampleRate {
 		return
 	}
 
-	// Calculate multiplier to preserve statistical accuracy
-	// If sampleRate=0.1, we only emit 10% of the time, so multiply counts by 10
 	multiplier := 1.0 / m.sampleRate
-
-	baseTags := []string{
-		"project:" + m.project,
-		"online_store_type:" + m.onlineStore,
-	}
 
 	for featureID, count := range m.notFound {
 		if count == 0 {
 			continue
 		}
-		// Adjust count to preserve accuracy when sampling
 		adjustedCount := int64(float64(count) * multiplier)
-		tags := make([]string, len(baseTags)+2)
-		copy(tags, baseTags)
-		tags[len(baseTags)] = "feature:" + featureID
-		tags[len(baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
+		tags := make([]string, len(m.baseTags)+2)
+		copy(tags, m.baseTags)
+		tags[len(m.baseTags)] = "feature:" + featureID
+		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
 		m.client.Count(LookupNotFoundMetric, adjustedCount, tags, 1.0)
 	}
 
@@ -140,10 +126,10 @@ func (m *LookupMetricsAggregator) Emit() {
 			continue
 		}
 		adjustedCount := int64(float64(count) * multiplier)
-		tags := make([]string, len(baseTags)+2)
-		copy(tags, baseTags)
-		tags[len(baseTags)] = "feature:" + featureID
-		tags[len(baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
+		tags := make([]string, len(m.baseTags)+2)
+		copy(tags, m.baseTags)
+		tags[len(m.baseTags)] = "feature:" + featureID
+		tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
 		m.client.Count(LookupNullOrExpiredMetric, adjustedCount, tags, 1.0)
 	}
 
@@ -152,9 +138,9 @@ func (m *LookupMetricsAggregator) Emit() {
 			continue
 		}
 		adjustedCount := int64(float64(count) * multiplier)
-		tags := make([]string, len(baseTags)+1)
-		copy(tags, baseTags)
-		tags[len(baseTags)] = "feature_view:" + fvName
+		tags := make([]string, len(m.baseTags)+1)
+		copy(tags, m.baseTags)
+		tags[len(m.baseTags)] = "feature_view:" + fvName
 		m.client.Count(LookupRequestsMetric, adjustedCount, tags, 1.0)
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -24,6 +24,7 @@ func extractFeatureView(featureName string) string {
 type LookupMetricsAggregator struct {
 	notFound      map[string]int64
 	nullOrExpired map[string]int64
+	totalByFV     map[string]int64
 	project       string
 	onlineStore   string
 	client        StatsdClient
@@ -51,6 +52,7 @@ func NewLookupMetricsAggregator(
 	return &LookupMetricsAggregator{
 		notFound:      make(map[string]int64),
 		nullOrExpired: make(map[string]int64),
+		totalByFV:     make(map[string]int64),
 		project:       project,
 		onlineStore:   onlineStore,
 		client:        client,
@@ -62,6 +64,7 @@ func (m *LookupMetricsAggregator) Record(featureID string, status serving.FieldS
 	if m == nil {
 		return
 	}
+	m.totalByFV[extractFeatureView(featureID)]++
 	switch status {
 	case serving.FieldStatus_NOT_FOUND:
 		m.notFound[featureID]++
@@ -136,5 +139,16 @@ func (m *LookupMetricsAggregator) Emit() {
 		tags[len(baseTags)] = "feature:" + featureID
 		tags[len(baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
 		m.client.Count("mlpfs.featureserver.feature_lookup_null_or_expired", adjustedCount, tags, 1.0)
+	}
+
+	for fvName, count := range m.totalByFV {
+		if count == 0 {
+			continue
+		}
+		adjustedCount := int64(float64(count) * multiplier)
+		tags := make([]string, len(baseTags)+1)
+		copy(tags, baseTags)
+		tags[len(baseTags)] = "feature_view:" + fvName
+		m.client.Count("mlpfs.featureserver.feature_lookup_requests", adjustedCount, tags, 1.0)
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -10,6 +10,12 @@ import (
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 )
 
+const (
+	LookupNotFoundMetric      = "mlpfs.featureserver.feature_lookup_not_found"
+	LookupNullOrExpiredMetric = "mlpfs.featureserver.feature_lookup_null_or_expired"
+	LookupRequestsMetric      = "mlpfs.featureserver.feature_lookup_requests"
+)
+
 // extractFeatureView extracts the feature view name from a full feature name.
 // Feature names follow the format: feature_view__feature_name
 // Example: "hotel_fv__price" -> "hotel_fv"
@@ -126,7 +132,7 @@ func (m *LookupMetricsAggregator) Emit() {
 		copy(tags, baseTags)
 		tags[len(baseTags)] = "feature:" + featureID
 		tags[len(baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count("mlpfs.featureserver.feature_lookup_not_found", adjustedCount, tags, 1.0)
+		m.client.Count(LookupNotFoundMetric, adjustedCount, tags, 1.0)
 	}
 
 	for featureID, count := range m.nullOrExpired {
@@ -138,7 +144,7 @@ func (m *LookupMetricsAggregator) Emit() {
 		copy(tags, baseTags)
 		tags[len(baseTags)] = "feature:" + featureID
 		tags[len(baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
-		m.client.Count("mlpfs.featureserver.feature_lookup_null_or_expired", adjustedCount, tags, 1.0)
+		m.client.Count(LookupNullOrExpiredMetric, adjustedCount, tags, 1.0)
 	}
 
 	for fvName, count := range m.totalByFV {
@@ -149,6 +155,6 @@ func (m *LookupMetricsAggregator) Emit() {
 		tags := make([]string, len(baseTags)+1)
 		copy(tags, baseTags)
 		tags[len(baseTags)] = "feature_view:" + fvName
-		m.client.Count("mlpfs.featureserver.feature_lookup_requests", adjustedCount, tags, 1.0)
+		m.client.Count(LookupRequestsMetric, adjustedCount, tags, 1.0)
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -13,12 +13,14 @@ type metricCall struct {
 	name  string
 	value int64
 	tags  []string
+	rate  float64
 }
 
 type distCall struct {
 	name  string
 	value float64
 	tags  []string
+	rate  float64
 }
 
 type fakeStatsdClient struct {
@@ -27,12 +29,12 @@ type fakeStatsdClient struct {
 }
 
 func (f *fakeStatsdClient) Count(name string, value int64, tags []string, rate float64) error {
-	f.calls = append(f.calls, metricCall{name: name, value: value, tags: tags})
+	f.calls = append(f.calls, metricCall{name: name, value: value, tags: tags, rate: rate})
 	return nil
 }
 
 func (f *fakeStatsdClient) Distribution(name string, value float64, tags []string, rate float64) error {
-	f.distCalls = append(f.distCalls, distCall{name: name, value: value, tags: tags})
+	f.distCalls = append(f.distCalls, distCall{name: name, value: value, tags: tags, rate: rate})
 	return nil
 }
 
@@ -283,7 +285,7 @@ func filterCalls(calls []metricCall, name string) []metricCall {
 
 func TestParseSampleRate_Default(t *testing.T) {
 	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-	assert.Equal(t, DefaultSampleRate, ParseSampleRate(), "Default should be 0.01")
+	assert.Equal(t, DefaultLookupSampleRate, ParseSampleRate(), "Default should be 0.01")
 }
 
 func TestParseSampleRate_ReadFromEnv(t *testing.T) {
@@ -298,11 +300,11 @@ func TestParseSampleRate_InvalidValues(t *testing.T) {
 		value    string
 		expected float64
 	}{
-		{"-0.5", DefaultSampleRate},
-		{"1.5", DefaultSampleRate},
-		{"0", DefaultSampleRate},
-		{"abc", DefaultSampleRate},
-		{"", DefaultSampleRate},
+		{"-0.5", DefaultLookupSampleRate},
+		{"1.5", DefaultLookupSampleRate},
+		{"0", DefaultLookupSampleRate},
+		{"abc", DefaultLookupSampleRate},
+		{"", DefaultLookupSampleRate},
 	}
 
 	for _, tc := range testCases {
@@ -325,23 +327,13 @@ func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
 
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
+	agg.Emit()
 
-	// Try multiple times to ensure at least one emit happens
-	emitted := false
-	for i := 0; i < 50; i++ {
-		fake.calls = nil
-		agg.Emit()
-		if len(fake.calls) > 0 {
-			emitted = true
-			notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
-			assert.Len(t, notFoundCalls, 1)
-			// With sample_rate=0.5, count of 2 should become 4 (2 / 0.5)
-			assert.Equal(t, int64(4), notFoundCalls[0].value, "Count should be adjusted by 1/sample_rate")
-			break
-		}
-	}
-
-	assert.True(t, emitted, "Should have emitted at least once in 50 tries")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
+	assert.Len(t, notFoundCalls, 1)
+	// Raw count is passed; statsd agent scales using the sample rate parameter.
+	assert.Equal(t, int64(2), notFoundCalls[0].value)
+	assert.Equal(t, float64(0.5), notFoundCalls[0].rate)
 }
 
 func TestSampling_NoAdjustmentWhenNotSampling(t *testing.T) {

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -15,12 +15,24 @@ type metricCall struct {
 	tags  []string
 }
 
+type distCall struct {
+	name  string
+	value float64
+	tags  []string
+}
+
 type fakeStatsdClient struct {
-	calls []metricCall
+	calls     []metricCall
+	distCalls []distCall
 }
 
 func (f *fakeStatsdClient) Count(name string, value int64, tags []string, rate float64) error {
 	f.calls = append(f.calls, metricCall{name: name, value: value, tags: tags})
+	return nil
+}
+
+func (f *fakeStatsdClient) Distribution(name string, value float64, tags []string, rate float64) error {
+	f.distCalls = append(f.distCalls, distCall{name: name, value: value, tags: tags})
 	return nil
 }
 
@@ -37,10 +49,15 @@ func TestAggregator_AllNotFound(t *testing.T) {
 	agg.Record("user_fv__age", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 1)
-	assert.Equal(t, "mlpfs.featureserver.feature_lookup_not_found", fake.calls[0].name)
-	assert.Equal(t, int64(3), fake.calls[0].value)
-	assert.Contains(t, fake.calls[0].tags, "feature:user_fv__age")
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 1)
+	assert.Equal(t, int64(3), notFoundCalls[0].value)
+	assert.Contains(t, notFoundCalls[0].tags, "feature:user_fv__age")
+
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 1)
+	assert.Equal(t, int64(3), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature_view:user_fv")
 }
 
 func TestAggregator_AllNullOrExpired(t *testing.T) {
@@ -52,10 +69,14 @@ func TestAggregator_AllNullOrExpired(t *testing.T) {
 	agg.Record("order_fv__amt", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 1)
-	assert.Equal(t, "mlpfs.featureserver.feature_lookup_null_or_expired", fake.calls[0].name)
-	assert.Equal(t, int64(3), fake.calls[0].value)
-	assert.Contains(t, fake.calls[0].tags, "feature:order_fv__amt")
+	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	assert.Len(t, nullCalls, 1)
+	assert.Equal(t, int64(3), nullCalls[0].value)
+	assert.Contains(t, nullCalls[0].tags, "feature:order_fv__amt")
+
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 1)
+	assert.Equal(t, int64(3), totalCalls[0].value)
 }
 
 func TestAggregator_MixedStatuses(t *testing.T) {
@@ -69,18 +90,22 @@ func TestAggregator_MixedStatuses(t *testing.T) {
 	agg.Record("fv_b__f2", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 2)
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 1)
+	assert.Equal(t, int64(1), notFoundCalls[0].value)
 
-	callsByName := map[string]metricCall{}
-	for _, c := range fake.calls {
-		callsByName[c.name+":"+findTag(c.tags, "feature:")] = c
+	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	assert.Len(t, nullCalls, 1)
+	assert.Equal(t, int64(2), nullCalls[0].value)
+
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 2)
+	totalByFV := map[string]int64{}
+	for _, c := range totalCalls {
+		totalByFV[findTag(c.tags, "feature_view:")] = c.value
 	}
-
-	nf := callsByName["mlpfs.featureserver.feature_lookup_not_found:fv_a__f1"]
-	assert.Equal(t, int64(1), nf.value)
-
-	ne := callsByName["mlpfs.featureserver.feature_lookup_null_or_expired:fv_b__f2"]
-	assert.Equal(t, int64(2), ne.value)
+	assert.Equal(t, int64(2), totalByFV["fv_a"])
+	assert.Equal(t, int64(3), totalByFV["fv_b"])
 }
 
 func TestAggregator_AllPresent(t *testing.T) {
@@ -91,7 +116,16 @@ func TestAggregator_AllPresent(t *testing.T) {
 	agg.Record("fv__f1", serving.FieldStatus_PRESENT)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 0)
+	// No not_found or null_or_expired calls
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	assert.Len(t, notFoundCalls, 0)
+	assert.Len(t, nullCalls, 0)
+
+	// But total requests should still be emitted
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 1)
+	assert.Equal(t, int64(2), totalCalls[0].value)
 }
 
 func TestAggregator_NilSafe(t *testing.T) {
@@ -114,8 +148,9 @@ func TestAggregator_Tags(t *testing.T) {
 	agg.Record("hotel_fv__price", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 1)
-	tags := fake.calls[0].tags
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 1)
+	tags := notFoundCalls[0].tags
 	assert.Contains(t, tags, "project:mlpfs")
 	assert.Contains(t, tags, "online_store_type:eg-valkey")
 	assert.Contains(t, tags, "feature:hotel_fv__price")
@@ -140,14 +175,20 @@ func TestRecordFromFeatureVectors(t *testing.T) {
 	agg.RecordFromFeatureVectors(vectors)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 2)
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 2)
 
 	callsByFeature := map[string]int64{}
-	for _, c := range fake.calls {
+	for _, c := range notFoundCalls {
 		callsByFeature[findTag(c.tags, "feature:")] = c.value
 	}
 	assert.Equal(t, int64(1), callsByFeature["fv_a__f1"])
 	assert.Equal(t, int64(2), callsByFeature["fv_a__f2"])
+
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 1)
+	assert.Equal(t, int64(4), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature_view:fv_a")
 }
 
 func TestRecordFromRangeFeatureVectors(t *testing.T) {
@@ -167,9 +208,14 @@ func TestRecordFromRangeFeatureVectors(t *testing.T) {
 	agg.RecordFromRangeFeatureVectors(vectors)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 1)
-	assert.Equal(t, int64(2), fake.calls[0].value)
-	assert.Equal(t, "mlpfs.featureserver.feature_lookup_not_found", fake.calls[0].name)
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 1)
+	assert.Equal(t, int64(2), notFoundCalls[0].value)
+
+	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	assert.Len(t, totalCalls, 1)
+	assert.Equal(t, int64(3), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature_view:sfv")
 }
 
 func TestIsMissingKeyMetricsEnabled(t *testing.T) {
@@ -222,6 +268,17 @@ func findTag(tags []string, prefix string) string {
 		}
 	}
 	return ""
+}
+
+// filterCalls returns only metric calls matching the given metric name.
+func filterCalls(calls []metricCall, name string) []metricCall {
+	var result []metricCall
+	for _, c := range calls {
+		if c.name == name {
+			result = append(result, c)
+		}
+	}
+	return result
 }
 
 func TestSampling_DefaultNoSampling(t *testing.T) {
@@ -289,8 +346,10 @@ func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
 		agg.Emit()
 		if len(fake.calls) > 0 {
 			emitted = true
+			notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+			assert.Len(t, notFoundCalls, 1)
 			// With sample_rate=0.5, count of 2 should become 4 (2 / 0.5)
-			assert.Equal(t, int64(4), fake.calls[0].value, "Count should be adjusted by 1/sample_rate")
+			assert.Equal(t, int64(4), notFoundCalls[0].value, "Count should be adjusted by 1/sample_rate")
 			break
 		}
 	}
@@ -309,6 +368,7 @@ func TestSampling_NoAdjustmentWhenNotSampling(t *testing.T) {
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	assert.Len(t, fake.calls, 1)
-	assert.Equal(t, int64(2), fake.calls[0].value, "Count should not be adjusted with sample_rate=1.0")
+	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	assert.Len(t, notFoundCalls, 1)
+	assert.Equal(t, int64(2), notFoundCalls[0].value, "Count should not be adjusted with sample_rate=1.0")
 }

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -59,6 +59,7 @@ func TestAggregator_AllNotFound(t *testing.T) {
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature:user_fv__age")
 	assert.Contains(t, totalCalls[0].tags, "feature_view:user_fv")
 }
 
@@ -79,6 +80,8 @@ func TestAggregator_AllNullOrExpired(t *testing.T) {
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature:order_fv__amt")
+	assert.Contains(t, totalCalls[0].tags, "feature_view:order_fv")
 }
 
 func TestAggregator_MixedStatuses(t *testing.T) {
@@ -102,12 +105,12 @@ func TestAggregator_MixedStatuses(t *testing.T) {
 
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 2)
-	totalByFV := map[string]int64{}
+	totalByFeature := map[string]int64{}
 	for _, c := range totalCalls {
-		totalByFV[findTag(c.tags, "feature_view:")] = c.value
+		totalByFeature[findTag(c.tags, "feature:")] = c.value
 	}
-	assert.Equal(t, int64(2), totalByFV["fv_a"])
-	assert.Equal(t, int64(3), totalByFV["fv_b"])
+	assert.Equal(t, int64(2), totalByFeature["fv_a__f1"])
+	assert.Equal(t, int64(3), totalByFeature["fv_b__f2"])
 }
 
 func TestAggregator_AllPresent(t *testing.T) {
@@ -124,10 +127,11 @@ func TestAggregator_AllPresent(t *testing.T) {
 	assert.Len(t, notFoundCalls, 0)
 	assert.Len(t, nullCalls, 0)
 
-	// But total requests should still be emitted
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(2), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature:fv__f1")
+	assert.Contains(t, totalCalls[0].tags, "feature_view:fv")
 }
 
 func TestAggregator_NilSafe(t *testing.T) {
@@ -188,9 +192,13 @@ func TestRecordFromFeatureVectors(t *testing.T) {
 	assert.Equal(t, int64(2), callsByFeature["fv_a__f2"])
 
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
-	assert.Len(t, totalCalls, 1)
-	assert.Equal(t, int64(4), totalCalls[0].value)
-	assert.Contains(t, totalCalls[0].tags, "feature_view:fv_a")
+	assert.Len(t, totalCalls, 2)
+	totalByFeature := map[string]int64{}
+	for _, c := range totalCalls {
+		totalByFeature[findTag(c.tags, "feature:")] = c.value
+	}
+	assert.Equal(t, int64(2), totalByFeature["fv_a__f1"])
+	assert.Equal(t, int64(2), totalByFeature["fv_a__f2"])
 }
 
 func TestRecordFromRangeFeatureVectors(t *testing.T) {
@@ -217,6 +225,7 @@ func TestRecordFromRangeFeatureVectors(t *testing.T) {
 	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
+	assert.Contains(t, totalCalls[0].tags, "feature:sfv__f1")
 	assert.Contains(t, totalCalls[0].tags, "feature_view:sfv")
 }
 

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -283,19 +283,19 @@ func filterCalls(calls []metricCall, name string) []metricCall {
 	return result
 }
 
-func TestParseSampleRate_Default(t *testing.T) {
+func TestParseLookupSampleRate_Default(t *testing.T) {
 	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-	assert.Equal(t, DefaultLookupSampleRate, ParseSampleRate(), "Default should be 0.01")
+	assert.Equal(t, DefaultLookupSampleRate, ParseLookupSampleRate(), "Default should be 0.01")
 }
 
-func TestParseSampleRate_ReadFromEnv(t *testing.T) {
+func TestParseLookupSampleRate_ReadFromEnv(t *testing.T) {
 	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.5")
 	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
 
-	assert.Equal(t, 0.5, ParseSampleRate())
+	assert.Equal(t, 0.5, ParseLookupSampleRate())
 }
 
-func TestParseSampleRate_InvalidValues(t *testing.T) {
+func TestParseLookupSampleRate_InvalidValues(t *testing.T) {
 	testCases := []struct {
 		value    string
 		expected float64
@@ -316,7 +316,7 @@ func TestParseSampleRate_InvalidValues(t *testing.T) {
 				defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
 			}
 
-			assert.Equal(t, tc.expected, ParseSampleRate())
+			assert.Equal(t, tc.expected, ParseLookupSampleRate())
 		})
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -37,7 +37,7 @@ func (f *fakeStatsdClient) Distribution(name string, value float64, tags []strin
 }
 
 func newTestAggregator(client StatsdClient) *LookupMetricsAggregator {
-	return NewLookupMetricsAggregator("test_project", "redis", client)
+	return NewLookupMetricsAggregator("test_project", "redis", client, 1.0)
 }
 
 func TestAggregator_AllNotFound(t *testing.T) {
@@ -137,13 +137,13 @@ func TestAggregator_NilSafe(t *testing.T) {
 }
 
 func TestAggregator_NilClient(t *testing.T) {
-	agg := NewLookupMetricsAggregator("p", "r", nil)
+	agg := NewLookupMetricsAggregator("p", "r", nil, 1.0)
 	assert.Nil(t, agg)
 }
 
 func TestAggregator_Tags(t *testing.T) {
 	fake := &fakeStatsdClient{}
-	agg := NewLookupMetricsAggregator("mlpfs", "eg-valkey", fake)
+	agg := NewLookupMetricsAggregator("mlpfs", "eg-valkey", fake, 1.0)
 
 	agg.Record("hotel_fv__price", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
@@ -281,34 +281,28 @@ func filterCalls(calls []metricCall, name string) []metricCall {
 	return result
 }
 
-func TestSampling_DefaultNoSampling(t *testing.T) {
+func TestParseSampleRate_Default(t *testing.T) {
 	os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-	fake := &fakeStatsdClient{}
-	agg := newTestAggregator(fake)
-
-	assert.Equal(t, 1.0, agg.sampleRate, "Default sample rate should be 1.0")
+	assert.Equal(t, DefaultSampleRate, ParseSampleRate(), "Default should be 0.01")
 }
 
-func TestSampling_ReadFromEnv(t *testing.T) {
+func TestParseSampleRate_ReadFromEnv(t *testing.T) {
 	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.5")
 	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
 
-	fake := &fakeStatsdClient{}
-	agg := newTestAggregator(fake)
-
-	assert.Equal(t, 0.5, agg.sampleRate, "Should read sample rate from environment")
+	assert.Equal(t, 0.5, ParseSampleRate())
 }
 
-func TestSampling_InvalidValues(t *testing.T) {
+func TestParseSampleRate_InvalidValues(t *testing.T) {
 	testCases := []struct {
 		value    string
 		expected float64
 	}{
-		{"-0.5", 1.0}, // Negative
-		{"1.5", 1.0},  // > 1.0
-		{"0", 1.0},    // Zero
-		{"abc", 1.0},  // Non-numeric
-		{"", 1.0},     // Empty (unset uses default)
+		{"-0.5", DefaultSampleRate},
+		{"1.5", DefaultSampleRate},
+		{"0", DefaultSampleRate},
+		{"abc", DefaultSampleRate},
+		{"", DefaultSampleRate},
 	}
 
 	for _, tc := range testCases {
@@ -320,22 +314,15 @@ func TestSampling_InvalidValues(t *testing.T) {
 				defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
 			}
 
-			fake := &fakeStatsdClient{}
-			agg := newTestAggregator(fake)
-
-			assert.Equal(t, tc.expected, agg.sampleRate)
+			assert.Equal(t, tc.expected, ParseSampleRate())
 		})
 	}
 }
 
 func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
-	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "0.5")
-	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-
 	fake := &fakeStatsdClient{}
-	agg := newTestAggregator(fake)
+	agg := NewLookupMetricsAggregator("test_project", "redis", fake, 0.5)
 
-	// Record 2 missing keys
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 
@@ -358,11 +345,8 @@ func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
 }
 
 func TestSampling_NoAdjustmentWhenNotSampling(t *testing.T) {
-	os.Setenv("FEAST_METRICS_SAMPLE_RATE", "1.0")
-	defer os.Unsetenv("FEAST_METRICS_SAMPLE_RATE")
-
 	fake := &fakeStatsdClient{}
-	agg := newTestAggregator(fake)
+	agg := NewLookupMetricsAggregator("test_project", "redis", fake, 1.0)
 
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -49,12 +49,12 @@ func TestAggregator_AllNotFound(t *testing.T) {
 	agg.Record("user_fv__age", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 1)
 	assert.Equal(t, int64(3), notFoundCalls[0].value)
 	assert.Contains(t, notFoundCalls[0].tags, "feature:user_fv__age")
 
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
 	assert.Contains(t, totalCalls[0].tags, "feature_view:user_fv")
@@ -69,12 +69,12 @@ func TestAggregator_AllNullOrExpired(t *testing.T) {
 	agg.Record("order_fv__amt", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
-	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	nullCalls := filterCalls(fake.calls, LookupNullOrExpiredMetric)
 	assert.Len(t, nullCalls, 1)
 	assert.Equal(t, int64(3), nullCalls[0].value)
 	assert.Contains(t, nullCalls[0].tags, "feature:order_fv__amt")
 
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
 }
@@ -90,15 +90,15 @@ func TestAggregator_MixedStatuses(t *testing.T) {
 	agg.Record("fv_b__f2", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 1)
 	assert.Equal(t, int64(1), notFoundCalls[0].value)
 
-	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	nullCalls := filterCalls(fake.calls, LookupNullOrExpiredMetric)
 	assert.Len(t, nullCalls, 1)
 	assert.Equal(t, int64(2), nullCalls[0].value)
 
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 2)
 	totalByFV := map[string]int64{}
 	for _, c := range totalCalls {
@@ -117,13 +117,13 @@ func TestAggregator_AllPresent(t *testing.T) {
 	agg.Emit()
 
 	// No not_found or null_or_expired calls
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
-	nullCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_null_or_expired")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
+	nullCalls := filterCalls(fake.calls, LookupNullOrExpiredMetric)
 	assert.Len(t, notFoundCalls, 0)
 	assert.Len(t, nullCalls, 0)
 
 	// But total requests should still be emitted
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(2), totalCalls[0].value)
 }
@@ -148,7 +148,7 @@ func TestAggregator_Tags(t *testing.T) {
 	agg.Record("hotel_fv__price", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 1)
 	tags := notFoundCalls[0].tags
 	assert.Contains(t, tags, "project:mlpfs")
@@ -175,7 +175,7 @@ func TestRecordFromFeatureVectors(t *testing.T) {
 	agg.RecordFromFeatureVectors(vectors)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 2)
 
 	callsByFeature := map[string]int64{}
@@ -185,7 +185,7 @@ func TestRecordFromFeatureVectors(t *testing.T) {
 	assert.Equal(t, int64(1), callsByFeature["fv_a__f1"])
 	assert.Equal(t, int64(2), callsByFeature["fv_a__f2"])
 
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(4), totalCalls[0].value)
 	assert.Contains(t, totalCalls[0].tags, "feature_view:fv_a")
@@ -208,11 +208,11 @@ func TestRecordFromRangeFeatureVectors(t *testing.T) {
 	agg.RecordFromRangeFeatureVectors(vectors)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 1)
 	assert.Equal(t, int64(2), notFoundCalls[0].value)
 
-	totalCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_requests")
+	totalCalls := filterCalls(fake.calls, LookupRequestsMetric)
 	assert.Len(t, totalCalls, 1)
 	assert.Equal(t, int64(3), totalCalls[0].value)
 	assert.Contains(t, totalCalls[0].tags, "feature_view:sfv")
@@ -346,7 +346,7 @@ func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
 		agg.Emit()
 		if len(fake.calls) > 0 {
 			emitted = true
-			notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+			notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 			assert.Len(t, notFoundCalls, 1)
 			// With sample_rate=0.5, count of 2 should become 4 (2 / 0.5)
 			assert.Equal(t, int64(4), notFoundCalls[0].value, "Count should be adjusted by 1/sample_rate")
@@ -368,7 +368,7 @@ func TestSampling_NoAdjustmentWhenNotSampling(t *testing.T) {
 	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
-	notFoundCalls := filterCalls(fake.calls, "mlpfs.featureserver.feature_lookup_not_found")
+	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
 	assert.Len(t, notFoundCalls, 1)
 	assert.Equal(t, int64(2), notFoundCalls[0].value, "Count should not be adjusted with sample_rate=1.0")
 }

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -94,14 +94,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features")
-		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, true)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
 		return nil, errors.GrpcFromError(err)
 	}
 
@@ -114,14 +107,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
 
-		if len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, false)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
 	}
 
 	resp := &serving.GetOnlineFeaturesResponse{
@@ -208,14 +194,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")
-		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, true)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
 		return nil, errors.GrpcFromError(err)
 	}
 
@@ -228,14 +207,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
 
-		if len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, false)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
 	}
 
 	entities := request.GetEntities()

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -101,19 +101,12 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features")
-		if s.metricsCtx != nil {
-			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
-		}
+		s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, true)
 		return nil, errors.GrpcFromError(err)
 	}
 
-	if s.metricsCtx != nil {
-		agg := s.metricsCtx.NewLookupAggregator()
-		agg.RecordFromFeatureVectors(featureVectors)
-		agg.Emit()
-
-		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
-	}
+	s.metricsCtx.EmitLookupMetrics(featureVectors)
+	s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, false)
 
 	resp := &serving.GetOnlineFeaturesResponse{
 		Results: make([]*serving.GetOnlineFeaturesResponse_FeatureVector, 0),
@@ -199,19 +192,12 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")
-		if s.metricsCtx != nil {
-			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
-		}
+		s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, true)
 		return nil, errors.GrpcFromError(err)
 	}
 
-	if s.metricsCtx != nil {
-		agg := s.metricsCtx.NewLookupAggregator()
-		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
-		agg.Emit()
-
-		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
-	}
+	s.metricsCtx.EmitRangeLookupMetrics(rangeFeatureVectors)
+	s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, false)
 
 	entities := request.GetEntities()
 	results := make([]*serving.GetOnlineFeaturesRangeResponse_RangeFeatureVector, 0, len(rangeFeatureVectors))

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -97,7 +97,7 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		request.GetRequestContext(),
 		request.GetFullFeatureNames())
 
-	latencyMs := float64(time.Since(t0).Milliseconds())
+	latencyMs := float64(time.Since(t0).Microseconds()) / 1000.0
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features")
@@ -195,7 +195,7 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		request.GetFullFeatureNames(),
 	)
 
-	latencyMs := float64(time.Since(t0).Milliseconds())
+	latencyMs := float64(time.Since(t0).Microseconds()) / 1000.0
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/feast-dev/feast/go/internal/feast"
 	"github.com/feast-dev/feast/go/internal/feast/errors"
@@ -77,6 +79,9 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		return nil, err
 	}
 
+	fvNames := extractFVNamesFromRequest(featuresOrService.FeaturesRefs, featuresOrService.FeatureService)
+	t0 := time.Now()
+
 	featureVectors, err := s.fs.GetOnlineFeatures(
 		ctx,
 		featuresOrService.FeaturesRefs,
@@ -85,8 +90,18 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		request.GetRequestContext(),
 		request.GetFullFeatureNames())
 
+	latencyMs := float64(time.Since(t0).Milliseconds())
+
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features")
+		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, true)
+		}
 		return nil, errors.GrpcFromError(err)
 	}
 
@@ -98,6 +113,15 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 		)
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
+
+		if len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, false)
+		}
 	}
 
 	resp := &serving.GetOnlineFeaturesResponse{
@@ -165,6 +189,9 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		return nil, err
 	}
 
+	fvNames := extractFVNamesFromRequest(featuresOrService.FeaturesRefs, featuresOrService.FeatureService)
+	t0 := time.Now()
+
 	rangeFeatureVectors, err := s.fs.GetOnlineFeaturesRange(
 		ctx,
 		featuresOrService.FeaturesRefs,
@@ -177,8 +204,18 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		request.GetFullFeatureNames(),
 	)
 
+	latencyMs := float64(time.Since(t0).Milliseconds())
+
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")
+		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, true)
+		}
 		return nil, errors.GrpcFromError(err)
 	}
 
@@ -190,6 +227,15 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 		)
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
+
+		if len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, false)
+		}
 	}
 
 	entities := request.GetEntities()

--- a/go/internal/feast/server/grpc_server.go
+++ b/go/internal/feast/server/grpc_server.go
@@ -32,12 +32,19 @@ type grpcServingServiceServer struct {
 	fs             *feast.FeatureStore
 	loggingService *logging.LoggingService
 	metricsClient  metrics.StatsdClient
+	metricsCtx     *MetricsContext
 	config         *registry.RepoConfig
 	serving.UnimplementedServingServiceServer
 }
 
 func NewGrpcServingServiceServer(fs *feast.FeatureStore, loggingService *logging.LoggingService, metricsClient metrics.StatsdClient, config *registry.RepoConfig) *grpcServingServiceServer {
-	return &grpcServingServiceServer{fs: fs, loggingService: loggingService, metricsClient: metricsClient, config: config}
+	return &grpcServingServiceServer{
+		fs:             fs,
+		loggingService: loggingService,
+		metricsClient:  metricsClient,
+		metricsCtx:     NewMetricsContext(metricsClient, config),
+		config:         config,
+	}
 }
 
 func (s *grpcServingServiceServer) GetFeastServingInfo(ctx context.Context, request *serving.GetFeastServingInfoRequest) (*serving.GetFeastServingInfoResponse, error) {
@@ -94,20 +101,18 @@ func (s *grpcServingServiceServer) GetOnlineFeatures(ctx context.Context, reques
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features")
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
+		if s.metricsCtx != nil {
+			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
+		}
 		return nil, errors.GrpcFromError(err)
 	}
 
-	if s.metricsClient != nil && s.config != nil {
-		agg := metrics.NewLookupMetricsAggregator(
-			s.config.Project,
-			metrics.GetOnlineStoreType(s.config),
-			s.metricsClient,
-		)
+	if s.metricsCtx != nil {
+		agg := s.metricsCtx.NewLookupAggregator()
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
 
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
+		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
 	}
 
 	resp := &serving.GetOnlineFeaturesResponse{
@@ -194,20 +199,18 @@ func (s *grpcServingServiceServer) GetOnlineFeaturesRange(ctx context.Context, r
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting online features range")
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
+		if s.metricsCtx != nil {
+			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
+		}
 		return nil, errors.GrpcFromError(err)
 	}
 
-	if s.metricsClient != nil && s.config != nil {
-		agg := metrics.NewLookupMetricsAggregator(
-			s.config.Project,
-			metrics.GetOnlineStoreType(s.config),
-			s.metricsClient,
-		)
+	if s.metricsCtx != nil {
+		agg := s.metricsCtx.NewLookupAggregator()
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
 
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
+		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
 	}
 
 	entities := request.GetEntities()

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -451,14 +451,7 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting feature vector")
-		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, true)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
 		writeJSONError(w, fmt.Errorf("Error getting feature vector: %+v", err), http.StatusInternalServerError)
 		return
 	}
@@ -472,14 +465,7 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
 
-		if len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, false)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
 	}
 
 	var featureNames []string
@@ -687,14 +673,7 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting range feature vectors")
-		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, true)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
 		writeJSONError(w, err, http.StatusInternalServerError)
 		return
 	}
@@ -708,14 +687,7 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
 
-		if len(fvNames) > 0 {
-			fvMetrics := metrics.NewFeatureViewReadMetrics(
-				s.config.Project,
-				metrics.GetOnlineStoreType(s.config),
-				s.metricsClient,
-			)
-			fvMetrics.Emit(fvNames, latencyMs, false)
-		}
+		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
 	}
 
 	featureNames, entities, results, err := processFeatureVectors(

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -33,6 +33,7 @@ type HttpServer struct {
 	fs             *feast.FeatureStore
 	loggingService *logging.LoggingService
 	metricsClient  metrics.StatsdClient
+	metricsCtx     *MetricsContext
 	config         *registry.RepoConfig
 	server         *http.Server
 }
@@ -325,7 +326,13 @@ type getOnlineFeaturesRequest struct {
 }
 
 func NewHttpServer(fs *feast.FeatureStore, loggingService *logging.LoggingService, metricsClient metrics.StatsdClient, config *registry.RepoConfig) *HttpServer {
-	return &HttpServer{fs: fs, loggingService: loggingService, metricsClient: metricsClient, config: config}
+	return &HttpServer{
+		fs:             fs,
+		loggingService: loggingService,
+		metricsClient:  metricsClient,
+		metricsCtx:     NewMetricsContext(metricsClient, config),
+		config:         config,
+	}
 }
 
 func extractFVNamesFromRequest(features []string, featureService *model.FeatureService) []string {
@@ -451,21 +458,19 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting feature vector")
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
+		if s.metricsCtx != nil {
+			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
+		}
 		writeJSONError(w, fmt.Errorf("Error getting feature vector: %+v", err), http.StatusInternalServerError)
 		return
 	}
 
-	if s.metricsClient != nil && s.config != nil {
-		agg := metrics.NewLookupMetricsAggregator(
-			s.config.Project,
-			metrics.GetOnlineStoreType(s.config),
-			s.metricsClient,
-		)
+	if s.metricsCtx != nil {
+		agg := s.metricsCtx.NewLookupAggregator()
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
 
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
+		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
 	}
 
 	var featureNames []string
@@ -673,21 +678,19 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting range feature vectors")
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, true)
+		if s.metricsCtx != nil {
+			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
+		}
 		writeJSONError(w, err, http.StatusInternalServerError)
 		return
 	}
 
-	if s.metricsClient != nil && s.config != nil {
-		agg := metrics.NewLookupMetricsAggregator(
-			s.config.Project,
-			metrics.GetOnlineStoreType(s.config),
-			s.metricsClient,
-		)
+	if s.metricsCtx != nil {
+		agg := s.metricsCtx.NewLookupAggregator()
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
 
-		emitFVReadMetrics(s.metricsClient, s.config, fvNames, latencyMs, false)
+		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
 	}
 
 	featureNames, entities, results, err := processFeatureVectors(

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -436,20 +436,13 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting feature vector")
-		if s.metricsCtx != nil {
-			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
-		}
+		s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, true)
 		writeJSONError(w, fmt.Errorf("Error getting feature vector: %+v", err), http.StatusInternalServerError)
 		return
 	}
 
-	if s.metricsCtx != nil {
-		agg := s.metricsCtx.NewLookupAggregator()
-		agg.RecordFromFeatureVectors(featureVectors)
-		agg.Emit()
-
-		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
-	}
+	s.metricsCtx.EmitLookupMetrics(featureVectors)
+	s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, false)
 
 	var featureNames []string
 	var results []map[string]interface{}
@@ -656,20 +649,13 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting range feature vectors")
-		if s.metricsCtx != nil {
-			s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, true)
-		}
+		s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, true)
 		writeJSONError(w, err, http.StatusInternalServerError)
 		return
 	}
 
-	if s.metricsCtx != nil {
-		agg := s.metricsCtx.NewLookupAggregator()
-		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
-		agg.Emit()
-
-		s.metricsCtx.FVReadMetrics.Emit(fvNames, latencyMs, false)
-	}
+	s.metricsCtx.EmitRangeLookupMetrics(rangeFeatureVectors)
+	s.metricsCtx.EmitFVReadMetrics(fvNames, latencyMs, false)
 
 	featureNames, entities, results, err := processFeatureVectors(
 		rangeFeatureVectors, includeMetadata, entitiesProto)

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -328,6 +328,28 @@ func NewHttpServer(fs *feast.FeatureStore, loggingService *logging.LoggingServic
 	return &HttpServer{fs: fs, loggingService: loggingService, metricsClient: metricsClient, config: config}
 }
 
+func extractFVNamesFromRequest(features []string, featureService *model.FeatureService) []string {
+	seen := make(map[string]struct{})
+
+	for _, ref := range features {
+		if parts := strings.SplitN(ref, ":", 2); len(parts) == 2 {
+			seen[parts[0]] = struct{}{}
+		}
+	}
+
+	if featureService != nil {
+		for _, proj := range featureService.Projections {
+			seen[proj.NameToUse()] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	return names
+}
+
 func parseIncludeMetadata(r *http.Request) (bool, error) {
 	q := r.URL.Query()
 	raw := strings.TrimSpace(q.Get("includeMetadata"))
@@ -408,6 +430,9 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		requestContextProto[key] = value.ToProto()
 	}
 
+	fvNames := extractFVNamesFromRequest(request.Features, featureService)
+	t0 := time.Now()
+
 	featureVectors, err = s.fs.GetOnlineFeatures(
 		ctx,
 		request.Features,
@@ -415,6 +440,8 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		entitiesProto,
 		requestContextProto,
 		request.FullFeatureNames)
+
+	latencyMs := float64(time.Since(t0).Milliseconds())
 
 	defer func() {
 		if featureVectors != nil {
@@ -424,6 +451,14 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting feature vector")
+		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, true)
+		}
 		writeJSONError(w, fmt.Errorf("Error getting feature vector: %+v", err), http.StatusInternalServerError)
 		return
 	}
@@ -436,6 +471,15 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		)
 		agg.RecordFromFeatureVectors(featureVectors)
 		agg.Emit()
+
+		if len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, false)
+		}
 	}
 
 	var featureNames []string
@@ -619,6 +663,9 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	fvNames := extractFVNamesFromRequest(request.Features, featureService)
+	t0 := time.Now()
+
 	rangeFeatureVectors, err := s.fs.GetOnlineFeaturesRange(
 		ctx,
 		request.Features,
@@ -630,6 +677,8 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		requestContextProto,
 		request.FullFeatureNames)
 
+	latencyMs := float64(time.Since(t0).Milliseconds())
+
 	defer func() {
 		if rangeFeatureVectors != nil {
 			go releaseCGORangeMemory(rangeFeatureVectors)
@@ -638,6 +687,14 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 
 	if err != nil {
 		logSpanContext.Error().Err(err).Msg("Error getting range feature vectors")
+		if s.metricsClient != nil && s.config != nil && len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, true)
+		}
 		writeJSONError(w, err, http.StatusInternalServerError)
 		return
 	}
@@ -650,6 +707,15 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		)
 		agg.RecordFromRangeFeatureVectors(rangeFeatureVectors)
 		agg.Emit()
+
+		if len(fvNames) > 0 {
+			fvMetrics := metrics.NewFeatureViewReadMetrics(
+				s.config.Project,
+				metrics.GetOnlineStoreType(s.config),
+				s.metricsClient,
+			)
+			fvMetrics.Emit(fvNames, latencyMs, false)
+		}
 	}
 
 	featureNames, entities, results, err := processFeatureVectors(

--- a/go/internal/feast/server/http_server.go
+++ b/go/internal/feast/server/http_server.go
@@ -335,28 +335,6 @@ func NewHttpServer(fs *feast.FeatureStore, loggingService *logging.LoggingServic
 	}
 }
 
-func extractFVNamesFromRequest(features []string, featureService *model.FeatureService) []string {
-	seen := make(map[string]struct{})
-
-	for _, ref := range features {
-		if parts := strings.SplitN(ref, ":", 2); len(parts) == 2 {
-			seen[parts[0]] = struct{}{}
-		}
-	}
-
-	if featureService != nil {
-		for _, proj := range featureService.Projections {
-			seen[proj.NameToUse()] = struct{}{}
-		}
-	}
-
-	names := make([]string, 0, len(seen))
-	for name := range seen {
-		names = append(names, name)
-	}
-	return names
-}
-
 func parseIncludeMetadata(r *http.Request) (bool, error) {
 	q := r.URL.Query()
 	raw := strings.TrimSpace(q.Get("includeMetadata"))
@@ -448,7 +426,7 @@ func (s *HttpServer) getOnlineFeatures(w http.ResponseWriter, r *http.Request) {
 		requestContextProto,
 		request.FullFeatureNames)
 
-	latencyMs := float64(time.Since(t0).Milliseconds())
+	latencyMs := float64(time.Since(t0).Microseconds()) / 1000.0
 
 	defer func() {
 		if featureVectors != nil {
@@ -668,7 +646,7 @@ func (s *HttpServer) getOnlineFeaturesRange(w http.ResponseWriter, r *http.Reque
 		requestContextProto,
 		request.FullFeatureNames)
 
-	latencyMs := float64(time.Since(t0).Milliseconds())
+	latencyMs := float64(time.Since(t0).Microseconds()) / 1000.0
 
 	defer func() {
 		if rangeFeatureVectors != nil {

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/feast-dev/feast/go/internal/feast/metrics"
 	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
@@ -27,11 +28,12 @@ func LogWithSpanContext(span *tracer.Span) zerolog.Logger {
 
 // MetricsContext holds pre-initialized metrics objects for the server lifetime.
 type MetricsContext struct {
-	FVReadMetrics *metrics.FeatureViewReadMetrics
-	SampleRate    float64
-	Project       string
-	OnlineStore   string
-	Client        metrics.StatsdClient
+	FVReadMetrics            *metrics.FeatureViewReadMetrics
+	SampleRate               float64
+	Project                  string
+	OnlineStore              string
+	Client                   metrics.StatsdClient
+	MissingKeyMetricsEnabled bool
 }
 
 func NewMetricsContext(client metrics.StatsdClient, config *registry.RepoConfig) *MetricsContext {
@@ -41,20 +43,51 @@ func NewMetricsContext(client metrics.StatsdClient, config *registry.RepoConfig)
 	project := config.Project
 	onlineStore := metrics.GetOnlineStoreType(config)
 
+	var fvReadMetrics *metrics.FeatureViewReadMetrics
+	if metrics.IsFVMetricsEnabled() {
+		fvReadMetrics = metrics.NewFeatureViewReadMetrics(project, onlineStore, client, metrics.ParseFVSampleRate())
+	}
+
 	return &MetricsContext{
-		FVReadMetrics: metrics.NewFeatureViewReadMetrics(project, onlineStore, client, metrics.ParseFVSampleRate()),
-		SampleRate:    metrics.ParseLookupSampleRate(),
-		Project:       project,
-		OnlineStore:   onlineStore,
-		Client:        client,
+		FVReadMetrics:            fvReadMetrics,
+		SampleRate:               metrics.ParseLookupSampleRate(),
+		Project:                  project,
+		OnlineStore:              onlineStore,
+		Client:                   client,
+		MissingKeyMetricsEnabled: metrics.IsMissingKeyMetricsEnabled(),
 	}
 }
 
 func (mc *MetricsContext) NewLookupAggregator() *metrics.LookupMetricsAggregator {
-	if mc == nil {
+	if mc == nil || !mc.MissingKeyMetricsEnabled {
 		return nil
 	}
 	return metrics.NewLookupMetricsAggregator(mc.Project, mc.OnlineStore, mc.Client, mc.SampleRate)
+}
+
+func (mc *MetricsContext) EmitFVReadMetrics(fvNames []string, latencyMs float64, hasError bool) {
+	if mc == nil {
+		return
+	}
+	mc.FVReadMetrics.Emit(fvNames, latencyMs, hasError)
+}
+
+func (mc *MetricsContext) EmitLookupMetrics(vectors []*onlineserving.FeatureVector) {
+	if mc == nil {
+		return
+	}
+	agg := mc.NewLookupAggregator()
+	agg.RecordFromFeatureVectors(vectors)
+	agg.Emit()
+}
+
+func (mc *MetricsContext) EmitRangeLookupMetrics(vectors []*onlineserving.RangeFeatureVector) {
+	if mc == nil {
+		return
+	}
+	agg := mc.NewLookupAggregator()
+	agg.RecordFromRangeFeatureVectors(vectors)
+	agg.Emit()
 }
 
 func extractFVNamesFromRequest(features []string, featureService *model.FeatureService) []string {

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -1,11 +1,13 @@
 package server
 
 import (
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"os"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/feast-dev/feast/go/internal/feast/metrics"
+	"github.com/feast-dev/feast/go/internal/feast/registry"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 )
 
@@ -19,6 +21,18 @@ func LogWithSpanContext(span *tracer.Span) zerolog.Logger {
 		Logger()
 
 	return logger
+}
+
+func emitFVReadMetrics(metricsClient metrics.StatsdClient, config *registry.RepoConfig, fvNames []string, latencyMs float64, hasError bool) {
+	if metricsClient == nil || config == nil || len(fvNames) == 0 {
+		return
+	}
+	fvMetrics := metrics.NewFeatureViewReadMetrics(
+		config.Project,
+		metrics.GetOnlineStoreType(config),
+		metricsClient,
+	)
+	fvMetrics.Emit(fvNames, latencyMs, hasError)
 }
 
 func CommonHttpHandlers(s *HttpServer, healthCheckHandler http.HandlerFunc) []Handler {

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -26,7 +26,6 @@ func LogWithSpanContext(span *tracer.Span) zerolog.Logger {
 }
 
 // MetricsContext holds pre-initialized metrics objects for the server lifetime.
-// Created once at server startup to avoid per-request allocations and env reads.
 type MetricsContext struct {
 	FVReadMetrics *metrics.FeatureViewReadMetrics
 	SampleRate    float64
@@ -44,7 +43,7 @@ func NewMetricsContext(client metrics.StatsdClient, config *registry.RepoConfig)
 
 	return &MetricsContext{
 		FVReadMetrics: metrics.NewFeatureViewReadMetrics(project, onlineStore, client, metrics.ParseFVSampleRate()),
-		SampleRate:    metrics.ParseSampleRate(),
+		SampleRate:    metrics.ParseLookupSampleRate(),
 		Project:       project,
 		OnlineStore:   onlineStore,
 		Client:        client,

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -23,16 +23,38 @@ func LogWithSpanContext(span *tracer.Span) zerolog.Logger {
 	return logger
 }
 
-func emitFVReadMetrics(metricsClient metrics.StatsdClient, config *registry.RepoConfig, fvNames []string, latencyMs float64, hasError bool) {
-	if metricsClient == nil || config == nil || len(fvNames) == 0 {
-		return
+// MetricsContext holds pre-initialized metrics objects for the server lifetime.
+// Created once at server startup to avoid per-request allocations and env reads.
+type MetricsContext struct {
+	FVReadMetrics *metrics.FeatureViewReadMetrics
+	SampleRate    float64
+	Project       string
+	OnlineStore   string
+	Client        metrics.StatsdClient
+}
+
+func NewMetricsContext(client metrics.StatsdClient, config *registry.RepoConfig) *MetricsContext {
+	if client == nil || config == nil {
+		return nil
 	}
-	fvMetrics := metrics.NewFeatureViewReadMetrics(
-		config.Project,
-		metrics.GetOnlineStoreType(config),
-		metricsClient,
-	)
-	fvMetrics.Emit(fvNames, latencyMs, hasError)
+	sampleRate := metrics.ParseSampleRate()
+	project := config.Project
+	onlineStore := metrics.GetOnlineStoreType(config)
+
+	return &MetricsContext{
+		FVReadMetrics: metrics.NewFeatureViewReadMetrics(project, onlineStore, client, sampleRate),
+		SampleRate:    sampleRate,
+		Project:       project,
+		OnlineStore:   onlineStore,
+		Client:        client,
+	}
+}
+
+func (mc *MetricsContext) NewLookupAggregator() *metrics.LookupMetricsAggregator {
+	if mc == nil {
+		return nil
+	}
+	return metrics.NewLookupMetricsAggregator(mc.Project, mc.OnlineStore, mc.Client, mc.SampleRate)
 }
 
 func CommonHttpHandlers(s *HttpServer, healthCheckHandler http.HandlerFunc) []Handler {

--- a/go/internal/feast/server/server_commons.go
+++ b/go/internal/feast/server/server_commons.go
@@ -3,9 +3,11 @@ package server
 import (
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/feast-dev/feast/go/internal/feast/metrics"
+	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
@@ -37,13 +39,12 @@ func NewMetricsContext(client metrics.StatsdClient, config *registry.RepoConfig)
 	if client == nil || config == nil {
 		return nil
 	}
-	sampleRate := metrics.ParseSampleRate()
 	project := config.Project
 	onlineStore := metrics.GetOnlineStoreType(config)
 
 	return &MetricsContext{
-		FVReadMetrics: metrics.NewFeatureViewReadMetrics(project, onlineStore, client, sampleRate),
-		SampleRate:    sampleRate,
+		FVReadMetrics: metrics.NewFeatureViewReadMetrics(project, onlineStore, client, metrics.ParseFVSampleRate()),
+		SampleRate:    metrics.ParseSampleRate(),
 		Project:       project,
 		OnlineStore:   onlineStore,
 		Client:        client,
@@ -55,6 +56,28 @@ func (mc *MetricsContext) NewLookupAggregator() *metrics.LookupMetricsAggregator
 		return nil
 	}
 	return metrics.NewLookupMetricsAggregator(mc.Project, mc.OnlineStore, mc.Client, mc.SampleRate)
+}
+
+func extractFVNamesFromRequest(features []string, featureService *model.FeatureService) []string {
+	seen := make(map[string]struct{})
+
+	for _, ref := range features {
+		if parts := strings.SplitN(ref, ":", 2); len(parts) == 2 {
+			seen[parts[0]] = struct{}{}
+		}
+	}
+
+	if featureService != nil {
+		for _, proj := range featureService.Projections {
+			seen[proj.NameToUse()] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	return names
 }
 
 func CommonHttpHandlers(s *HttpServer, healthCheckHandler http.HandlerFunc) []Handler {

--- a/go/internal/feast/server/server_commons_test.go
+++ b/go/internal/feast/server/server_commons_test.go
@@ -1,0 +1,50 @@
+//go:build !integration
+
+package server
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func sortedStrings(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	sort.Strings(out)
+	return out
+}
+
+func TestExtractFVNamesFromRequest_FeatureRefs(t *testing.T) {
+	names := extractFVNamesFromRequest([]string{"hotel_fv:price", "hotel_fv:rating", "user_fv:age"}, nil)
+	assert.Equal(t, []string{"hotel_fv", "user_fv"}, sortedStrings(names))
+}
+
+func TestExtractFVNamesFromRequest_NoColon(t *testing.T) {
+	// refs without ":" are ignored (not a valid feature ref)
+	names := extractFVNamesFromRequest([]string{"hotel_fv_price"}, nil)
+	assert.Empty(t, names)
+}
+
+func TestExtractFVNamesFromRequest_FeatureService(t *testing.T) {
+	fs := &model.FeatureService{
+		Projections: []*model.FeatureViewProjection{
+			{Name: "hotel_fv", NameAlias: ""},
+			{Name: "user_fv", NameAlias: ""},
+		},
+	}
+	names := extractFVNamesFromRequest(nil, fs)
+	assert.Equal(t, []string{"hotel_fv", "user_fv"}, sortedStrings(names))
+}
+
+func TestExtractFVNamesFromRequest_Deduplication(t *testing.T) {
+	names := extractFVNamesFromRequest([]string{"hotel_fv:price", "hotel_fv:rating"}, nil)
+	assert.Equal(t, []string{"hotel_fv"}, names)
+}
+
+func TestExtractFVNamesFromRequest_Empty(t *testing.T) {
+	names := extractFVNamesFromRequest(nil, nil)
+	assert.Empty(t, names)
+}

--- a/go/internal/feast/server/server_commons_test.go
+++ b/go/internal/feast/server/server_commons_test.go
@@ -3,12 +3,72 @@
 package server
 
 import (
+	"os"
 	"sort"
 	"testing"
 
+	"github.com/feast-dev/feast/go/internal/feast/metrics"
 	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/registry"
 	"github.com/stretchr/testify/assert"
 )
+
+type fakeStatsdClient struct{}
+
+func (f *fakeStatsdClient) Count(string, int64, []string, float64) error          { return nil }
+func (f *fakeStatsdClient) Distribution(string, float64, []string, float64) error { return nil }
+
+func TestNewLookupAggregator_NilWhenMissingKeyMetricsDisabled(t *testing.T) {
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+	mc := &MetricsContext{
+		MissingKeyMetricsEnabled: metrics.IsMissingKeyMetricsEnabled(),
+		Project:                  "test",
+		OnlineStore:              "redis",
+		Client:                   &fakeStatsdClient{},
+		SampleRate:               1.0,
+	}
+	assert.Nil(t, mc.NewLookupAggregator())
+}
+
+func TestNewLookupAggregator_NonNilWhenMissingKeyMetricsEnabled(t *testing.T) {
+	os.Setenv("ENABLE_MISSING_KEY_METRICS", "true")
+	defer os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+	mc := &MetricsContext{
+		MissingKeyMetricsEnabled: metrics.IsMissingKeyMetricsEnabled(),
+		Project:                  "test",
+		OnlineStore:              "redis",
+		Client:                   &fakeStatsdClient{},
+		SampleRate:               1.0,
+	}
+	assert.NotNil(t, mc.NewLookupAggregator())
+}
+
+func TestNewMetricsContext_FVReadMetricsNilWhenFVMetricsDisabled(t *testing.T) {
+	os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+	os.Setenv("ENABLE_MISSING_KEY_METRICS", "true")
+	defer os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+
+	config := &registry.RepoConfig{Project: "test"}
+	mc := NewMetricsContext(&fakeStatsdClient{}, config)
+
+	assert.NotNil(t, mc)
+	assert.Nil(t, mc.FVReadMetrics)
+	assert.True(t, mc.MissingKeyMetricsEnabled)
+}
+
+func TestNewMetricsContext_LookupMetricsDisabledWhenMissingKeyMetricsDisabled(t *testing.T) {
+	os.Setenv("ENABLE_FV_LEVEL_METRICS", "true")
+	defer os.Unsetenv("ENABLE_FV_LEVEL_METRICS")
+	os.Unsetenv("ENABLE_MISSING_KEY_METRICS")
+
+	config := &registry.RepoConfig{Project: "test"}
+	mc := NewMetricsContext(&fakeStatsdClient{}, config)
+
+	assert.NotNil(t, mc)
+	assert.NotNil(t, mc.FVReadMetrics)
+	assert.False(t, mc.MissingKeyMetricsEnabled)
+	assert.Nil(t, mc.NewLookupAggregator())
+}
 
 func sortedStrings(s []string) []string {
 	out := make([]string, len(s))

--- a/go/main.go
+++ b/go/main.go
@@ -114,7 +114,7 @@ func main() {
 			} else {
 				metricsClient = client
 				defer client.Close()
-				log.Info().Msg("Feature view level metrics enabled")
+				log.Info().Msg("Metrics client enabled (FV metrics, missing key metrics, or both)")
 			}
 		} else {
 			log.Warn().Msg("ENABLE_FV_LEVEL_METRICS/ENABLE_MISSING_KEY_METRICS is true but DD_AGENT_HOST is not set")

--- a/go/main.go
+++ b/go/main.go
@@ -106,18 +106,18 @@ func main() {
 	}
 
 	var metricsClient metrics.StatsdClient
-	if metrics.IsMissingKeyMetricsEnabled() {
+	if metrics.IsFVMetricsEnabled() {
 		if addr := metrics.GetStatsDAddress(); addr != "" {
 			client, clientErr := statsd.New(addr)
 			if clientErr != nil {
-				log.Error().Err(clientErr).Msg("Failed to create statsd client for missing key metrics")
+				log.Error().Err(clientErr).Msg("Failed to create statsd client for metrics")
 			} else {
 				metricsClient = client
 				defer client.Close()
-				log.Info().Msg("Missing key metrics enabled")
+				log.Info().Msg("Feature view level metrics enabled")
 			}
 		} else {
-			log.Warn().Msg("ENABLE_MISSING_KEY_METRICS is true but DD_AGENT_HOST is not set")
+			log.Warn().Msg("ENABLE_FV_LEVEL_METRICS/ENABLE_MISSING_KEY_METRICS is true but DD_AGENT_HOST is not set")
 		}
 	}
 

--- a/go/main.go
+++ b/go/main.go
@@ -106,7 +106,7 @@ func main() {
 	}
 
 	var metricsClient metrics.StatsdClient
-	if metrics.IsFVMetricsEnabled() {
+	if metrics.IsMetricsClientEnabled() {
 		if addr := metrics.GetStatsDAddress(); addr != "" {
 			client, clientErr := statsd.New(addr)
 			if clientErr != nil {


### PR DESCRIPTION
Emit per-feature-view latency, request count, error count, and total lookup requests on every online read in the Go feature server (HTTP + gRPC). This enables per-FV hit-rate computation in Datadog and allows filtering latency/error distributions by feature view.

Key changes:
- Add Distribution() to StatsdClient interface
- New FeatureViewReadMetrics emitter (fv_read_latency_ms, fv_read_requests, fv_read_errors)
- Extend LookupMetricsAggregator with totalByFV for feature_lookup_requests
- Extract FV names from request (works with fullFeatureNames=false)
- New unified flag ENABLE_FV_LEVEL_METRICS (backward compatible with ENABLE_MISSING_KEY_METRICS)
- Instrument GetOnlineFeatures and GetOnlineFeaturesRange in both HTTP and gRPC handlers

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
