### PR TITLE
fix: Extract feature view names at API boundary for metrics tagging

### DIFF
--- a/go/internal/feast/metrics/lookup_metrics.go
+++ b/go/internal/feast/metrics/lookup_metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"strings"
+	"log"
 
 	"github.com/feast-dev/feast/go/internal/feast/onlineserving"
 	"github.com/feast-dev/feast/go/protos/feast/serving"
@@ -13,25 +13,15 @@ const (
 	LookupRequestsMetric      = "mlpfs.featureserver.feature_lookup_requests"
 )
 
-// extractFeatureView extracts the feature view name from a full feature name.
-// Feature names follow the format: feature_view__feature_name
-// Example: "hotel_fv__price" -> "hotel_fv"
-func extractFeatureView(featureName string) string {
-	parts := strings.SplitN(featureName, "__", 2)
-	if len(parts) == 2 {
-		return parts[0]
-	}
-	return "unknown"
-}
-
 // LookupMetricsAggregator accumulates per-feature lookup statuses for a single request and emits aggregated counts.
 type LookupMetricsAggregator struct {
-	notFound      map[string]int64
-	nullOrExpired map[string]int64
-	total         map[string]int64
-	baseTags      []string
-	client        StatsdClient
-	sampleRate    float64
+	notFound         map[string]int64
+	nullOrExpired    map[string]int64
+	total            map[string]int64
+	featureToViewMap map[string]string
+	baseTags         []string
+	client           StatsdClient
+	sampleRate       float64
 }
 
 func NewLookupMetricsAggregator(
@@ -44,9 +34,10 @@ func NewLookupMetricsAggregator(
 	}
 
 	return &LookupMetricsAggregator{
-		notFound:      make(map[string]int64),
-		nullOrExpired: make(map[string]int64),
-		total:         make(map[string]int64),
+		notFound:         make(map[string]int64),
+		nullOrExpired:    make(map[string]int64),
+		total:            make(map[string]int64),
+		featureToViewMap: make(map[string]string),
 		baseTags: []string{
 			"project:" + project,
 			"online_store_type:" + onlineStore,
@@ -56,11 +47,15 @@ func NewLookupMetricsAggregator(
 	}
 }
 
-func (m *LookupMetricsAggregator) Record(featureID string, status serving.FieldStatus) {
+func (m *LookupMetricsAggregator) Record(featureID, featureViewName string, status serving.FieldStatus) {
 	if m == nil {
 		return
 	}
 	m.total[featureID]++
+	// Store FV name mapping if not present
+	if _, exists := m.featureToViewMap[featureID]; !exists {
+		m.featureToViewMap[featureID] = featureViewName
+	}
 	switch status {
 	case serving.FieldStatus_NOT_FOUND:
 		m.notFound[featureID]++
@@ -75,7 +70,7 @@ func (m *LookupMetricsAggregator) RecordFromFeatureVectors(vectors []*onlineserv
 	}
 	for _, vector := range vectors {
 		for _, status := range vector.Statuses {
-			m.Record(vector.Name, status)
+			m.Record(vector.Name, vector.FeatureViewName, status)
 		}
 	}
 }
@@ -87,17 +82,21 @@ func (m *LookupMetricsAggregator) RecordFromRangeFeatureVectors(vectors []*onlin
 	for _, vector := range vectors {
 		for _, entityStatuses := range vector.RangeStatuses {
 			for _, status := range entityStatuses {
-				m.Record(vector.Name, status)
+				m.Record(vector.Name, vector.FeatureViewName, status)
 			}
 		}
 	}
 }
 
-func (m *LookupMetricsAggregator) featureTags(featureID string) []string {
+func (m *LookupMetricsAggregator) featureTags(featureID, featureViewName string) []string {
 	tags := make([]string, len(m.baseTags)+2)
 	copy(tags, m.baseTags)
 	tags[len(m.baseTags)] = "feature:" + featureID
-	tags[len(m.baseTags)+1] = "feature_view:" + extractFeatureView(featureID)
+	if featureViewName == "" {
+		featureViewName = "unknown"
+		log.Printf("WARNING: Lookup metrics feature_view tag set to 'unknown' for feature: %s. This may indicate FeatureViewName was not populated.", featureID)
+	}
+	tags[len(m.baseTags)+1] = "feature_view:" + featureViewName
 	return tags
 }
 
@@ -108,17 +107,20 @@ func (m *LookupMetricsAggregator) Emit() {
 
 	for featureID, count := range m.notFound {
 		if count > 0 {
-			m.client.Count(LookupNotFoundMetric, count, m.featureTags(featureID), m.sampleRate)
+			fvName := m.featureToViewMap[featureID]
+			m.client.Count(LookupNotFoundMetric, count, m.featureTags(featureID, fvName), m.sampleRate)
 		}
 	}
 	for featureID, count := range m.nullOrExpired {
 		if count > 0 {
-			m.client.Count(LookupNullOrExpiredMetric, count, m.featureTags(featureID), m.sampleRate)
+			fvName := m.featureToViewMap[featureID]
+			m.client.Count(LookupNullOrExpiredMetric, count, m.featureTags(featureID, fvName), m.sampleRate)
 		}
 	}
 	for featureID, count := range m.total {
 		if count > 0 {
-			m.client.Count(LookupRequestsMetric, count, m.featureTags(featureID), m.sampleRate)
+			fvName := m.featureToViewMap[featureID]
+			m.client.Count(LookupRequestsMetric, count, m.featureTags(featureID, fvName), m.sampleRate)
 		}
 	}
 }

--- a/go/internal/feast/metrics/lookup_metrics_test.go
+++ b/go/internal/feast/metrics/lookup_metrics_test.go
@@ -46,9 +46,9 @@ func TestAggregator_AllNotFound(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := newTestAggregator(fake)
 
-	agg.Record("user_fv__age", serving.FieldStatus_NOT_FOUND)
-	agg.Record("user_fv__age", serving.FieldStatus_NOT_FOUND)
-	agg.Record("user_fv__age", serving.FieldStatus_NOT_FOUND)
+	agg.Record("user_fv__age", "user_fv", serving.FieldStatus_NOT_FOUND)
+	agg.Record("user_fv__age", "user_fv", serving.FieldStatus_NOT_FOUND)
+	agg.Record("user_fv__age", "user_fv", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
 	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
@@ -67,9 +67,9 @@ func TestAggregator_AllNullOrExpired(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := newTestAggregator(fake)
 
-	agg.Record("order_fv__amt", serving.FieldStatus_NULL_VALUE)
-	agg.Record("order_fv__amt", serving.FieldStatus_NULL_VALUE)
-	agg.Record("order_fv__amt", serving.FieldStatus_OUTSIDE_MAX_AGE)
+	agg.Record("order_fv__amt", "order_fv", serving.FieldStatus_NULL_VALUE)
+	agg.Record("order_fv__amt", "order_fv", serving.FieldStatus_NULL_VALUE)
+	agg.Record("order_fv__amt", "order_fv", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
 	nullCalls := filterCalls(fake.calls, LookupNullOrExpiredMetric)
@@ -88,11 +88,11 @@ func TestAggregator_MixedStatuses(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := newTestAggregator(fake)
 
-	agg.Record("fv_a__f1", serving.FieldStatus_PRESENT)
-	agg.Record("fv_a__f1", serving.FieldStatus_NOT_FOUND)
-	agg.Record("fv_b__f2", serving.FieldStatus_NULL_VALUE)
-	agg.Record("fv_b__f2", serving.FieldStatus_PRESENT)
-	agg.Record("fv_b__f2", serving.FieldStatus_OUTSIDE_MAX_AGE)
+	agg.Record("fv_a__f1", "fv_a", serving.FieldStatus_PRESENT)
+	agg.Record("fv_a__f1", "fv_a", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv_b__f2", "fv_b", serving.FieldStatus_NULL_VALUE)
+	agg.Record("fv_b__f2", "fv_b", serving.FieldStatus_PRESENT)
+	agg.Record("fv_b__f2", "fv_b", serving.FieldStatus_OUTSIDE_MAX_AGE)
 	agg.Emit()
 
 	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
@@ -117,8 +117,8 @@ func TestAggregator_AllPresent(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := newTestAggregator(fake)
 
-	agg.Record("fv__f1", serving.FieldStatus_PRESENT)
-	agg.Record("fv__f1", serving.FieldStatus_PRESENT)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_PRESENT)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_PRESENT)
 	agg.Emit()
 
 	// No not_found or null_or_expired calls
@@ -136,7 +136,7 @@ func TestAggregator_AllPresent(t *testing.T) {
 
 func TestAggregator_NilSafe(t *testing.T) {
 	var agg *LookupMetricsAggregator
-	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_NOT_FOUND)
 	agg.RecordFromFeatureVectors(nil)
 	agg.RecordFromRangeFeatureVectors(nil)
 	agg.Emit()
@@ -151,7 +151,7 @@ func TestAggregator_Tags(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := NewLookupMetricsAggregator("mlpfs", "eg-valkey", fake, 1.0)
 
-	agg.Record("hotel_fv__price", serving.FieldStatus_NOT_FOUND)
+	agg.Record("hotel_fv__price", "hotel_fv", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
 	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
@@ -169,12 +169,14 @@ func TestRecordFromFeatureVectors(t *testing.T) {
 
 	vectors := []*onlineserving.FeatureVector{
 		{
-			Name:     "fv_a__f1",
-			Statuses: []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_NOT_FOUND},
+			Name:            "fv_a__f1",
+			FeatureViewName: "fv_a",
+			Statuses:        []serving.FieldStatus{serving.FieldStatus_PRESENT, serving.FieldStatus_NOT_FOUND},
 		},
 		{
-			Name:     "fv_a__f2",
-			Statuses: []serving.FieldStatus{serving.FieldStatus_NOT_FOUND, serving.FieldStatus_NOT_FOUND},
+			Name:            "fv_a__f2",
+			FeatureViewName: "fv_a",
+			Statuses:        []serving.FieldStatus{serving.FieldStatus_NOT_FOUND, serving.FieldStatus_NOT_FOUND},
 		},
 	}
 
@@ -207,7 +209,8 @@ func TestRecordFromRangeFeatureVectors(t *testing.T) {
 
 	vectors := []*onlineserving.RangeFeatureVector{
 		{
-			Name: "sfv__f1",
+			Name:            "sfv__f1",
+			FeatureViewName: "sfv",
 			RangeStatuses: [][]serving.FieldStatus{
 				{serving.FieldStatus_PRESENT, serving.FieldStatus_NOT_FOUND},
 				{serving.FieldStatus_NOT_FOUND},
@@ -246,29 +249,6 @@ func TestIsMissingKeyMetricsEnabled(t *testing.T) {
 }
 
 func TestGetOnlineStoreType(t *testing.T) {
-}
-
-func TestExtractFeatureView(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"standard format", "hotel_fv__price", "hotel_fv"},
-		{"with underscore in feature", "hotel_fv__review_score_avg", "hotel_fv"},
-		{"multiple feature views", "user_fv__age", "user_fv"},
-		{"long feature view name", "ranking_signals_fv__score", "ranking_signals_fv"},
-		{"no double underscore", "age", "unknown"},
-		{"colon separator", "hotel_fv:price", "unknown"},
-		{"empty string", "", "unknown"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractFeatureView(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }
 
 // findTag extracts the value portion of a tag matching the given prefix.
@@ -334,8 +314,8 @@ func TestSampling_AdjustsCountsCorrectly(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := NewLookupMetricsAggregator("test_project", "redis", fake, 0.5)
 
-	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
-	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
 	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)
@@ -349,8 +329,8 @@ func TestSampling_NoAdjustmentWhenNotSampling(t *testing.T) {
 	fake := &fakeStatsdClient{}
 	agg := NewLookupMetricsAggregator("test_project", "redis", fake, 1.0)
 
-	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
-	agg.Record("fv__f1", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_NOT_FOUND)
+	agg.Record("fv__f1", "fv", serving.FieldStatus_NOT_FOUND)
 	agg.Emit()
 
 	notFoundCalls := filterCalls(fake.calls, LookupNotFoundMetric)

--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -29,24 +29,29 @@ import (
 FeatureVector type represent result of retrieving single feature for multiple rows.
 It can be imagined as a column in output dataframe / table.
 It contains of feature name, list of values (across all rows),
-list of statuses and list of timestamp. All these lists have equal length.
+list of statuses and list of timestamp. FeatureViewName contains the name of the
+feature view this vector belongs to, used for metrics tagging to avoid string parsing.
+All these lists have equal length.
 And this length is also equal to number of entity rows received in request.
 */
 type FeatureVector struct {
-	Name       string
-	Values     interface{}
-	Statuses   []serving.FieldStatus
-	Timestamps []*timestamppb.Timestamp
+	Name            string
+	FeatureViewName string
+	Values          interface{}
+	Statuses        []serving.FieldStatus
+	Timestamps      []*timestamppb.Timestamp
 }
 
 /*
 RangeFeatureVector type represent result of retrieving a range of features for multiple entities.
 It is similar to FeatureVector but contains a list of lists of values, a list of lists of statuses and a list of lists
 of timestamps where each inner list represents the range of values, statuses, timestamps for a single entity.
+FeatureViewName contains the name of the feature view this vector belongs to.
 Each of these lists are of equal dimensionality.
 */
 type RangeFeatureVector struct {
 	Name            string
+	FeatureViewName string
 	RangeValues     interface{}
 	RangeStatuses   [][]serving.FieldStatus
 	RangeTimestamps [][]*timestamppb.Timestamp
@@ -766,10 +771,16 @@ func TransposeFeatureRowsIntoColumns(featureData2D [][]onlinestore.FeatureData,
 	vectors := make([]*FeatureVector, numFeatures)
 
 	for featureIndex := 0; featureIndex < numFeatures; featureIndex++ {
+		// Determine feature view name from groupRef
+		featureViewName = ""
+		if featureIndex < len(groupRef.FeatureViewNames) {
+			featureViewName = groupRef.FeatureViewNames[featureIndex]
+		}
 		currentVector := &FeatureVector{
-			Name:       groupRef.AliasedFeatureNames[featureIndex],
-			Statuses:   make([]serving.FieldStatus, numRows),
-			Timestamps: make([]*timestamppb.Timestamp, numRows),
+			Name:            groupRef.AliasedFeatureNames[featureIndex],
+			FeatureViewName: featureViewName,
+			Statuses:        make([]serving.FieldStatus, numRows),
+			Timestamps:      make([]*timestamppb.Timestamp, numRows),
 		}
 		vectors[featureIndex] = currentVector
 		protoValues := make([]*prototypes.Value, numRows)
@@ -839,7 +850,12 @@ func TransposeRangeFeatureRowsIntoColumns(
 	vectors := make([]*RangeFeatureVector, numFeatures)
 
 	for featureIndex := 0; featureIndex < numFeatures; featureIndex++ {
-		currentVector := initializeRangeFeatureVector(groupRef.AliasedFeatureNames[featureIndex], numRows)
+		// Determine feature view name from groupRef
+		featureViewName := ""
+		if featureIndex < len(groupRef.FeatureViewNames) {
+			featureViewName = groupRef.FeatureViewNames[featureIndex]
+		}
+		currentVector := initializeRangeFeatureVector(groupRef.AliasedFeatureNames[featureIndex], featureViewName, numRows)
 		vectors[featureIndex] = currentVector
 
 		rangeValuesByRow := make([]*prototypes.RepeatedValue, numRows)
@@ -879,9 +895,10 @@ func TransposeRangeFeatureRowsIntoColumns(
 	return vectors, nil
 }
 
-func initializeRangeFeatureVector(name string, numRows int) *RangeFeatureVector {
+func initializeRangeFeatureVector(name, featureViewName string, numRows int) *RangeFeatureVector {
 	return &RangeFeatureVector{
 		Name:            name,
+		FeatureViewName: featureViewName,
 		RangeStatuses:   make([][]serving.FieldStatus, numRows),
 		RangeTimestamps: make([][]*timestamppb.Timestamp, numRows),
 	}
@@ -1070,10 +1087,11 @@ func EntitiesToFeatureVectors(entityColumns map[string]*prototypes.RepeatedValue
 			return nil, errors.GrpcFromError(err)
 		}
 		vectors = append(vectors, &FeatureVector{
-			Name:       entityName,
-			Values:     entityColumn,
-			Statuses:   presentVector,
-			Timestamps: timestampVector,
+			Name:            entityName,
+			FeatureViewName: "", // Entity columns don't belong to a feature view
+			Values:          entityColumn,
+			Statuses:        presentVector,
+			Timestamps:      timestampVector,
 		})
 	}
 	return vectors, nil

--- a/go/internal/feast/transformation/transformation_service.go
+++ b/go/internal/feast/transformation/transformation_service.go
@@ -148,10 +148,11 @@ func ExtractTransformationResponse(
 		}
 
 		result = append(result, &onlineserving.FeatureVector{
-			Name:       featureName,
-			Values:     outRecord.Column(idx),
-			Statuses:   statuses,
-			Timestamps: timestamps,
+			Name:            featureName,
+			FeatureViewName: featureView.Base.Name,
+			Values:          outRecord.Column(idx),
+			Statuses:        statuses,
+			Timestamps:      timestamps,
 		})
 	}
 


### PR DESCRIPTION
- Added FeatureViewName field to FeatureVector struct
- Added FeatureViewName field to RangeFeatureVector struct
- Updated TransposeFeatureRowsIntoColumns to populate FeatureViewName from groupRef
- Updated TransposeRangeFeatureRowsIntoColumns to populate FeatureViewName from groupRef
- Fixed initializeRangeFeatureVector to accept and set FeatureViewName parameter
- Removed extractFeatureView() string parsing function from lookup_metrics.go
- Removed unused 'strings' import from lookup_metrics.go
- Updated lookup metrics aggregator to use direct field instead of string splitting
- Added observability logging when "unknown" feature_view tag fallback occurs
- Updated all test fixtures with new FeatureViewName fields
- Updated all Record() calls to pass feature view name

This fixes the bug where Datadog metrics for mlpfs.featureserver.feature_lookup_not_found and mlpfs.featureserver.feature_lookup_null_or_expired were showing feature_view:unknown instead of actual feature view names.


# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
