### PR TITLE
fix: Skip Cassandra rows whose TTL exceeds the 20-year maximum

### DIFF
--- a/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
@@ -84,6 +84,12 @@ E_CASSANDRA_UNKNOWN_LB_POLICY = (
     "Unknown/unsupported Load Balancing Policy name in Cassandra configuration"
 )
 
+# Cassandra's hard maximum TTL is 20 years (in seconds). A larger TTL is
+# rejected by the server ("ttl is too large" or, when it also overflows the
+# 32-bit int, "Unable to make int from ..."), which would otherwise abort the
+# whole batch and stall a stream on a single bad row.
+CASSANDRA_MAX_TTL = 630_720_000
+
 # CQL command templates (that is, before replacing schema names)
 INSERT_CQL_4_TEMPLATE = (
     "INSERT INTO {fqtable} (feature_name,"
@@ -517,6 +523,14 @@ class CassandraOnlineStore(OnlineStore):
                     )
                     if ttl < 0:
                         # The ttl is negative when the timestamp-adjusted ttl is in the past in which case skip inserting the row
+                        continue
+                    if ttl > CASSANDRA_MAX_TTL:
+                        logger.warning(
+                            f"Skipping row for {fqtable}: computed TTL {ttl}s exceeds "
+                            f"Cassandra's maximum of {CASSANDRA_MAX_TTL}s "
+                            f"(event_timestamp={timestamp}). The source timestamp is "
+                            f"likely invalid."
+                        )
                         continue
 
                     feature_values: tuple[Any, ...] = ()

--- a/sdk/python/tests/expediagroup/test_cassandra_online_store.py
+++ b/sdk/python/tests/expediagroup/test_cassandra_online_store.py
@@ -10,6 +10,7 @@ from cassandra.cluster import Cluster
 from feast import Entity, Field, FileSource, RepoConfig, ValueType, utils
 from feast.infra.offline_stores.dask import DaskOfflineStoreConfig
 from feast.infra.online_stores.cassandra_online_store.cassandra_online_store import (
+    CASSANDRA_MAX_TTL,
     CassandraOnlineStore,
     CassandraOnlineStoreConfig,
 )
@@ -267,6 +268,55 @@ class TestCassandraOnlineStore:
         )
         count = [row.count for row in result]
         assert count[0] == 10
+
+    def test_cassandra_online_write_batch_skips_ttl_over_cassandra_max(
+        self,
+        cassandra_session,
+        repo_config: RepoConfig,
+        online_store: CassandraOnlineStore,
+        caplog,
+    ):
+        """
+        A row whose computed TTL exceeds Cassandra's 20-year maximum (typically
+        caused by a far-future event_timestamp) must be skipped and logged,
+        not allowed to abort the whole batch. Otherwise a single bad record
+        fails the micro-batch and stalls the stream indefinitely.
+        """
+        session, keyspace = cassandra_session
+        n_good = 5
+        (
+            feature_view,
+            data,
+        ) = self._create_sorted_features_with_one_far_future_row(n_good=n_good)
+        constructed_table_name = (
+            online_store._fq_table_name(
+                keyspace,
+                repo_config.project,
+                feature_view,
+                repo_config.online_store.table_name_format_version,
+            )
+            .split(".")[1]
+            .strip('"')
+        )
+
+        online_store._create_table(repo_config, repo_config.project, feature_view)
+        with caplog.at_level("WARNING"):
+            online_store.online_write_batch(
+                config=repo_config,
+                table=feature_view,
+                data=data,
+                progress=None,
+            )
+
+        # Only the good rows land; the far-future row is skipped, not fatal.
+        result = session.execute(
+            f"SELECT COUNT(*) from {keyspace}.{constructed_table_name};"
+        )
+        count = [row.count for row in result]
+        assert count[0] == n_good
+        assert any(
+            "exceeds Cassandra's maximum" in rec.message for rec in caplog.records
+        )
 
     def test_cassandra_online_write_batch(
         self,
@@ -565,6 +615,54 @@ class TestCassandraOnlineStore:
             )
             for i in range(n)
         ]
+
+    def _create_sorted_features_with_one_far_future_row(self, n_good=5):
+        fv = SortedFeatureView(
+            name="sortedfeatureview_far_future",
+            source=FileSource(
+                name="my_file_source",
+                path="test.parquet",
+                timestamp_field="event_timestamp",
+            ),
+            entities=[Entity(name="id")],
+            ttl=timedelta(seconds=10),
+            sort_keys=[
+                SortKey(
+                    name="event_timestamp",
+                    value_type=ValueType.UNIX_TIMESTAMP,
+                    default_sort_order=SortOrder.DESC,
+                )
+            ],
+            schema=[
+                Field(name="id", dtype=String),
+                Field(name="text", dtype=String),
+                Field(name="event_timestamp", dtype=UnixTimestamp),
+            ],
+        )
+
+        def row(i, ts):
+            return (
+                EntityKeyProto(
+                    join_keys=["id"],
+                    entity_values=[ValueProto(string_val=str(i))],
+                ),
+                {
+                    "text": ValueProto(string_val="text"),
+                    "event_timestamp": ValueProto(
+                        unix_timestamp_val=int(ts.timestamp())
+                    ),
+                },
+                ts,
+                None,
+            )
+
+        now = datetime.utcnow()
+        # A timestamp ~25 years in the future yields a TTL well above
+        # Cassandra's 20-year (CASSANDRA_MAX_TTL) cap.
+        far_future = now + timedelta(seconds=CASSANDRA_MAX_TTL + 31_536_000)
+        data = [row(i, now) for i in range(n_good)]
+        data.append(row(n_good, far_future))
+        return fv, data
 
     def _create_n_test_sample_features(self, n=10):
         fv = SortedFeatureView(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

A SortedFeatureView row with a far-future event_timestamp produces a per-row TTL above Cassandra's 20-year cap (630,720,000s). Because the TTL is inlined into the CQL statement, session.prepare() rejects it ("ttl is too large" / "Unable to make int from ..."). That exception is raised during batch construction, bypasses the async on_failure handler, and aborts the entire micro-batch — stalling a stream indefinitely on a single bad record (the checkpoint can never advance past the poison row).

Add a CASSANDRA_MAX_TTL guard mirroring the existing 'ttl < 0' skip: oversized-TTL rows are now skipped and logged at WARNING instead of crashing the batch, so good rows in the same batch keep flowing. The non-sorted insert path uses a static key_ttl_seconds and cannot overflow from row data, so it needs no guard.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
