### PR TITLE
fix: Send data using content= in http registry

### DIFF
--- a/sdk/python/feast/infra/registry/http.py
+++ b/sdk/python/feast/infra/registry/http.py
@@ -146,7 +146,10 @@ class HttpRegistry(BaseRegistry):
 
     def _send_request(self, method: str, url: str, params=None, data=None):
         try:
-            request = httpx.Request(method=method, url=url, params=params, data=data)
+            headers = {"Content-Type": "application/json"} if data is not None else None
+            request = httpx.Request(
+                method=method, url=url, params=params, content=data, headers=headers
+            )
             response = self.http_client.send(request)
             response.raise_for_status()
             return response.json()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR fixes a small bug I discovered while testing the http registry built off the master branch. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
