### PR TITLE
fix: Delete sorted_feature_views rows when deleting a project

### DIFF
--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1447,6 +1447,7 @@ class SqlRegistry(CachingRegistry):
                     feature_views,
                     on_demand_feature_views,
                     stream_feature_views,
+                    sorted_feature_views,
                     data_sources,
                     entities,
                     permissions,

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -53,9 +53,12 @@ from feast.permissions.action import AuthzedAction
 from feast.permissions.permission import Permission
 from feast.permissions.policy import RoleBasedPolicy
 from feast.project import Project
+from feast.protos.feast.core.SortedFeatureView_pb2 import SortOrder
 from feast.protos.feast.registry import RegistryServer_pb2, RegistryServer_pb2_grpc
 from feast.registry_server import RegistryServer
 from feast.repo_config import RegistryConfig
+from feast.sort_key import SortKey
+from feast.sorted_feature_view import SortedFeatureView
 from feast.stream_feature_view import Aggregation, StreamFeatureView
 from feast.types import Array, Bytes, Float32, Int32, Int64, String
 from feast.utils import _utc_now
@@ -1803,12 +1806,35 @@ def test_apply_project_success(test_registry):
     entities = test_registry.list_entities(project.name)
     assert len(entities) == 1
 
+    # A SortedFeatureView is persisted in its own table (separate from FeatureView), so
+    # it's a distinct code path that delete_project must also clean up.
+    sorted_feature_view = SortedFeatureView(
+        name="driver_sorted_feature_view",
+        source=FileSource(name="my_file_source", path="test.parquet"),
+        entities=[entity],
+        schema=[Field(name="sort_key1", dtype=Int64)],
+        sort_keys=[
+            SortKey(
+                name="sort_key1",
+                value_type=ValueType.INT64,
+                default_sort_order=SortOrder.ASC,
+            )
+        ],
+    )
+    test_registry.apply_feature_view(sorted_feature_view, project.name)
+    sorted_feature_views = test_registry.list_sorted_feature_views(project.name)
+    assert len(sorted_feature_views) == 1
+
     test_registry.delete_project(project.name, commit=False)
 
     test_registry.commit()
 
     entities = test_registry.list_entities(project.name, False)
     assert len(entities) == 0
+    sorted_feature_views = test_registry.list_sorted_feature_views(
+        project.name, allow_cache=False
+    )
+    assert len(sorted_feature_views) == 0
     projects_list = test_registry.list_projects()
     assert len(projects_list) == 0
 


### PR DESCRIPTION
SqlRegistry.delete_project deletes rows from a fixed set of tables scoped by project_id, but was missing the sorted_feature_views table. SortedFeatureView is persisted separately from FeatureView, so any project with a SortedFeatureView left orphaned rows behind after delete_project, even though the in-memory cache (SqlFallbackRegistry) appeared clean.

Extends test_apply_project_success to apply a SortedFeatureView and assert it's removed after delete_project.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
