### PR TITLE
fix: Cassandra Entity Key Serialization + Warning 

### DIFF
--- a/.github/workflows/operator_pr.yml
+++ b/.github/workflows/operator_pr.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.9
+          go-version: 1.25.0
       - name: Operator tests
         run: make -C infra/feast-operator test
       - name: After code formatting, check for uncommitted differences

--- a/.github/workflows/operator_pr.yml
+++ b/.github/workflows/operator_pr.yml
@@ -1,11 +1,6 @@
 name: operator-pr
 
 on: [pull_request]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   operator-test:
     runs-on: ubuntu-latest
@@ -14,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.0
+          go-version: 1.22.9
       - name: Operator tests
         run: make -C infra/feast-operator test
       - name: After code formatting, check for uncommitted differences

--- a/.github/workflows/operator_pr.yml
+++ b/.github/workflows/operator_pr.yml
@@ -1,6 +1,11 @@
 name: operator-pr
 
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   operator-test:
     runs-on: ubuntu-latest
@@ -9,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.9
+          go-version: 1.25.0
       - name: Operator tests
         run: make -C infra/feast-operator test
       - name: After code formatting, check for uncommitted differences

--- a/go/internal/feast/onlinestore/cassandraonlinestore.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
@@ -45,6 +46,8 @@ type CassandraOnlineStore struct {
 
 	// Caches table names instead of generating the table name every time
 	tableNameCache sync.Map
+
+	versionMismatchWarned sync.Map
 }
 
 type CassandraConfig struct {
@@ -393,7 +396,7 @@ func (c *CassandraOnlineStore) buildCassandraEntityKeys(entityKeys []*types.Enti
 	cassandraKeys := make([]any, len(entityKeys))
 	cassandraKeyToEntityIndex := make(map[string]int)
 	for i := 0; i < len(entityKeys); i++ {
-		var key, err = utils.SerializeEntityKey(entityKeys[i], 2)
+		var key, err = utils.SerializeEntityKey(entityKeys[i], c.resolvedEntityKeySerializationVersion())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -402,6 +405,15 @@ func (c *CassandraOnlineStore) buildCassandraEntityKeys(entityKeys []*types.Enti
 		cassandraKeyToEntityIndex[encodedKey] = i
 	}
 	return cassandraKeys, cassandraKeyToEntityIndex, nil
+}
+
+func (c *CassandraOnlineStore) resolvedEntityKeySerializationVersion() int64 {
+	return resolveEntityKeySerializationVersion(c.config)
+}
+
+func (c *CassandraOnlineStore) warnPotentialVersionMismatch(views []string, numKeys int) {
+	warnPotentialEntityKeyVersionMismatch(
+		&c.versionMismatchWarned, "Cassandra", c.resolvedEntityKeySerializationVersion(), views, numKeys)
 }
 
 func (c *CassandraOnlineStore) validateUniqueFeatureNames(featureViewNames []string) error {
@@ -499,7 +511,9 @@ func (c *CassandraOnlineStore) executeBatchV2(
 	var deserializedValue *types.Value
 
 	batchFeatures := make(map[string]map[string]*FeatureData)
+	rowsScanned := 0
 	for scanner.Next() {
+		rowsScanned++
 		err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 		if err != nil {
 			return nil, fmt.Errorf("could not read row in query for (entity key, feature name, value, event ts): %w", err)
@@ -528,6 +542,15 @@ func (c *CassandraOnlineStore) executeBatchV2(
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("failed to scan features: %w", err)
+	}
+
+	// OnlineReadV2 issues a single batch that covers this feature view's full set of entity
+	// keys, so rowsScanned == 0 here means the entire request missed for the only view
+	// involved. That is exactly the "all requested views missed" condition, so warning
+	// directly from this single-batch path is safe (unlike the V1 OnlineRead path, which
+	// splits keys across batches and must aggregate results before deciding).
+	if rowsScanned == 0 {
+		c.warnPotentialVersionMismatch([]string{job.ViewName}, len(job.EntityKeys))
 	}
 
 	for _, serializedEntityKey := range job.EntityKeys {
@@ -591,6 +614,10 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 
 	batches := c.createBatches(serializedEntityKeys)
 
+	// viewsWithData records which feature views had at least one row returned by Cassandra.
+	// Used after all batches complete to detect per-view complete misses (possible version mismatch).
+	viewsWithData := &sync.Map{}
+
 	g.Go(func() error {
 		defer close(jobsChan)
 
@@ -635,13 +662,27 @@ func (c *CassandraOnlineStore) OnlineRead(ctx context.Context, entityKeys []*typ
 	for job := range jobsChan {
 		g.Go(func(j BatchJob) func() error {
 			return func() error {
-				return c.executeBatch(ctx, j, serializedEntityKeyToIndex, results, featureNamesToIdx)
+				return c.executeBatch(ctx, j, serializedEntityKeyToIndex, results, featureNamesToIdx, viewsWithData)
 			}
 		}(job))
 	}
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	// After all batches: only warn if EVERY requested feature view returned zero rows. A
+	// single view missing is normal (sparse/cold entities); a complete miss across the whole
+	// request is a stronger — though still not conclusive — signal of a possible
+	// serialization version mismatch. Warn once (deduped) for the full set of views.
+	missedViews := make([]string, 0, len(viewGroups))
+	for viewName := range viewGroups {
+		if _, hasData := viewsWithData.Load(viewName); !hasData {
+			missedViews = append(missedViews, viewName)
+		}
+	}
+	if len(viewGroups) > 0 && len(missedViews) == len(viewGroups) {
+		c.warnPotentialVersionMismatch(missedViews, len(entityKeys))
 	}
 
 	return results, nil
@@ -653,6 +694,7 @@ func (c *CassandraOnlineStore) executeBatch(
 	serializedEntityKeyToIndex map[string]int,
 	results [][]FeatureData,
 	featureNamesToIdx map[string]int,
+	viewsWithData *sync.Map,
 ) error {
 	iter := c.session.Query(job.CQLStatement, job.EntityKeys...).WithContext(ctx).Iter()
 	defer iter.Close()
@@ -665,7 +707,9 @@ func (c *CassandraOnlineStore) executeBatch(
 	var deserializedValue *types.Value
 
 	batchFeatures := make(map[string]map[string]*FeatureData)
+	rowsScanned := 0
 	for scanner.Next() {
+		rowsScanned++
 		err := scanner.Scan(&entityKey, &featureName, &eventTs, &valueStr)
 		if err != nil {
 			return fmt.Errorf("could not read row in query for (entity key, feature name, value, event ts): %w", err)
@@ -694,6 +738,12 @@ func (c *CassandraOnlineStore) executeBatch(
 
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("failed to scan features: %w", err)
+	}
+
+	// Mark this feature view as having returned data so OnlineRead can determine
+	// per-view whether a complete miss occurred across all batches.
+	if rowsScanned > 0 && viewsWithData != nil {
+		viewsWithData.Store(job.ViewName, struct{}{})
 	}
 
 	for _, serializedEntityKey := range job.EntityKeys {
@@ -914,6 +964,11 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 	var waitGroup sync.WaitGroup
 	errorsChannel := make(chan error, nBatches)
 
+	// sawAnyRow is set to true by the first goroutine that returns at least one row.
+	// If it remains false after all batches finish, every entity key got a complete miss —
+	// a possible indicator of a serialization version mismatch.
+	var sawAnyRow atomic.Bool
+
 	canonicalFeats := make([]string, len(groupedRefs.FeatureNames))
 	isSortKey := make([]bool, len(groupedRefs.FeatureNames))
 	for i, name := range groupedRefs.FeatureNames {
@@ -950,6 +1005,7 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 					continue
 				}
 
+				sawAnyRow.Store(true)
 				rowData := results[rowIdx]
 
 				for i, featName := range groupedRefs.FeatureNames {
@@ -1009,6 +1065,12 @@ func (c *CassandraOnlineStore) OnlineReadRange(ctx context.Context, groupedRefs 
 
 	if len(allErrors) > 0 {
 		return nil, errors.Join(allErrors...)
+	}
+
+	// OnlineReadRange handles a single feature view, so a complete miss across all batches is
+	// the "all requested views missed" condition. Warn once if this looks like a version mismatch.
+	if !sawAnyRow.Load() {
+		c.warnPotentialVersionMismatch([]string{prepCtx.featureViewName}, len(groupedRefs.EntityKeys))
 	}
 
 	return results, nil

--- a/go/internal/feast/onlinestore/cassandraonlinestore_test.go
+++ b/go/internal/feast/onlinestore/cassandraonlinestore_test.go
@@ -3,16 +3,20 @@
 package onlinestore
 
 import (
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
+	"github.com/feast-dev/feast/go/internal/feast/registry"
+	"github.com/feast-dev/feast/go/internal/feast/utils"
 	"github.com/feast-dev/feast/go/protos/feast/core"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
 	"github.com/feast-dev/feast/go/protos/feast/types"
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -538,4 +542,127 @@ func TestResolveFeatureValue_AlreadyLowercaseFeature(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, serving.FieldStatus_PRESENT, status)
 	assert.Equal(t, "hello", val.(*types.Value).GetStringVal())
+}
+
+func sampleEntityKey() *types.EntityKey {
+	return &types.EntityKey{
+		JoinKeys: []string{"user_id"},
+		EntityValues: []*types.Value{
+			{Val: &types.Value_Int64Val{Int64Val: 42}},
+		},
+	}
+}
+
+func serializedHex(t *testing.T, key *types.EntityKey, version int64) string {
+	t.Helper()
+	b, err := utils.SerializeEntityKey(key, version)
+	require.NoError(t, err)
+	return hex.EncodeToString(*b)
+}
+
+func TestBuildCassandraEntityKeys_UsesConfiguredVersion(t *testing.T) {
+	key := sampleEntityKey()
+
+	for _, tc := range []struct {
+		name    string
+		version int64
+	}{
+		{"version2", 2},
+		{"version3", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &CassandraOnlineStore{
+				config: &registry.RepoConfig{
+					EntityKeySerializationVersion: tc.version,
+				},
+			}
+
+			cassandraKeys, keyToIdx, err := store.buildCassandraEntityKeys([]*types.EntityKey{key})
+			require.NoError(t, err)
+			require.Len(t, cassandraKeys, 1)
+
+			gotHex := cassandraKeys[0].(string)
+			wantHex := serializedHex(t, key, tc.version)
+
+			assert.Equal(t, wantHex, gotHex,
+				"hex key for version %d should match utils.SerializeEntityKey output", tc.version)
+			assert.Equal(t, 0, keyToIdx[gotHex])
+		})
+	}
+
+	storeV2 := &CassandraOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 2}}
+	storeV3 := &CassandraOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 3}}
+	keysV2, _, _ := storeV2.buildCassandraEntityKeys([]*types.EntityKey{key})
+	keysV3, _, _ := storeV3.buildCassandraEntityKeys([]*types.EntityKey{key})
+	assert.NotEqual(t, keysV2[0], keysV3[0],
+		"v2 and v3 serialized keys must differ for the same entity key")
+}
+
+func TestBuildCassandraEntityKeys_ZeroVersionDefaultsToV3(t *testing.T) {
+	key := sampleEntityKey()
+
+	store := &CassandraOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 0},
+	}
+	keys, _, err := store.buildCassandraEntityKeys([]*types.EntityKey{key})
+	require.NoError(t, err)
+
+	wantHex := serializedHex(t, key, 3)
+	assert.Equal(t, wantHex, keys[0].(string), "zero version should produce v3 keys")
+}
+
+func TestResolvedEntityKeySerializationVersion(t *testing.T) {
+	assert.Equal(t, int64(3), (&CassandraOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 0}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(2), (&CassandraOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 2}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(3), (&CassandraOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 3}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(3), (&CassandraOnlineStore{config: nil}).resolvedEntityKeySerializationVersion(), "nil config should default to v3 without panicking")
+}
+
+func TestWarnPotentialVersionMismatch_DeduplicatesPerRequest(t *testing.T) {
+	store := &CassandraOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	const view = "my_feature_view"
+
+	store.warnPotentialVersionMismatch([]string{view}, 5)
+	_, warned := store.versionMismatchWarned.Load(view)
+	assert.True(t, warned, "view should be recorded after first call")
+
+	store.warnPotentialVersionMismatch([]string{view}, 5)
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 1, count, "only one entry should exist for the view after repeated calls")
+
+	const otherView = "other_feature_view"
+	store.warnPotentialVersionMismatch([]string{otherView}, 3)
+	count = 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 2, count, "each distinct request should have its own warning entry")
+}
+
+func TestWarnPotentialVersionMismatch_MultiViewDedupIsOrderIndependent(t *testing.T) {
+	store := &CassandraOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	store.warnPotentialVersionMismatch([]string{"view_a", "view_b"}, 4)
+	store.warnPotentialVersionMismatch([]string{"view_b", "view_a"}, 4)
+
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 1, count, "same set of views in any order should dedupe to one entry")
+}
+
+func TestWarnPotentialVersionMismatch_EmptyViewsIsNoop(t *testing.T) {
+	store := &CassandraOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	store.warnPotentialVersionMismatch(nil, 5)
+	store.warnPotentialVersionMismatch([]string{}, 5)
+
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 0, count, "no warning entry should be recorded for an empty view set")
 }

--- a/go/internal/feast/onlinestore/egvalkeyonlinestore.go
+++ b/go/internal/feast/onlinestore/egvalkeyonlinestore.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/feast-dev/feast/go/internal/feast/model"
 	"github.com/feast-dev/feast/go/internal/feast/utils"
@@ -53,6 +54,10 @@ type ValkeyOnlineStore struct {
 
 	// Number of keys to read in a batch
 	ReadBatchSize int
+
+	// Tracks request shapes for which a potential serialization-version-mismatch warning has
+	// already been emitted, so the warning fires at most once per shape per process lifetime.
+	versionMismatchWarned sync.Map
 }
 
 func parseConnectionString(onlineStoreConfig map[string]interface{}, valkeyStoreType valkeyType) (valkey.ClientOption, error) {
@@ -257,6 +262,15 @@ func (v *ValkeyOnlineStore) buildValkeyKeys(entityKeys []*types.EntityKey) ([]*[
 	return valkeyKeys, nil
 }
 
+func (v *ValkeyOnlineStore) resolvedEntityKeySerializationVersion() int64 {
+	return resolveEntityKeySerializationVersion(v.config)
+}
+
+func (v *ValkeyOnlineStore) warnPotentialVersionMismatch(views []string, numKeys int) {
+	warnPotentialEntityKeyVersionMismatch(
+		&v.versionMismatchWarned, "Valkey", v.resolvedEntityKeySerializationVersion(), views, numKeys)
+}
+
 func (v *ValkeyOnlineStore) OnlineReadV2(ctx context.Context, entityKeys []*types.EntityKey, featureViewNames []string, featureNames []string) ([][]FeatureData, error) {
 	return v.OnlineRead(ctx, entityKeys, featureViewNames, featureNames)
 }
@@ -282,6 +296,9 @@ func (v *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 	}
 
 	var resContainsNonNil bool
+	// viewsWithData records which feature views returned at least one non-nil value across all
+	// entity keys. Used after the read completes to detect a complete miss (possible version mismatch).
+	viewsWithData := make(map[string]bool)
 	for entityIndex, values := range v.client.DoMulti(ctx, cmds...) {
 
 		if err := values.Error(); err != nil {
@@ -324,6 +341,7 @@ func (v *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 				if value, _, err = utils.UnmarshalStoredProto([]byte(valueString)); err != nil {
 					return nil, errors.New("error converting parsed valkey Value to types.Value")
 				}
+				viewsWithData[featureViewName] = true
 			}
 
 			if _, ok := timeStampMap[featureViewName]; !ok {
@@ -351,6 +369,23 @@ func (v *ValkeyOnlineStore) OnlineRead(ctx context.Context, entityKeys []*types.
 		if !resContainsNonNil {
 			results[entityIndex] = nil
 		}
+	}
+
+	// Only warn if EVERY requested feature view returned zero data. A single sparse view is
+	// normal; a complete miss across the whole request is a stronger — though not conclusive —
+	// signal of a possible serialization version mismatch. Warn once (deduped) per request shape.
+	requestedViews := make(map[string]struct{})
+	for _, viewName := range featureViewNames {
+		requestedViews[viewName] = struct{}{}
+	}
+	missedViews := make([]string, 0, len(requestedViews))
+	for viewName := range requestedViews {
+		if !viewsWithData[viewName] {
+			missedViews = append(missedViews, viewName)
+		}
+	}
+	if len(requestedViews) > 0 && len(missedViews) == len(requestedViews) {
+		v.warnPotentialVersionMismatch(missedViews, len(entityKeys))
 	}
 
 	return results, nil
@@ -550,6 +585,7 @@ func (v *ValkeyOnlineStore) processEntityKey(
 	limit int64,
 	results [][]RangeFeatureData,
 	featNames, fvNames []string,
+	sawAnyRow *atomic.Bool,
 ) error {
 	select {
 	case <-ctx.Done():
@@ -650,6 +686,11 @@ func (v *ValkeyOnlineStore) processEntityKey(
 			}
 			continue
 		}
+		// At least one stored member exists for this entity/feature view — record that the
+		// request returned data so OnlineReadRange can detect a complete miss across all keys.
+		if sawAnyRow != nil {
+			sawAnyRow.Store(true)
+		}
 		// build list of hash fields to retrieve
 		fields := append(append([]string{}, grp.FieldHashes...), grp.TsKey)
 		if err := valkeyBatchHMGET(
@@ -739,6 +780,11 @@ func (v *ValkeyOnlineStore) OnlineReadRange(
 
 	results := make([][]RangeFeatureData, len(groupedRefs.EntityKeys))
 
+	// sawAnyRow is set by the first entity goroutine that finds at least one stored member.
+	// If it remains false after all goroutines finish, every entity key got a complete miss —
+	// a possible (not guaranteed) indicator of a serialization version mismatch.
+	var sawAnyRow atomic.Bool
+
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(groupedRefs.EntityKeys))
 
@@ -757,6 +803,7 @@ func (v *ValkeyOnlineStore) OnlineReadRange(
 				limit,
 				results,
 				featNames, fvNames,
+				&sawAnyRow,
 			); err != nil {
 				errChan <- err
 			}
@@ -776,6 +823,16 @@ func (v *ValkeyOnlineStore) OnlineReadRange(
 	if len(allErrors) > 0 {
 		return nil, errors.Join(allErrors...)
 	}
+
+	// Complete miss across all entity keys — warn once if this looks like a version mismatch.
+	if !sawAnyRow.Load() {
+		requestedViews := make([]string, 0, len(fvGroups))
+		for fv := range fvGroups {
+			requestedViews = append(requestedViews, fv)
+		}
+		v.warnPotentialVersionMismatch(requestedViews, len(groupedRefs.EntityKeys))
+	}
+
 	return results, nil
 }
 

--- a/go/internal/feast/onlinestore/egvalkeyonlinestore_test.go
+++ b/go/internal/feast/onlinestore/egvalkeyonlinestore_test.go
@@ -355,3 +355,59 @@ func TestGetValkeyTraceServiceName(t *testing.T) {
 		os.Unsetenv("DD_SERVICE")
 	})
 }
+
+func TestValkeyResolvedEntityKeySerializationVersion(t *testing.T) {
+	assert.Equal(t, int64(3), (&ValkeyOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 0}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(2), (&ValkeyOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 2}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(3), (&ValkeyOnlineStore{config: &registry.RepoConfig{EntityKeySerializationVersion: 3}}).resolvedEntityKeySerializationVersion())
+	assert.Equal(t, int64(3), (&ValkeyOnlineStore{config: nil}).resolvedEntityKeySerializationVersion(), "nil config should default to v3 without panicking")
+}
+
+func TestValkeyWarnPotentialVersionMismatch_DeduplicatesPerRequest(t *testing.T) {
+	store := &ValkeyOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	const view = "my_feature_view"
+
+	store.warnPotentialVersionMismatch([]string{view}, 5)
+	_, warned := store.versionMismatchWarned.Load(view)
+	assert.True(t, warned, "view should be recorded after first call")
+
+	store.warnPotentialVersionMismatch([]string{view}, 5)
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 1, count, "only one entry should exist for the view after repeated calls")
+
+	const otherView = "other_feature_view"
+	store.warnPotentialVersionMismatch([]string{otherView}, 3)
+	count = 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 2, count, "each distinct request should have its own warning entry")
+}
+
+func TestValkeyWarnPotentialVersionMismatch_MultiViewDedupIsOrderIndependent(t *testing.T) {
+	store := &ValkeyOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	store.warnPotentialVersionMismatch([]string{"view_a", "view_b"}, 4)
+	store.warnPotentialVersionMismatch([]string{"view_b", "view_a"}, 4)
+
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 1, count, "same set of views in any order should dedupe to one entry")
+}
+
+func TestValkeyWarnPotentialVersionMismatch_EmptyViewsIsNoop(t *testing.T) {
+	store := &ValkeyOnlineStore{
+		config: &registry.RepoConfig{EntityKeySerializationVersion: 3},
+	}
+
+	store.warnPotentialVersionMismatch(nil, 5)
+	store.warnPotentialVersionMismatch([]string{}, 5)
+
+	count := 0
+	store.versionMismatchWarned.Range(func(_, _ any) bool { count++; return true })
+	assert.Equal(t, 0, count, "no warning entry should be recorded for an empty view set")
+}

--- a/go/internal/feast/onlinestore/entitykeyserialization.go
+++ b/go/internal/feast/onlinestore/entitykeyserialization.go
@@ -1,0 +1,53 @@
+package onlinestore
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/feast-dev/feast/go/internal/feast/registry"
+	"github.com/rs/zerolog/log"
+)
+
+// resolveEntityKeySerializationVersion returns the entity key serialization version that an
+// online store should use for reads. It mirrors utils.SerializeEntityKey (and Python's
+// default): a 0/unset version resolves to v3. It is nil-safe so it can be called on stores
+// constructed without a config (e.g. in tests).
+func resolveEntityKeySerializationVersion(config *registry.RepoConfig) int64 {
+	if config != nil && config.EntityKeySerializationVersion != 0 {
+		return config.EntityKeySerializationVersion
+	}
+	return 3
+}
+
+// warnPotentialEntityKeyVersionMismatch emits a single, de-duplicated warning when an online
+// read returned no data for every requested feature view. A complete miss across the whole
+// request is a *potential* (not guaranteed) symptom of an entity_key_serialization_version
+// mismatch between the write (materialization) and read (feature server) paths. It can also
+// legitimately mean the requested entities simply are not present (e.g. not yet materialized
+// or expired), so the message is intentionally non-alarming.
+//
+// De-duplication is keyed on the sorted set of views (tracked in warned) so each distinct
+// request shape warns at most once per process lifetime. storeName is used only to make the
+// message specific (e.g. "Cassandra", "Valkey"). configuredVersion is the effective read
+// version, surfaced in the message to help operators compare against materialization.
+func warnPotentialEntityKeyVersionMismatch(warned *sync.Map, storeName string, configuredVersion int64, views []string, numKeys int) {
+	if len(views) == 0 {
+		return
+	}
+	sortedViews := append([]string(nil), views...)
+	sort.Strings(sortedViews)
+	dedupKey := strings.Join(sortedViews, ",")
+	if _, alreadyWarned := warned.LoadOrStore(dedupKey, struct{}{}); alreadyWarned {
+		return
+	}
+	log.Warn().Msgf(
+		"%s online read returned no data for all %d entity key(s) across every requested "+
+			"feature view %v. This is not necessarily a problem — it can simply mean the requested "+
+			"entities are not present (e.g. not yet materialized or expired). However, if data was "+
+			"expected, it may indicate an entity_key_serialization_version mismatch between "+
+			"materialization (write) and the feature server (read). If so, verify that "+
+			"entity_key_serialization_version in feature_store.yaml (current configured read version: "+
+			"%d) matches the version used to materialize these feature views.",
+		storeName, numKeys, sortedViews, configuredVersion)
+}

--- a/go/internal/test/go_integration_test_utils.go
+++ b/go/internal/test/go_integration_test_utils.go
@@ -279,8 +279,8 @@ func SetupInitializedRepo(basePath string) error {
 		t.Hour(), t.Minute(), t.Second())
 
 	// Use an explicit start time far enough in the past to include test data.
-	// Test parquet files have timestamps from April 2025, so we start from 2025-01-01.
-	materializeCommand := exec.Command(feastExec, "materialize", "2025-01-01T00:00:00", formattedEndTime)
+	// Test parquet files have timestamps from 2021-2022, so we start from 2021-01-01.
+	materializeCommand := exec.Command(feastExec, "materialize", "2021-01-01T00:00:00", formattedEndTime)
 	materializeCommand.Env = os.Environ()
 	materializeCommand.Dir = featureRepoPath
 	out, err = materializeCommand.CombinedOutput()

--- a/go/internal/test/go_integration_test_utils.go
+++ b/go/internal/test/go_integration_test_utils.go
@@ -274,11 +274,13 @@ func SetupInitializedRepo(basePath string) error {
 	}
 	t := time.Now()
 
-	formattedTime := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",
+	formattedEndTime := fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d",
 		t.Year(), t.Month(), t.Day(),
 		t.Hour(), t.Minute(), t.Second())
 
-	materializeCommand := exec.Command(feastExec, "materialize-incremental", formattedTime)
+	// Use an explicit start time far enough in the past to include test data.
+	// Test parquet files have timestamps from April 2025, so we start from 2025-01-01.
+	materializeCommand := exec.Command(feastExec, "materialize", "2025-01-01T00:00:00", formattedEndTime)
 	materializeCommand.Env = os.Environ()
 	materializeCommand.Dir = featureRepoPath
 	out, err = materializeCommand.CombinedOutput()

--- a/infra/feast-operator/.golangci.yml
+++ b/infra/feast-operator/.golangci.yml
@@ -1,55 +1,67 @@
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-    - path: "test/*"
-      linters:
-        - lll
-    - path: "upgrade/*"
-      linters:
-        - lll
-    - path: "previous-version/*"
-      linters:
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
+    - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - ginkgolinter
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"
+        - "-ST*"
+  exclusions:
+    generated: lax
+    presets: []
     rules:
-      - name: comment-spacings
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - goconst
+          - lll
+        path: internal/*
+      - linters:
+          - goconst
+          - lll
+        path: test/*
+      - linters:
+          - lll
+        path: upgrade/*
+      - linters:
+          - lll
+        path: previous-version/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -56,7 +56,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 FS_IMG ?= quay.io/feastdev/feature-server:$(VERSION)
 CJ_IMG ?= quay.io/openshift/origin-cli:4.17
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -116,7 +116,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: build-installer vet lint envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOTOOLCHAIN=go$(shell go env GOVERSION | sed 's/^go//') go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
@@ -242,7 +242,7 @@ ENVSUBST = $(LOCALBIN)/envsubst
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 CRD_REF_DOCS_VERSION ?= v0.1.0
-ENVTEST_VERSION ?= release-0.18
+ENVTEST_VERSION ?= release-0.21
 GOLANGCI_LINT_VERSION ?= v1.59.1
 ENVSUBST_VERSION ?= v1.4.2
 

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -56,7 +56,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 FS_IMG ?= quay.io/feastdev/feature-server:$(VERSION)
 CJ_IMG ?= quay.io/openshift/origin-cli:4.17
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 1.31.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -116,7 +116,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: build-installer vet lint envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOTOOLCHAIN=go$(shell go env GOVERSION | sed 's/^go//') go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
@@ -239,11 +239,11 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ENVSUBST = $(LOCALBIN)/envsubst
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.4.2
-CONTROLLER_TOOLS_VERSION ?= v0.15.0
-CRD_REF_DOCS_VERSION ?= v0.1.0
-ENVTEST_VERSION ?= release-0.18
-GOLANGCI_LINT_VERSION ?= v1.59.1
+KUSTOMIZE_VERSION ?= v5.4.3
+CONTROLLER_TOOLS_VERSION ?= v0.18.0
+CRD_REF_DOCS_VERSION ?= v0.2.0
+ENVTEST_VERSION ?= release-0.21
+GOLANGCI_LINT_VERSION ?= v2.12.2
 ENVSUBST_VERSION ?= v1.4.2
 
 .PHONY: kustomize
@@ -264,7 +264,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: envsubst
 envsubst: $(ENVSUBST) ## Download envsubst locally if necessary.

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -56,7 +56,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 FS_IMG ?= quay.io/feastdev/feature-server:$(VERSION)
 CJ_IMG ?= quay.io/openshift/origin-cli:4.17
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.30.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -116,7 +116,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: build-installer vet lint envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOTOOLCHAIN=go$(shell go env GOVERSION | sed 's/^go//') go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
@@ -242,7 +242,7 @@ ENVSUBST = $(LOCALBIN)/envsubst
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 CRD_REF_DOCS_VERSION ?= v0.1.0
-ENVTEST_VERSION ?= release-0.21
+ENVTEST_VERSION ?= release-0.18
 GOLANGCI_LINT_VERSION ?= v1.59.1
 ENVSUBST_VERSION ?= v1.4.2
 

--- a/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
+++ b/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: featurestores.feast.dev
 spec:
   group: feast.dev
@@ -113,8 +113,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -320,7 +319,7 @@ spec:
                       activeDeadlineSeconds:
                         description: |-
                           Specifies the duration in seconds relative to the startTime that the job
-                          may be continuously active before the system tr
+                          may be continuously active before the system...
                         format: int64
                         type: integer
                       backoffLimit:
@@ -496,8 +495,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -871,8 +869,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -1333,8 +1330,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -1798,8 +1794,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -2243,7 +2238,7 @@ spec:
                       supplementalGroups:
                         description: |-
                           A list of groups applied to the first process run in each container, in addition
-                          to the container's primary GID, the fsG
+                          to the container's primary GID, the...
                         items:
                           format: int64
                           type: integer
@@ -2305,8 +2300,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -2604,7 +2598,7 @@ spec:
                         awsElasticBlockStore:
                           description: |-
                             awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                            kubelet's host machine and then exposed to th
+                            kubelet's host machine and then exposed to...
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -2654,7 +2648,7 @@ spec:
                             kind:
                               description: 'kind expected values are Shared: multiple
                                 blob disks per storage account  Dedicated: single
-                                blob disk per storage accoun'
+                                blob disk per storage...'
                               type: string
                             readOnly:
                               description: |-
@@ -2781,7 +2775,7 @@ spec:
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
-                                ConfigMap will be projected into the volum
+                                ConfigMap will be projected into the...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -2821,7 +2815,7 @@ spec:
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
-                            CSI drivers (Beta fea
+                            CSI drivers (Beta...
                           properties:
                             driver:
                               description: driver is the name of the CSI driver that
@@ -2833,7 +2827,7 @@ spec:
                             nodePublishSecretRef:
                               description: |-
                                 nodePublishSecretRef is a reference to the secret object containing
-                                sensitive information to pass to the CSI driver to c
+                                sensitive information to pass to the CSI driver to...
                               properties:
                                 name:
                                   default: ""
@@ -2895,7 +2889,7 @@ spec:
                                   mode:
                                     description: |-
                                       Optional: mode bits used to set permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal valu
+                                      between 0000 and 0777 or a decimal...
                                     format: int32
                                     type: integer
                                   path:
@@ -3144,9 +3138,9 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
-                              description: "wwids Optional: FC volume world wide identifiers
-                                (wwids)\nEither wwids or combination of targetWWNs
-                                and lun must be set, "
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set,...
                               items:
                                 type: string
                               type: array
@@ -3181,7 +3175,7 @@ spec:
                             secretRef:
                               description: |-
                                 secretRef is Optional: secretRef is reference to the secret object containing
-                                sensitive information to pass to the plugi
+                                sensitive information to pass to the...
                               properties:
                                 name:
                                   default: ""
@@ -3202,7 +3196,7 @@ spec:
                             datasetName:
                               description: |-
                                 datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                should be considered as depreca
+                                should be considered as...
                               type: string
                             datasetUUID:
                               description: datasetUUID is the UUID of the dataset.
@@ -3212,7 +3206,7 @@ spec:
                         gcePersistentDisk:
                           description: |-
                             gcePersistentDisk represents a GCE Disk resource that is attached to a
-                            kubelet's host machine and then exposed to the po
+                            kubelet's host machine and then exposed to the...
                           properties:
                             fsType:
                               description: fsType is filesystem type of the volume
@@ -3546,7 +3540,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volum
+                                          ConfigMap will be projected into the...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -3617,7 +3611,7 @@ spec:
                                             mode:
                                               description: |-
                                                 Optional: mode bits used to set permissions on this file, must be an octal value
-                                                between 0000 and 0777 or a decimal valu
+                                                between 0000 and 0777 or a decimal...
                                               format: int32
                                               type: integer
                                             path:
@@ -3666,7 +3660,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          Secret will be projected into the volume a
+                                          Secret will be projected into the volume...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -3747,12 +3741,12 @@ spec:
                             registry:
                               description: |-
                                 registry represents a single or multiple Quobyte Registry services
-                                specified as a string as host:port pair (multiple ent
+                                specified as a string as host:port pair (multiple...
                               type: string
                             tenant:
                               description: |-
                                 tenant owning the given Quobyte volume in the Backend
-                                Used with dynamically provisioned Quobyte volumes, value is set by
+                                Used with dynamically provisioned Quobyte volumes, value is set...
                               type: string
                             user:
                               description: |-
@@ -3908,7 +3902,7 @@ spec:
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
-                                Secret will be projected into the volume a
+                                Secret will be projected into the volume...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -4094,8 +4088,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -4303,7 +4296,7 @@ spec:
                           activeDeadlineSeconds:
                             description: |-
                               Specifies the duration in seconds relative to the startTime that the job
-                              may be continuously active before the system tr
+                              may be continuously active before the system...
                             format: int64
                             type: integer
                           backoffLimit:
@@ -4482,8 +4475,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -4862,8 +4854,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -5332,8 +5323,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -5809,8 +5799,7 @@ spec:
                                         value:
                                           description: |-
                                             Variable references $(VAR_NAME) are expanded
-                                            using the previously defined environment variables in the container and
-                                            any
+                                            using the previously defined environment variables in the container and...
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -6265,7 +6254,7 @@ spec:
                           supplementalGroups:
                             description: |-
                               A list of groups applied to the first process run in each container, in addition
-                              to the container's primary GID, the fsG
+                              to the container's primary GID, the...
                             items:
                               format: int64
                               type: integer
@@ -6328,8 +6317,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -6629,7 +6617,7 @@ spec:
                             awsElasticBlockStore:
                               description: |-
                                 awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to th
+                                kubelet's host machine and then exposed to...
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -6679,7 +6667,7 @@ spec:
                                 kind:
                                   description: 'kind expected values are Shared: multiple
                                     blob disks per storage account  Dedicated: single
-                                    blob disk per storage accoun'
+                                    blob disk per storage...'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -6807,7 +6795,7 @@ spec:
                                 items:
                                   description: |-
                                     items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volum
+                                    ConfigMap will be projected into the...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -6847,7 +6835,7 @@ spec:
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
-                                CSI drivers (Beta fea
+                                CSI drivers (Beta...
                               properties:
                                 driver:
                                   description: driver is the name of the CSI driver
@@ -6860,7 +6848,7 @@ spec:
                                 nodePublishSecretRef:
                                   description: |-
                                     nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to c
+                                    sensitive information to pass to the CSI driver to...
                                   properties:
                                     name:
                                       default: ""
@@ -6924,7 +6912,7 @@ spec:
                                       mode:
                                         description: |-
                                           Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal valu
+                                          between 0000 and 0777 or a decimal...
                                         format: int32
                                         type: integer
                                       path:
@@ -7176,9 +7164,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: "wwids Optional: FC volume world wide
-                                    identifiers (wwids)\nEither wwids or combination
-                                    of targetWWNs and lun must be set, "
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set,...
                                   items:
                                     type: string
                                   type: array
@@ -7213,7 +7201,7 @@ spec:
                                 secretRef:
                                   description: |-
                                     secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugi
+                                    sensitive information to pass to the...
                                   properties:
                                     name:
                                       default: ""
@@ -7234,7 +7222,7 @@ spec:
                                 datasetName:
                                   description: |-
                                     datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as depreca
+                                    should be considered as...
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -7244,7 +7232,7 @@ spec:
                             gcePersistentDisk:
                               description: |-
                                 gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the po
+                                kubelet's host machine and then exposed to the...
                               properties:
                                 fsType:
                                   description: fsType is filesystem type of the volume
@@ -7580,7 +7568,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volum
+                                              ConfigMap will be projected into the...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7653,7 +7641,7 @@ spec:
                                                 mode:
                                                   description: |-
                                                     Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal valu
+                                                    between 0000 and 0777 or a decimal...
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -7702,7 +7690,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume a
+                                              Secret will be projected into the volume...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7783,12 +7771,12 @@ spec:
                                 registry:
                                   description: |-
                                     registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple ent
+                                    specified as a string as host:port pair (multiple...
                                   type: string
                                 tenant:
                                   description: |-
                                     tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by
+                                    Used with dynamically provisioned Quobyte volumes, value is set...
                                   type: string
                                 user:
                                   description: |-
@@ -7944,7 +7932,7 @@ spec:
                                 items:
                                   description: |-
                                     items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume a
+                                    Secret will be projected into the volume...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -8093,10 +8081,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/infra/feast-operator/config/rbac/role.yaml
+++ b/infra/feast-operator/config/rbac/role.yaml
@@ -5,35 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
@@ -63,6 +34,35 @@ rules:
   - pods/exec
   verbs:
   - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - feast.dev
   resources:

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -11,7 +11,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: featurestores.feast.dev
 spec:
   group: feast.dev
@@ -121,8 +121,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -328,7 +327,7 @@ spec:
                       activeDeadlineSeconds:
                         description: |-
                           Specifies the duration in seconds relative to the startTime that the job
-                          may be continuously active before the system tr
+                          may be continuously active before the system...
                         format: int64
                         type: integer
                       backoffLimit:
@@ -504,8 +503,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -879,8 +877,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -1341,8 +1338,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -1806,8 +1802,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -2251,7 +2246,7 @@ spec:
                       supplementalGroups:
                         description: |-
                           A list of groups applied to the first process run in each container, in addition
-                          to the container's primary GID, the fsG
+                          to the container's primary GID, the...
                         items:
                           format: int64
                           type: integer
@@ -2313,8 +2308,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -2612,7 +2606,7 @@ spec:
                         awsElasticBlockStore:
                           description: |-
                             awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                            kubelet's host machine and then exposed to th
+                            kubelet's host machine and then exposed to...
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -2662,7 +2656,7 @@ spec:
                             kind:
                               description: 'kind expected values are Shared: multiple
                                 blob disks per storage account  Dedicated: single
-                                blob disk per storage accoun'
+                                blob disk per storage...'
                               type: string
                             readOnly:
                               description: |-
@@ -2789,7 +2783,7 @@ spec:
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
-                                ConfigMap will be projected into the volum
+                                ConfigMap will be projected into the...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -2829,7 +2823,7 @@ spec:
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
-                            CSI drivers (Beta fea
+                            CSI drivers (Beta...
                           properties:
                             driver:
                               description: driver is the name of the CSI driver that
@@ -2841,7 +2835,7 @@ spec:
                             nodePublishSecretRef:
                               description: |-
                                 nodePublishSecretRef is a reference to the secret object containing
-                                sensitive information to pass to the CSI driver to c
+                                sensitive information to pass to the CSI driver to...
                               properties:
                                 name:
                                   default: ""
@@ -2903,7 +2897,7 @@ spec:
                                   mode:
                                     description: |-
                                       Optional: mode bits used to set permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal valu
+                                      between 0000 and 0777 or a decimal...
                                     format: int32
                                     type: integer
                                   path:
@@ -3152,9 +3146,9 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
-                              description: "wwids Optional: FC volume world wide identifiers
-                                (wwids)\nEither wwids or combination of targetWWNs
-                                and lun must be set, "
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set,...
                               items:
                                 type: string
                               type: array
@@ -3189,7 +3183,7 @@ spec:
                             secretRef:
                               description: |-
                                 secretRef is Optional: secretRef is reference to the secret object containing
-                                sensitive information to pass to the plugi
+                                sensitive information to pass to the...
                               properties:
                                 name:
                                   default: ""
@@ -3210,7 +3204,7 @@ spec:
                             datasetName:
                               description: |-
                                 datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                should be considered as depreca
+                                should be considered as...
                               type: string
                             datasetUUID:
                               description: datasetUUID is the UUID of the dataset.
@@ -3220,7 +3214,7 @@ spec:
                         gcePersistentDisk:
                           description: |-
                             gcePersistentDisk represents a GCE Disk resource that is attached to a
-                            kubelet's host machine and then exposed to the po
+                            kubelet's host machine and then exposed to the...
                           properties:
                             fsType:
                               description: fsType is filesystem type of the volume
@@ -3554,7 +3548,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volum
+                                          ConfigMap will be projected into the...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -3625,7 +3619,7 @@ spec:
                                             mode:
                                               description: |-
                                                 Optional: mode bits used to set permissions on this file, must be an octal value
-                                                between 0000 and 0777 or a decimal valu
+                                                between 0000 and 0777 or a decimal...
                                               format: int32
                                               type: integer
                                             path:
@@ -3674,7 +3668,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          Secret will be projected into the volume a
+                                          Secret will be projected into the volume...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -3755,12 +3749,12 @@ spec:
                             registry:
                               description: |-
                                 registry represents a single or multiple Quobyte Registry services
-                                specified as a string as host:port pair (multiple ent
+                                specified as a string as host:port pair (multiple...
                               type: string
                             tenant:
                               description: |-
                                 tenant owning the given Quobyte volume in the Backend
-                                Used with dynamically provisioned Quobyte volumes, value is set by
+                                Used with dynamically provisioned Quobyte volumes, value is set...
                               type: string
                             user:
                               description: |-
@@ -3916,7 +3910,7 @@ spec:
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
-                                Secret will be projected into the volume a
+                                Secret will be projected into the volume...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -4102,8 +4096,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -4311,7 +4304,7 @@ spec:
                           activeDeadlineSeconds:
                             description: |-
                               Specifies the duration in seconds relative to the startTime that the job
-                              may be continuously active before the system tr
+                              may be continuously active before the system...
                             format: int64
                             type: integer
                           backoffLimit:
@@ -4490,8 +4483,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -4870,8 +4862,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -5340,8 +5331,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -5817,8 +5807,7 @@ spec:
                                         value:
                                           description: |-
                                             Variable references $(VAR_NAME) are expanded
-                                            using the previously defined environment variables in the container and
-                                            any
+                                            using the previously defined environment variables in the container and...
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -6273,7 +6262,7 @@ spec:
                           supplementalGroups:
                             description: |-
                               A list of groups applied to the first process run in each container, in addition
-                              to the container's primary GID, the fsG
+                              to the container's primary GID, the...
                             items:
                               format: int64
                               type: integer
@@ -6336,8 +6325,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -6637,7 +6625,7 @@ spec:
                             awsElasticBlockStore:
                               description: |-
                                 awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to th
+                                kubelet's host machine and then exposed to...
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -6687,7 +6675,7 @@ spec:
                                 kind:
                                   description: 'kind expected values are Shared: multiple
                                     blob disks per storage account  Dedicated: single
-                                    blob disk per storage accoun'
+                                    blob disk per storage...'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -6815,7 +6803,7 @@ spec:
                                 items:
                                   description: |-
                                     items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volum
+                                    ConfigMap will be projected into the...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -6855,7 +6843,7 @@ spec:
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
-                                CSI drivers (Beta fea
+                                CSI drivers (Beta...
                               properties:
                                 driver:
                                   description: driver is the name of the CSI driver
@@ -6868,7 +6856,7 @@ spec:
                                 nodePublishSecretRef:
                                   description: |-
                                     nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to c
+                                    sensitive information to pass to the CSI driver to...
                                   properties:
                                     name:
                                       default: ""
@@ -6932,7 +6920,7 @@ spec:
                                       mode:
                                         description: |-
                                           Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal valu
+                                          between 0000 and 0777 or a decimal...
                                         format: int32
                                         type: integer
                                       path:
@@ -7184,9 +7172,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: "wwids Optional: FC volume world wide
-                                    identifiers (wwids)\nEither wwids or combination
-                                    of targetWWNs and lun must be set, "
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set,...
                                   items:
                                     type: string
                                   type: array
@@ -7221,7 +7209,7 @@ spec:
                                 secretRef:
                                   description: |-
                                     secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugi
+                                    sensitive information to pass to the...
                                   properties:
                                     name:
                                       default: ""
@@ -7242,7 +7230,7 @@ spec:
                                 datasetName:
                                   description: |-
                                     datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as depreca
+                                    should be considered as...
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -7252,7 +7240,7 @@ spec:
                             gcePersistentDisk:
                               description: |-
                                 gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the po
+                                kubelet's host machine and then exposed to the...
                               properties:
                                 fsType:
                                   description: fsType is filesystem type of the volume
@@ -7588,7 +7576,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volum
+                                              ConfigMap will be projected into the...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7661,7 +7649,7 @@ spec:
                                                 mode:
                                                   description: |-
                                                     Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal valu
+                                                    between 0000 and 0777 or a decimal...
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -7710,7 +7698,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume a
+                                              Secret will be projected into the volume...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -7791,12 +7779,12 @@ spec:
                                 registry:
                                   description: |-
                                     registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple ent
+                                    specified as a string as host:port pair (multiple...
                                   type: string
                                 tenant:
                                   description: |-
                                     tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by
+                                    Used with dynamically provisioned Quobyte volumes, value is set...
                                   type: string
                                 user:
                                   description: |-
@@ -7952,7 +7940,7 @@ spec:
                                 items:
                                   description: |-
                                     items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume a
+                                    Secret will be projected into the volume...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -8101,10 +8089,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -8251,35 +8236,6 @@ metadata:
   name: feast-operator-manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
@@ -8309,6 +8265,35 @@ rules:
   - pods/exec
   verbs:
   - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - feast.dev
   resources:

--- a/infra/feast-operator/docs/api/markdown/ref.md
+++ b/infra/feast-operator/docs/api/markdown/ref.md
@@ -115,7 +115,6 @@ time for any reason.  Missed jobs executions will be counted as failed ones. |
 | `concurrencyPolicy` _[ConcurrencyPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#concurrencypolicy-v1-batch)_ | Specifies how to treat concurrent executions of a Job.
 Valid values are:
 
-
 - "Allow" (default): allows CronJobs to run concurrently;
 - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
 - "Replace": cancels currently running job and replaces it with a new one |
@@ -303,7 +302,6 @@ represented by the jobs's .status.failed field, is incremented and it is
 checked against the backoffLimit. This field cannot be used in combination
 with restartPolicy=OnFailure.
 
-
 This field is beta-level. It can be used when the `JobPodFailurePolicy`
 feature gate is enabled (enabled by default). |
 | `backoffLimit` _integer_ | Specifies the number of retries before marking this job failed. |
@@ -335,11 +333,9 @@ the Job becomes eligible to be deleted immediately after it finishes. |
 | `completionMode` _[CompletionMode](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#completionmode-v1-batch)_ | completionMode specifies how Pod completions are tracked. It can be
 `NonIndexed` (default) or `Indexed`.
 
-
 `NonIndexed` means that the Job is considered complete when there have
 been .spec.completions successfully completed Pods. Each Pod completion is
 homologous to each other.
-
 
 `Indexed` means that the Pods of a
 Job get an associated completion index from 0 to (.spec.completions - 1),
@@ -351,7 +347,6 @@ When value is `Indexed`, .spec.completions must be specified and
 In addition, The Pod name takes the form
 `$(job-name)-$(index)-$(random-string)`,
 the Pod hostname takes the form `$(job-name)-$(index)`.
-
 
 More completion modes can be added in the future.
 If the Job controller observes a mode that it doesn't recognize, which
@@ -370,7 +365,6 @@ Possible values are:
   when they are terminating (has a metadata.deletionTimestamp) or failed.
 - Failed means to wait until a previously created Pod is fully terminated (has phase
   Failed or Succeeded) before creating a replacement Pod.
-
 
 When using podFailurePolicy, Failed is the the only allowed value.
 TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.

--- a/infra/feast-operator/internal/controller/services/util.go
+++ b/infra/feast-operator/internal/controller/services/util.go
@@ -300,7 +300,7 @@ func hasAttrib(s interface{}, fieldName string, value interface{}) (bool, error)
 	val := reflect.ValueOf(s)
 
 	// Check that the object is a pointer so we can modify it
-	if val.Kind() != reflect.Ptr || val.IsNil() {
+	if val.Kind() != reflect.Pointer || val.IsNil() {
 		return false, fmt.Errorf("expected a pointer to struct, got %v", val.Kind())
 	}
 


### PR DESCRIPTION
Cassandra was hardcoding serialization version 2 at read time, which means anyone who writes to Cassandra with with entity key serialization version 3 is unable to retrieve data.

Also adds a shared warnPotentialEntityKeyVersionMismatch helper (extracted into `entitykeyserialization.go`) that fires a single deduplicated warning when an online read returns zero data for all requested feature views — a possible indicator of a write/read version mismatch. Covered by new unit tests in both store test files.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
